### PR TITLE
fix: Add patch to requirements documentation

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -4,10 +4,11 @@ Communication manager for Quiet project. Uses OrbitDB, Libp2p, Tor and websocket
 
 ### Installation
 
-Requirements: 
+Requirements:
 - node@12
 - typescript
 - ts-node
+- patch
 
 Install dependencies:
 
@@ -54,10 +55,10 @@ docker-compose helps to create a local network of nodes . This is purely for tes
 docker-compose build
 docker-compose up  // Run default - 3 peers
 
-docker-compose up --scale peer=3  // Run with scaled number of regular peers 
+docker-compose up --scale peer=3  // Run with scaled number of regular peers
 ```
 
-Currently there is no db data in this network - to be added. 
+Currently there is no db data in this network - to be added.
 
 ### Webpack
 
@@ -68,5 +69,3 @@ When your aim is to build the desktop app run the following command in packages/
 ### Architecture
 
 // TODO
-
-

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -3,8 +3,9 @@
 Running the desktop version of Quiet should be straightforward on Mac and Linux. On Windows we recommend using git-bash or just wsl.
 Here are the steps:
 
-0. Use `Node 18.12.1` and `npm 8.19.2`. We recommend [nvm](https://github.com/nvm-sh/nvm) for easily switching Node versions, and if this README gets out of date you can see the actual version used by CI [here](https://github.com/TryQuiet/quiet/blob/master/.github/actions/setup-env/action.yml). If you are using nvm, you can run `nvm use` in the project's root to switch to the correct version.
-1. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies and trigger a prepublish script which builds them.
+0. Install `patch` (e.g. via your Linux package manager)
+1. Use `Node 18.12.1` and `npm 8.19.2`. We recommend [nvm](https://github.com/nvm-sh/nvm) for easily switching Node versions, and if this README gets out of date you can see the actual version used by CI [here](https://github.com/TryQuiet/quiet/blob/master/.github/actions/setup-env/action.yml). If you are using nvm, you can run `nvm use` in the project's root to switch to the correct version.
+2. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies and trigger a prepublish script which builds them.
 
 ```
 npm i lerna@6.6.2
@@ -14,7 +15,7 @@ npm run lerna bootstrap
 
 If you run into problems please double check if you have exact version Node and NPM as listed in point 0.
 
-2. In `quiet/packages/desktop` run:
+3. In `quiet/packages/desktop` run:
 
 ```
 npm run start

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -6,6 +6,8 @@ Quiet Mobile is a React Native app for Android and iOS that shares a Node.js [ba
 
 ### Prerequisites
 
+Install `patch` (e.g. via your Linux package manager).
+
 In the root directory of `quiet/`, install the monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies and trigger a prepublish script which builds them.
 
 ```
@@ -85,7 +87,7 @@ const watchFolders = [
 ```
 
 ## Running E2E tests (optional)
-We use Detox (https://wix.github.io/Detox/) for E2E testing on mobile.  
+We use Detox (https://wix.github.io/Detox/) for E2E testing on mobile.
 Detox recommends to install its `detox-cli` globally, enabling usage of the command line tools outside npm scripts.
 
 ```
@@ -100,7 +102,7 @@ Choose proper configuration depending on the os and target device and pass it wi
 There're two commands to use:
 (remember to prefix commands with `npx` if using globally installed `detox-cli`)
 
-The first one for building binary file to put under test:  
+The first one for building binary file to put under test:
 
 ```
 detox build --configuration android.att.debug
@@ -136,7 +138,7 @@ Tests can also be started at a particular story pointed out using `-starting-sto
 
 ## Development hints
 
-React-native projects consists of two parts: javascript code and native code. Native code lives within the `/android` and `/ios` folder.  
+React-native projects consists of two parts: javascript code and native code. Native code lives within the `/android` and `/ios` folder.
 
 ### IDE
 
@@ -146,7 +148,7 @@ Altough if you plan to modify the native code, Android Studio is recommended as 
 
 ### When to rebuild the project?
 
-Both Android and iOS manages their own dependencies with the help of `gradle` (Android) and `cocoapods` (iOS). They work similar to `npm`.  
+Both Android and iOS manages their own dependencies with the help of `gradle` (Android) and `cocoapods` (iOS). They work similar to `npm`.
 Whenewer there're changes to the dependencies in the native projects (`build.gradle` or `podfile`) there's a need to sync gradle files (it's fairly easy to do with Android Studio) or to run `pod install` command from the `/ios` directory. It doesn't happen very often but may be a case while attaching react-native modules getting use of the native methods (eg. for file management).
 
 If changes are made to the native part of the project (java, kotlin, objc or swift) it's neccessary to rebuild the project (`npm run android`, `npm run ios`)
@@ -164,13 +166,13 @@ enter it and find directory data within `/Documents` folder
 
 ### The app is stuck on splash screen
 
-Sometimes metro loader takes long enough to cause a race condition failure with the native service notifying javascript code about the data of websocket server 
+Sometimes metro loader takes long enough to cause a race condition failure with the native service notifying javascript code about the data of websocket server
 we use to communicate with backend. In this case, we should be able to observe a log informing us that an event has been emitted but there was nothing to receive it:
 ```
 WEBSOCKET CONNECTION: Starting on 11000
 RCTNativeAppEventEmitter: Tried to send an event but got NULL on reactContext
 ```
-The easiest solution is to close the app and open it again by tapping it's icon on the device (there's no need to rebuild the project) (Android/iOS)  
+The easiest solution is to close the app and open it again by tapping it's icon on the device (there's no need to rebuild the project) (Android/iOS)
 or to follow `Product -> Perform Action -> Run Without Building` in Xcode. (iOS)
 
 If it's not enough, you can locally increase the `WEBSOCKET_CONNECTION_DELAY` for emitting the event at `mobile/android/app/src/main/java/com/quietmobile/Utils/Const.kt` (Android)
@@ -188,7 +190,7 @@ Mobile package uses several patches for external dependencies. If you encounter 
 
 ### Invalid symlink at
 
-Built app bundle cannot contain symlinks linking outside the package (which sometimes happens when symlink uses absolute path). In this case one needs to change the symlink to relative path. It can be achieved by adding a custom built task either in Gradle or Xcode. 
+Built app bundle cannot contain symlinks linking outside the package (which sometimes happens when symlink uses absolute path). In this case one needs to change the symlink to relative path. It can be achieved by adding a custom built task either in Gradle or Xcode.
 
 ### Unable to resolve module
 


### PR DESCRIPTION
I noticed that `patch` was not installed on my system, leading to Electron being
imported in the backend, which then caused an error: "Electron failed to install
correctly, please delete node_modules/electron and try installing again". The
build steps are currently written such that they succeed even if the patch
command fails. This works for now since it makes them idempotent, since patch
fails if it cannot apply changes (e.g. the changes are already applied).
However, it also hides the case where patch isn't installed. I'd like to ensure
patch is installed and provide an error otherwise, but for now we can just
update the documentation to let users know it's required.


### Pull Request Checklist

- [ ] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).