### PR TITLE
Every user opening Settings for the first time should be in a tab with invitation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@
 * Integration state manager layer with UI layer(desktop and mobile)
 
 * Clarify autoupdate language in update modal to let users know that the app will update on restart.
+
+* Invite tab as default in settings

--- a/packages/desktop/src/renderer/components/Settings/SettingsComponent.tsx
+++ b/packages/desktop/src/renderer/components/Settings/SettingsComponent.tsx
@@ -82,7 +82,7 @@ export const SettingsComponent: React.FC<SettingsComponentProps> = ({
 
   const [offset, setOffset] = React.useState(0)
 
-  const defaultCurrentTab = isOwner ? 'invite' : 'notifications'
+  const defaultCurrentTab = 'invite'
   const [currentTab, setCurrentTab] = useState(defaultCurrentTab)
 
   const adjustOffset = () => {


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to related GitHub issue.
- [x] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).