### PR TITLE
typo channel address method

### DIFF
--- a/packages/common/src/channelAddress.test.ts
+++ b/packages/common/src/channelAddress.test.ts
@@ -1,0 +1,29 @@
+import { generateChannelId, getChannelNameFormChannelId } from './channelAddress'
+
+describe('Generate Channel Id', () => {
+  it('name "rockets" is the channel name', () => {
+    expect(generateChannelId('rockets')).toContain('rockets')
+  })
+
+  it('Should include hexadecimals characters in a determined structure (name + _ + 16 hex)', () => {
+    const channelName = 'rockets'
+    const randomBytesLength = 32 // 16 chars in hex
+    const underscoreLength = 1
+    const expectedLength = channelName.length + underscoreLength + randomBytesLength
+    expect(generateChannelId('rockets')).toHaveLength(expectedLength)
+  })
+})
+
+describe('Get Channel Name From Channel Id', () => {
+  it('Should return the channel name', () => {
+    const channelId = 'rockets_1faff74afc8daff3256275ce89d30528'
+    const channelName = 'rockets'
+    expect(getChannelNameFormChannelId(channelId)).toEqual(channelName)
+  })
+  it('Should return the channel id fi does not match the structure', () => {
+    const channelName = 'rockets'
+    const invalidChannelId = 'rockets+1faff74afc8daff3256275ce89d30528'
+    expect(getChannelNameFormChannelId(channelName)).toEqual(channelName)
+    expect(getChannelNameFormChannelId(invalidChannelId)).toEqual(invalidChannelId)
+  })
+})

--- a/packages/common/src/channelAddress.test.ts
+++ b/packages/common/src/channelAddress.test.ts
@@ -20,7 +20,7 @@ describe('Get Channel Name From Channel Id', () => {
     const channelName = 'rockets'
     expect(getChannelNameFromChannelId(channelId)).toEqual(channelName)
   })
-  it('Should return the channel id fi does not match the structure', () => {
+  it('Should return the channel id if does not match the structure', () => {
     const channelName = 'rockets'
     const invalidChannelId = 'rockets+1faff74afc8daff3256275ce89d30528'
     expect(getChannelNameFromChannelId(channelName)).toEqual(channelName)

--- a/packages/common/src/channelAddress.test.ts
+++ b/packages/common/src/channelAddress.test.ts
@@ -1,4 +1,4 @@
-import { generateChannelId, getChannelNameFormChannelId } from './channelAddress'
+import { generateChannelId, getChannelNameFromChannelId } from './channelAddress'
 
 describe('Generate Channel Id', () => {
   it('name "rockets" is the channel name', () => {
@@ -18,12 +18,12 @@ describe('Get Channel Name From Channel Id', () => {
   it('Should return the channel name', () => {
     const channelId = 'rockets_1faff74afc8daff3256275ce89d30528'
     const channelName = 'rockets'
-    expect(getChannelNameFormChannelId(channelId)).toEqual(channelName)
+    expect(getChannelNameFromChannelId(channelId)).toEqual(channelName)
   })
   it('Should return the channel id fi does not match the structure', () => {
     const channelName = 'rockets'
     const invalidChannelId = 'rockets+1faff74afc8daff3256275ce89d30528'
-    expect(getChannelNameFormChannelId(channelName)).toEqual(channelName)
-    expect(getChannelNameFormChannelId(invalidChannelId)).toEqual(invalidChannelId)
+    expect(getChannelNameFromChannelId(channelName)).toEqual(channelName)
+    expect(getChannelNameFromChannelId(invalidChannelId)).toEqual(invalidChannelId)
   })
 })

--- a/packages/common/src/channelAddress.ts
+++ b/packages/common/src/channelAddress.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 
 export const generateChannelId = (channelName: string) => `${channelName}_${crypto.randomBytes(16).toString('hex')}`
 
-export const getChannelNameFormChannelId = (channelId: string) => {
+export const getChannelNameFromChannelId = (channelId: string) => {
   const index = channelId.indexOf('_')
   if (index === -1) {
     return channelId

--- a/packages/mobile/src/screens/ChannelList/ChannelList.screen.tsx
+++ b/packages/mobile/src/screens/ChannelList/ChannelList.screen.tsx
@@ -12,7 +12,7 @@ import { formatMessageDisplayDate } from '../../utils/functions/formatMessageDis
 
 import { useContextMenu } from '../../hooks/useContextMenu'
 import { MenuName } from '../../const/MenuNames.enum'
-import { getChannelNameFormChannelId } from '@quiet/common'
+import { getChannelNameFromChannelId } from '@quiet/common'
 import { initSelectors } from '../../store/init/init.selectors'
 
 export const ChannelListScreen: FC = () => {
@@ -43,7 +43,7 @@ export const ChannelListScreen: FC = () => {
     const date = newestMessage?.createdAt ? formatMessageDisplayDate(newestMessage.createdAt) : undefined
 
     const tile: ChannelTileProps = {
-      name: getChannelNameFormChannelId(status.id),
+      name: getChannelNameFromChannelId(status.id),
       id: status.id,
       message,
       date,


### PR DESCRIPTION
### Main Changes

Renamed method from `getChannelNameFormChannelId` to `getChannelNameFromChannelId` (7e00db1)

### Context

- **No merge before #1726.** 
- Note that this PR is polluted with the commits from the other PR (check #1726 changelog for details)

### Changelog

- 7e00db1 fix: typo in function name by @UlisesGascon