### PR TITLE
Add dependency review GH Action

### DIFF
--- a/.github/workflows/depencency-review.yml
+++ b/.github/workflows/depencency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1


### PR DESCRIPTION
### Main Changes

Added an official GitHub Action to [review dependencies](https://github.com/actions/dependency-review-action) (b4496fe). It is triggered in every PR. It will fail if any dependency introduces a vulnerability or an invalid license.

### Context

Related TryQuiet/quiet#1732


### Changelog

- b4496fe chore: added dependency review GitHub Action by @UlisesGascon
