### PR TITLE
fix: Revert github runners for E2E tests

### DIFF
--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest-m]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     timeout-minutes: 180
 

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -3,7 +3,7 @@ name: E2E Windows
 on: [workflow_call]
 jobs:
   windows:
-    runs-on: windows-latest-l
+    runs-on: windows-2019
 
     timeout-minutes: 180
 
@@ -66,7 +66,7 @@ jobs:
         run: Start-Process "Quiet Setup ${{ steps.extract_version.outputs.version }}.exe" -Wait
         working-directory: ./packages/desktop/dist
         shell: powershell
-      
+
       - name: Check if Quiet installed properly
         run: Get-ChildItem -Path C:\Users\runneradmin\AppData\Local\Programs\@quietdesktop
         shell: powershell


### PR DESCRIPTION
Use the github provided runners for now because the E2E tests are expensive to run and it's unclear how much value the larger runner provides. Tor seems to cause a lot of variability in test run time. We are still using the larger Linux runner for the Android build.


### Pull Request Checklist

- [ ] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
