### PR TITLE
splash screen fixes

### DIFF
--- a/packages/desktop/src/main/main.test.ts
+++ b/packages/desktop/src/main/main.test.ts
@@ -14,6 +14,8 @@ const mockwebContentsOn = jest.fn()
 const mockwebContentsOnce = jest.fn()
 const mockDestroyWindow = jest.fn()
 const mockWindowOnce = jest.fn()
+const mockSetMovable = jest.fn()
+const mockSetAlwaysOnTop = jest.fn()
 
 const spyApplyDevTools = jest.spyOn(main, 'applyDevTools')
 const spyCreateWindow = jest.spyOn(main, 'createWindow')
@@ -70,6 +72,12 @@ jest.mock('electron', () => {
         once: mockWindowOnce,
         getTitle: jest.fn(),
         destroy: mockDestroyWindow,
+        setAlwaysOnTop: mockSetAlwaysOnTop,
+        setMovable: mockSetMovable,
+        getSize: jest.fn().mockImplementation(() => [600, 800]),
+        getPosition: jest.fn().mockImplementation(() => [600, 800]),
+        setSize: jest.fn(),
+        setPosition: jest.fn(),
         webContents: {
           on: mockwebContentsOn,
           once: mockwebContentsOnce,
@@ -138,6 +146,9 @@ describe('electron app ready event', () => {
     expect(BrowserWindow).toHaveBeenCalledTimes(2)
     // show spalsh screen
     expect(mockShowWindow).toHaveBeenCalledTimes(1)
+
+    expect(mockSetAlwaysOnTop).toHaveBeenCalledWith(false)
+    expect(mockSetMovable).toHaveBeenCalledWith(true)
   })
 
   it('replacing splash screen with main window in webcontents did-finish-load window event', async () => {
@@ -155,7 +166,7 @@ describe('electron app ready event', () => {
   it('close application and save state correctly', async () => {
     const mockWindowOnceCalls = mockWindowOnce.mock.calls
 
-    expect(mockWindowOnce).toHaveBeenCalledTimes(1)
+    expect(mockWindowOnce).toHaveBeenCalledTimes(2)
     expect(mockWindowOnceCalls[0][0]).toBe('close')
     const event = { preventDefault: () => { } }
     mockWindowOnceCalls[0][1](event)

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -332,6 +332,11 @@ app.on('ready', async () => {
   await createWindow()
 
   mainWindow.webContents.on('did-finish-load', () => {
+    const [width, height] = splash.getSize()
+    mainWindow.setSize(width, height)
+    const [ splashWindowX, splashWindowY ] = splash.getPosition()
+    mainWindow.setPosition(splashWindowX, splashWindowY)
+    
     splash.destroy()
     mainWindow.show()
     const temporaryFilesDirectory = path.join(appDataPath, 'temporaryFiles')

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -188,8 +188,12 @@ export const createWindow = async () => {
     alwaysOnTop: true
   })
 
+  remote.enable(splash.webContents)
+
   // eslint-disable-next-line
   splash.loadURL(`file://${__dirname}/splash.html`)
+  splash.setAlwaysOnTop(false)
+  splash.setMovable(true)
   splash.show()
 
   electronLocalshortcut.register(splash, 'F12', () => {

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -388,6 +388,13 @@ app.on('ready', async () => {
     mainWindow.webContents.send('force-save-state')
   })
 
+  splash.once('close', e => {
+    e.preventDefault()
+    log('Closing window')
+    mainWindow.webContents.send('force-save-state')
+    closeBackendProcess()
+  })
+
   ipcMain.on('state-saved', e => {
     mainWindow.close()
     log('Saved state, closed window')

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -338,9 +338,9 @@ app.on('ready', async () => {
   mainWindow.webContents.on('did-finish-load', () => {
     const [width, height] = splash.getSize()
     mainWindow.setSize(width, height)
-    const [ splashWindowX, splashWindowY ] = splash.getPosition()
+    const [splashWindowX, splashWindowY] = splash.getPosition()
     mainWindow.setPosition(splashWindowX, splashWindowY)
-    
+
     splash.destroy()
     mainWindow.show()
     const temporaryFilesDirectory = path.join(appDataPath, 'temporaryFiles')


### PR DESCRIPTION
fixes:
- main window have same size and position like splash window now
- closing the splash window closes the app now
- splash window is movable and no always in the background now (mac os bug)