### PR TITLE
bug/1976 - display a shorter invite link on a mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Shorter dots-placeholder for invite link
 
+* Display a shorter invite link on a mobile
+
 * Removed registration attempts selector and corresponding usage.
 
 * Revert adjusting bootstrap scripts for developing on Windows

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.component.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.component.tsx
@@ -133,6 +133,7 @@ export const ContextMenu: FC<ContextMenuProps> = ({
                 <Typography
                   fontSize={14}
                   fontWeight={'normal'}
+                  numberOfLines={1}
                   style={{ lineHeight: 20, color: defaultPalette.typography.gray50 }}
                   onPress={linkAction}
                 >

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -60,7 +60,7 @@ storiesOf('ContextMenu', module)
         title={'Add members'}
         items={invitation_items}
         hint={'Anyone with Quiet app can follow this link to join this community. Only share with people you trust.'}
-        link={'https://chat.quiet.org/quiet://?code=bidrmzr3ee6qa2vvrlcnqvvvsk2gmjktcqkunba326parszr44gibwyd'}
+        link={`https://tryquiet.org/join#QmNzTe4kwwq7yDrC9GRXWFT5JoBSGukWAcLSTMYPmrensB=vag3ot2imv7lrwsqesv2qykyx2fxenvjfcawgngab6gjzo2gg5o5vqqd&QmZx8actcU9E49Dff3PDVyXTCrVor9iBQryxfasfN4Drxo=sdiy7sermcmtaomn4w3bnxlmdqoun5bxre34xfcaxckhy7obhphcypad&QmQGCuEB5ChnqYCGu5nuBhtyzd9BmDdVUH9neaHNuCDd1M=pr42dxkelrs5iy2a4n4ycv2ptzk4yur274hq2zfshvgxu5rpay6lghqd&QmZgT4AbyPZjEPvMkpjCvfRSDYcrcyUiwTMDNF8rEigqHT=ka5m3rho2gvldgmigp7jn5taok7nwyp5v2fix3jdirpsyf7rdm547cqd`}
         visible={true}
         handleClose={() => {
           console.log('closing menu')

--- a/packages/mobile/src/components/ContextMenu/menus/InvitationContextMenu.container.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/InvitationContextMenu.container.tsx
@@ -82,7 +82,7 @@ export const InvitationContextMenu: FC = () => {
       title={'Add members'}
       items={items}
       hint={'Anyone with Quiet app can follow this link to join this community. Only share with people you trust.'}
-      link={invitationLink}
+      link={invitationLink.slice(0, 35) + '...'}
       linkAction={copyLink}
       {...invitationContextMenu}
     />

--- a/packages/mobile/src/components/ContextMenu/menus/InvitationContextMenu.container.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/InvitationContextMenu.container.tsx
@@ -82,7 +82,7 @@ export const InvitationContextMenu: FC = () => {
       title={'Add members'}
       items={items}
       hint={'Anyone with Quiet app can follow this link to join this community. Only share with people you trust.'}
-      link={invitationLink.slice(0, 35) + '...'}
+      link={invitationLink}
       linkAction={copyLink}
       {...invitationContextMenu}
     />


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to related GitHub issue.
- [x] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests

![image](https://github.com/TryQuiet/quiet/assets/111343884/11ff77f6-e9a9-4c33-9240-476ef6383312)



