### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,15 +60,17 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: docker
-    directory: /packages/integration-tests
-    schedule:
-      interval: weekly
+  # Currently, the integration tests pkg is waiting for a clean up.
+  # @SEE:  https://github.com/TryQuiet/quiet/pull/1734#discussion_r1302831794
+  # - package-ecosystem: docker
+  #   directory: /packages/integration-tests
+  #   schedule:
+  #     interval: weekly
 
-  - package-ecosystem: npm
-    directory: /packages/integration-tests
-    schedule:
-      interval: weekly
+  # - package-ecosystem: npm
+  #   directory: /packages/integration-tests
+  #   schedule:
+  #     interval: weekly
 
   - package-ecosystem: npm
     directory: /packages/logger

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /3rd-party/tor
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/backend-bundle
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /packages/backend
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/backend
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/common
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/desktop
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /packages/e2e-tests/docker
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/e2e-tests
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/eslint-config-custom
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/identity
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /packages/integration-tests
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/integration-tests
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/logger
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: bundler
+    directory: /packages/mobile
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /packages/mobile/android-environment
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/mobile/nodejs-modules/builtin_modules/rn-bridge
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/mobile
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/state-manager
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/types
+    schedule:
+      interval: weekly


### PR DESCRIPTION
### Main Changes

This PR will enable [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). While the suggested frequency is daily, I suggest weekly or even a custom CRON Job to control the noise (if you are not used to it) 🙂. It will automatically generate PRs with the dependency upgrades.


### Context

Related TryQuiet/quiet#1732

### Changelog

- 1b283ac feat: enable dependabot by @UlisesGascon







