### PR TITLE
write `:smile:` for 😄, `:tada:` for 🎉, `:rocket:` for 🚀 #540

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -481,6 +481,7 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
         } else if (inputStateRef.current === INPUT_STATE.AVAILABLE) {
           e.preventDefault()
           const target = e.target as HTMLInputElement
+          target.innerText = replaceEmojicodesWithEmoji(target.innerText);
           onChange(target.innerText)
           onKeyPress(target.innerText)
           setMessage('')
@@ -507,6 +508,16 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
       setSelected,
     ]
   )
+
+  const emojiMap: { [key: string]: string } = {
+    "smile": "😄",
+    "tada": "🎉",
+    "rocket": "🚀",
+  };
+
+  function replaceEmojicodesWithEmoji(text: string) {
+    return text.replace(/:(\w+):/g, (match, p1) => emojiMap[p1] || match);
+  }
 
   const handleFileInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

This is just a draft pull request for now. @holmesworcester and I were talking about it.

It's for this issue:

- #540

So far I'm only supporting three emoji codes (smile, tada, and rocket). And there's no preview, no picker. I was just happy to get something working. 😅 

Here are a couple screenshots:

<img width="914" alt="Screenshot 2023-09-16 at 11 00 15 PM" src="https://github.com/TryQuiet/quiet/assets/21006/54f63f7e-370a-484d-bc82-96fd05354570">


<img width="914" alt="Screenshot 2023-09-16 at 11 00 21 PM" src="https://github.com/TryQuiet/quiet/assets/21006/77ef44aa-8521-46c1-a6a9-00f20f4f9997">
