### PR TITLE
Add enhancements for e2e invitation link test on macos

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@quiet/backend",
-			"version": "1.2.0-alpha.26",
+			"version": "1.2.0-alpha.27",
 			"license": "MIT",
 			"dependencies": {
 				"@chainsafe/libp2p-gossipsub": "6.1.0",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "quiet",
-			"version": "1.2.0-alpha.29",
+			"version": "1.2.0-alpha.30",
 			"license": "ISC",
 			"dependencies": {
 				"@electron/remote": "^2.0.8",

--- a/packages/desktop/src/renderer/Root.tsx
+++ b/packages/desktop/src/renderer/Root.tsx
@@ -53,6 +53,11 @@ export default () => {
                   <Route index path='/' element={<Index />} />
                   <Route path='/main/*' element={<Main />} />
                 </Routes>
+                <div id='save-state-button' data-testid='save-state-button' data-is-saved='false' onClick={async () => {
+                  await persistor.flush()
+                  const element = document.getElementById('save-state-button')
+                  element.setAttribute('data-is-saved', 'true')
+                }}/>
               </PersistGate>
             </Provider>
           </HashRouter>

--- a/packages/e2e-tests/crossplatform.utils.ts
+++ b/packages/e2e-tests/crossplatform.utils.ts
@@ -11,10 +11,11 @@ export class BuildSetup {
   private child: ChildProcessWithoutNullStreams
   private useDataDir: boolean
 
-  constructor({ port, debugPort, useDataDir = true }: {port: number; debugPort: number; useDataDir?: boolean}) {
+  constructor({ port, debugPort, useDataDir = true, dataDir }: {port: number; debugPort: number; useDataDir?: boolean; dataDir?: string}) {
     this.port = port
     this.debugPort = debugPort
     this.useDataDir = useDataDir
+    this.dataDir = dataDir
   }
 
   private getBinaryLocation() {
@@ -31,7 +32,7 @@ export class BuildSetup {
   }
 
   public async createChromeDriver() {
-    if (this.useDataDir) {
+    if (this.useDataDir && !this.dataDir) {
       this.dataDir = `e2e_${(Math.random() * 10 ** 18).toString(36)}`
     }
 

--- a/packages/e2e-tests/selectors.crossplatform.ts
+++ b/packages/e2e-tests/selectors.crossplatform.ts
@@ -1,4 +1,30 @@
 import { By, Key, ThenableWebDriver, until } from 'selenium-webdriver'
+
+export class App {
+  private readonly driver: ThenableWebDriver
+  constructor(driver: ThenableWebDriver) {
+    this.driver = driver
+  }
+
+  get saveStateButton() {
+    return this.driver.wait(
+      until.elementLocated(By.xpath('//div[@data-testid="save-state-button"]'))
+    )
+  }
+
+  async saveState() {
+    const stateButton = await this.saveStateButton
+    await this.driver.executeScript('arguments[0].click();', stateButton)
+  }
+
+  async waitForSavedState() {
+    const dataSaved = this.driver.wait(
+      until.elementLocated(By.xpath('//div[@data-is-saved="true"]'))
+    )
+    return await dataSaved
+  }
+}
+
 export class StartingLoadingPanel {
   private readonly text: string
   private readonly driver: ThenableWebDriver


### PR DESCRIPTION
* Close one app during test so macos has only one instance of the app opened while clicking on a link
* Manually save redux state during test (selenium clicks on the app too fast and state is not saved properly)