### PR TITLE
simply "easier to fork" feature as "open source"

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,8 +346,8 @@ input[type=text] {
         <p>Apps like Signal &amp; WhatsApp do encrypt messages, but they still leak metadata, such as who you talk to and when, to whoever runs the server. Quiet uses Tor to protect that too.</p>
       </div>
       <div class="column w-col w-col-4 w-col-stack"><img src="images/Fork.svg" loading="lazy" alt="A simple icon of an arrow up with another arrow branching off ">
-        <h3 class="qt-heading-security">Easier to fork</h3>
-        <p>When an app&#x27;s data lives on servers run by a company, it&#x27;s harder for open source developers to protect users by &quot;forking&quot; (creating alternative versions.) Quiet&#x27;s peer-to-peer design makes forking easy.</p>
+        <h3 class="qt-heading-security">Open source</h3>
+        <p>Unlike Slack, Discord, WhatsApp, and the rest, Quiet is completely open source. This means there is no vendor lock-in. Developers can fork Quiet and create interoperable versions.</p>
       </div>
       <div class="column w-col w-col-4 w-col-stack"><img src="images/Van.svg" loading="lazy" alt="A simple icon of a van with a surfboard on top">
         <h3 class="qt-heading-security">We make it look easy</h3>


### PR DESCRIPTION
As discussed with @holmesworcester in #general, I find the "Easier to fork" feature a bit confusing and hard to follow, even after reading [a similar argument](https://github.com/TryQuiet/quiet/wiki/Quiet-FAQ#slack-and-discord) in the FAQ.

In this pull request I'm suggesting what I think is a simplification of the argument: no vendor lock-in because Quiet is open source. I also added a line about interoperability to try to remain true to the original intent but I don't think it's strictly necessary.

## Old: Easier to fork

<img width="425" alt="Screen Shot 2022-12-17 at 4 57 34 PM" src="https://user-images.githubusercontent.com/21006/208267503-5db92617-77fc-4751-a0a3-f6bc12a689db.png">

## New: Open source

<img width="425" alt="Screen Shot 2022-12-17 at 4 57 39 PM" src="https://user-images.githubusercontent.com/21006/208267504-408caf09-6fc2-42aa-90a5-7bbad70b18b8.png">