### PR TITLE
Restore capitalizeFirstLetter broken tests

### DIFF
--- a/packages/common/src/capitalize.test.ts
+++ b/packages/common/src/capitalize.test.ts
@@ -6,10 +6,10 @@ describe('Capitalize first letter', () => {
   })
 
   it("doesn't break if provided empty string", () => {
-    expect(capitalizeFirstLetter('')).toEqual(null)
+    expect(capitalizeFirstLetter('')).toEqual('')
   })
 
   it("doesn't break if string is undefined", () => {
-    expect(capitalizeFirstLetter(undefined)).toEqual(null)
+    expect(capitalizeFirstLetter(undefined)).toEqual('')
   })
 })

--- a/packages/common/src/capitalize.ts
+++ b/packages/common/src/capitalize.ts
@@ -2,6 +2,6 @@ export const capitalizeFirstLetter = (text: string): string => {
   if (text) {
     return text.charAt(0).toUpperCase() + text.slice(1)
   } else {
-    return null
+    return ''
   }
 }

--- a/packages/common/src/capitalize.ts
+++ b/packages/common/src/capitalize.ts
@@ -1,7 +1,7 @@
 export const capitalizeFirstLetter = (text: string): string => {
-  if (text?.length > 0) {
+  if (text) {
     return text.charAt(0).toUpperCase() + text.slice(1)
   } else {
-    return ''
+    return null
   }
 }


### PR DESCRIPTION
### Main Changes

- Common utility: `capitalizeFirstLetter` restored broken tests

**Before**

![Captura de pantalla 2023-08-23 a las 0 14 59](https://github.com/TryQuiet/quiet/assets/5110813/834a2963-0e09-4ff1-8a0c-48c612a9c465)


**After**
![Captura de pantalla 2023-08-23 a las 0 14 22](https://github.com/TryQuiet/quiet/assets/5110813/b0bcd02b-cbf8-4807-9af4-55cadc7c927b)


### Notes

Not sure if this tests are executed while running in the PR pipelines, but maybe is important to include them. What do you think?

### Changelog


- 47269fd fix: common: capitalize should return null if no string provided by @UlisesGascon
- c5f65ed test: restore broken tests for capitalizeFirstLetter by @UlisesGascon