### PR TITLE
Use large runners for E2E Windows/Linux tests and Android build

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -196,51 +196,6 @@ jobs:
         with:
           source-path: win32
 
-      #E2E - Start 
-      # - name: E2E - electron-builder
-      #   env:
-      #     CERTIFICATE_PATH: ${{ steps.write_file.outputs.filePath }}
-      #     WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-      #     WINDOWS_ALIAS: ${{ secrets.WIN_ALIAS }}
-      #   working-directory: ./packages/desktop
-      #   run: node_modules/.bin/electron-builder --win 
-      #   shell: bash
-
-      # - name: E2E - Extract version
-      #   id: extract_version
-      #   uses: Saionaro/extract-package-version@v1.2.1
-      #   with:
-      #     path: packages/desktop
-
-      # - name: E2E - FILE_NAME env
-      #   working-directory: ./packages/desktop/dist
-      #   run: echo "FILE_NAME=Quiet Setup ${{ steps.extract_version.outputs.version }}.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-      #   shell: powershell
-
-      # - name: E2E - Chmod
-      #   working-directory: ./packages/desktop/dist
-      #   run: chmod +x "$FILE_NAME"
-      #   shell: bash
-
-      # - name: E2E - Install exe
-      #   run: Start-Process "Quiet Setup ${{ steps.extract_version.outputs.version }}.exe" -Wait
-      #   working-directory: ./packages/desktop/dist
-      #   shell: powershell
-
-      # - name: E2E - Kill exe
-      #   run: Stop-Process -Name "Quiet" -Force
-      #   working-directory: ./packages/desktop/dist
-      #   shell: powershell
-
-      # - name: E2E - Run smoke test
-      #   uses: nick-fields/retry@v2
-      #   with:
-      #     timeout_minutes: 25
-      #     max_attempts: 3
-      #     shell: bash
-      #     command: cd packages/e2e-tests && npm run test smoke.crossplatform.test.ts
-      #E2E - End         
-
       - name: "Set electron-builder props"
         shell: bash
         run: echo "ELECTRON_BUILDER_PROPS=-c.publish.bucket=$S3_BUCKET" >> $GITHUB_ENV

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-latest-m]
 
     timeout-minutes: 180
 
@@ -74,7 +74,7 @@ jobs:
       - name: Chmod App Image 1.2.0
         working-directory: ./packages/e2e-tests/Quiet
         run: chmod +x Quiet-1.2.0.AppImage
-        
+
       - name: Run Backwards Compatibility test
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -3,8 +3,8 @@ name: E2E Windows
 on: [workflow_call]
 jobs:
   windows:
-    runs-on: windows-2019
-    
+    runs-on: windows-latest-l
+
     timeout-minutes: 180
 
     env:
@@ -36,7 +36,7 @@ jobs:
 
       - name: electron-builder
         working-directory: ./packages/desktop
-        run: node_modules/.bin/electron-builder --win 
+        run: node_modules/.bin/electron-builder --win
         shell: bash
 
       - name: Extract version

--- a/.github/workflows/mobile-deploy-android.yaml
+++ b/.github/workflows/mobile-deploy-android.yaml
@@ -2,7 +2,7 @@ name: Deploy Android to Google Play
 
 on:
   release:
-    types: 
+    types:
       [prereleased, released]
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest-m]
 
     steps:
       - name: "Print OS"
@@ -33,7 +33,7 @@ jobs:
         with:
           ndk-version: r21e
           add-to-path: false
-        
+
       - name: "Setup environment"
         uses: ./.github/actions/setup-env
         with:
@@ -47,7 +47,7 @@ jobs:
           printf "\
           NDK_PATH=${{ steps.setup-ndk.outputs.ndk-path }}\n\
           " > $HOME/.gradle/gradle.properties
-      
+
       - name: "Prepare signing configuration"
         run: |
           printf "\
@@ -76,7 +76,7 @@ jobs:
           mkdir -p distribution/whatsnew
           git log -1 --pretty=format:%s > distribution/whatsnew/whatsnew-pl-PL
           echo ${{ SECRETS.SERVICE_ACCOUNT_JSON }} | base64 --decode > google-play.json
-      
+
       - name: "Upload to Google Play"
         uses: r0adkll/upload-google-play@v1.1.2
         with:


### PR DESCRIPTION
I've enabled the large runners for Windows/Linux E2E tests and the Android build. We only have large runners for Windows and Linux and I've just focused on the most time-consuming builds to start. If we think we want to use the large runners for other workflows, we can do that.

As reference the lint step for Linux takes around 12 minutes using the default runners. I'd be interested in seeing what particularly is taking so long before moving that task to a larger runner.

### Pull Request Checklist

- [ ] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
