### PR TITLE
Fix: Clean up desktop UI console errors/warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 [2.1.0] - unreleased
 
+* Clean up desktop UI console errors/warnings
+
 * fix: Enable channel context menu for all users
 
 * Fix channel creation message impersonation bug by removing username from channel creation message

--- a/packages/desktop/src/renderer/components/Channel/DeleteChannel/DeleteChannel.test.tsx
+++ b/packages/desktop/src/renderer/components/Channel/DeleteChannel/DeleteChannel.test.tsx
@@ -23,7 +23,6 @@ describe('LeaveCommunity', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/ChannelCreationModal/ChannelCreationModal.test.tsx
+++ b/packages/desktop/src/renderer/components/ChannelCreationModal/ChannelCreationModal.test.tsx
@@ -15,7 +15,6 @@ describe('Create ChannelCreationModalComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/PerformCommunityActionComponent.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/PerformCommunityActionComponent.tsx
@@ -276,23 +276,21 @@ export const PerformCommunityActionComponent: React.FC<PerformCommunityActionPro
                     }}
                     onblur={() => {}}
                     InputProps={
-                      communityOwnership === CommunityOwnership.User ? (
-                        {
-                          endAdornment: (
-                            <InputAdornment position='end'>
-                              <IconButton size='small' onClick={handleClickInputReveal}>
-                                {!revealInputValue ? (
-                                  <VisibilityOff color='primary' fontSize='small' />
-                                ) : (
-                                  <Visibility color='primary' fontSize='small' />
-                                )}
-                              </IconButton>
-                            </InputAdornment>
-                          ),
-                        }
-                      ) : (
-                        <></>
-                      )
+                      communityOwnership === CommunityOwnership.User
+                        ? {
+                            endAdornment: (
+                              <InputAdornment position='end'>
+                                <IconButton size='small' onClick={handleClickInputReveal}>
+                                  {!revealInputValue ? (
+                                    <VisibilityOff color='primary' fontSize='small' />
+                                  ) : (
+                                    <Visibility color='primary' fontSize='small' />
+                                  )}
+                                </IconButton>
+                              </InputAdornment>
+                            ),
+                          }
+                        : undefined
                     }
                     type={revealInputValue ? 'text' : 'password'}
                     value={communityOwnership === CommunityOwnership.User ? field.value.trim() : field.value}

--- a/packages/desktop/src/renderer/components/LoadingPanel/JoiningPanelComponent.test.tsx
+++ b/packages/desktop/src/renderer/components/LoadingPanel/JoiningPanelComponent.test.tsx
@@ -24,7 +24,6 @@ describe('Create JoiningPanelComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"
@@ -161,7 +160,6 @@ describe('Create JoiningPanelComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/LoadingPanel/StartingPanelComponent.test.tsx
+++ b/packages/desktop/src/renderer/components/LoadingPanel/StartingPanelComponent.test.tsx
@@ -15,7 +15,6 @@ describe('Create StartingPanelComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/SearchModal/SearchModal.test.tsx
+++ b/packages/desktop/src/renderer/components/SearchModal/SearchModal.test.tsx
@@ -79,7 +79,6 @@ describe('Search Modal', () => {
           <div
             class="MuiModal-root css-1vjugmr-MuiModal-root"
             role="presentation"
-            zindex="1300"
           >
             <div
               aria-hidden="true"

--- a/packages/desktop/src/renderer/components/Settings/SettingsComponent.tsx
+++ b/packages/desktop/src/renderer/components/Settings/SettingsComponent.tsx
@@ -30,17 +30,9 @@ const StyledTabsWrapper = styled(Grid)(() => ({
   width: 168,
 }))
 
-const StyledAppBar = styled(AppBar, { label: 'xxxxx' })(() => ({
+const StyledAppBar = styled(AppBar, { label: 'xxxxx' })(({ theme }) => ({
   backgroundColor: '#fff',
   boxShadow: '0px 1px 3px rgba(0, 0, 0, 0.0)',
-}))
-
-const StyledTabs = styled(Tabs)(({ theme }) => ({
-  color: theme.palette.colors.trueBlack,
-
-  [`& .${classes.indicator}`]: {
-    height: '0 !important',
-  },
 
   [`& .${classes.leaveComunity}`]: {
     opacity: '1',
@@ -52,6 +44,14 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
     textTransform: 'none',
     lineHeight: '21px',
     minHeight: '0px',
+  },
+}))
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+  color: theme.palette.colors.trueBlack,
+
+  [`& .${classes.indicator}`]: {
+    height: '0 !important',
   },
 }))
 
@@ -145,18 +145,18 @@ export const SettingsComponent: React.FC<SettingsComponentProps> = ({
               <Tab value='notifications' label='Notifications' data-testid={'notifications-settings-tab'} />
               <Tab value='invite' label='Invite a friend' data-testid={'invite-settings-tab'} />
               <Tab value='qrcode' label='QR Code' data-testid={'qr-code-tab'} />
-              {!isWindows && (
-                <Grid style={{ marginTop: '24px', cursor: 'pointer' }}>
-                  <Typography
-                    data-testid='leave-community-tab'
-                    className={classes.leaveComunity}
-                    onClick={leaveCommunityModal.handleOpen}
-                  >
-                    Leave community
-                  </Typography>
-                </Grid>
-              )}
             </StyledTabs>
+            {!isWindows && (
+              <Grid style={{ marginTop: '24px', cursor: 'pointer' }}>
+                <Typography
+                  data-testid='leave-community-tab'
+                  className={classes.leaveComunity}
+                  onClick={leaveCommunityModal.handleOpen}
+                >
+                  Leave community
+                </Typography>
+              </Grid>
+            )}
           </StyledAppBar>
         </StyledTabsWrapper>
         <Grid item xs>

--- a/packages/desktop/src/renderer/components/Settings/Tabs/LeaveCommunity/LeaveCommunity.test.tsx
+++ b/packages/desktop/src/renderer/components/Settings/Tabs/LeaveCommunity/LeaveCommunity.test.tsx
@@ -24,7 +24,6 @@ describe('LeaveCommunity', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/Sidebar/TorStatus.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar/TorStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { styled } from '@mui/material/styles'
-import Grid from '@mui/material/Grid'
+import { Grid, GridProps } from '@mui/material'
 import { Typography } from '@mui/material'
 import { connection } from '@quiet/state-manager'
 import { useSelector } from 'react-redux'
@@ -14,10 +14,16 @@ const classes = {
   circle: `${PREFIX}circle`,
 }
 
-interface StyledGridProps {
-  isDev: boolean
+type StyledGridProps = GridProps & { isDev: boolean }
+
+// Added to remove React warnings due to props getting added to the DOM.
+// See: https://github.com/mui/material-ui/issues/40336
+const StyledGridWithProps = (props: StyledGridProps) => {
+  const { isDev, ...rest } = props
+  return <Grid {...rest} />
 }
-const StyledGrid = styled(Grid)(({ isDev }: StyledGridProps) => ({
+
+const StyledGrid = styled(StyledGridWithProps)(({ isDev }: StyledGridProps) => ({
   [`& .${classes.root}`]: {},
   [`& .${classes.wrapper}`]: {
     paddingBottom: '32px',

--- a/packages/desktop/src/renderer/components/ui/ErrorModal/ErrorModal.test.tsx
+++ b/packages/desktop/src/renderer/components/ui/ErrorModal/ErrorModal.test.tsx
@@ -25,7 +25,6 @@ describe('ErrorModal', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/ui/Modal/Modal.tsx
+++ b/packages/desktop/src/renderer/components/ui/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { styled } from '@mui/material/styles'
 import classNames from 'classnames'
 
-import MaterialModal from '@mui/material/Modal'
+import { Modal as MaterialModal, ModalProps as MaterialModalProps } from '@mui/material'
 import Typography from '@mui/material/Typography'
 import Grid from '@mui/material/Grid'
 
@@ -34,8 +34,17 @@ const classes = {
   sentry: `${PREFIX}sentry`,
 }
 
+type StyledMaterialModalProps = MaterialModalProps & { zIndex: number }
+
+// Added to remove React warnings due to props getting added to the DOM.
+// See: https://github.com/mui/material-ui/issues/40336
+const StyledMaterialModalWithProps = (props: StyledMaterialModalProps) => {
+  const { zIndex, ...rest } = props
+  return <MaterialModal {...rest} />
+}
+
 // @ts-ignore
-const StyledMaterialModal = styled(MaterialModal)(({ theme, zIndex }) => ({
+const StyledMaterialModal = styled(StyledMaterialModalWithProps)(({ theme, zIndex }: StyledMaterialModalProps) => ({
   zIndex: zIndex,
   [`& .${classes.root}`]: {
     padding: '0 15%',
@@ -150,12 +159,7 @@ export const Modal: React.FC<IModalProps> = ({
 }) => {
   const zIndex = isSentry ? 9000 : 1300
   return (
-    <StyledMaterialModal
-      // @ts-ignore
-      zIndex={zIndex}
-      open={open}
-      onClose={handleClose}
-    >
+    <StyledMaterialModal zIndex={zIndex} open={open} onClose={handleClose}>
       <Grid
         container
         direction='column'

--- a/packages/desktop/src/renderer/components/ui/OpenlinkModal/OpenlinkModal.test.tsx
+++ b/packages/desktop/src/renderer/components/ui/OpenlinkModal/OpenlinkModal.test.tsx
@@ -26,7 +26,6 @@ describe('OpenlinkModal', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/widgets/WarningModal/WarningModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/WarningModal/WarningModal.test.tsx
@@ -17,7 +17,6 @@ describe('WarningModal', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/widgets/possibleImpersonationAttackModal/PossibleImpersonationAttackModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/possibleImpersonationAttackModal/PossibleImpersonationAttackModal.test.tsx
@@ -21,7 +21,6 @@ describe('PossibleImpersonationAttackModal', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/widgets/update/UpdateModalComponent.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/update/UpdateModalComponent.test.tsx
@@ -24,7 +24,6 @@ describe('UpdateModal', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/widgets/userLabel/duplicate/DuplicateModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/userLabel/duplicate/DuplicateModal.test.tsx
@@ -21,7 +21,6 @@ describe('DuplicateModalComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/components/widgets/userLabel/unregistered/UnregisteredModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/userLabel/unregistered/UnregisteredModal.test.tsx
@@ -21,7 +21,6 @@ describe('UnregisteredModalComponent', () => {
         <div
           class="MuiModal-root css-1vjugmr-MuiModal-root"
           role="presentation"
-          zindex="1300"
         >
           <div
             aria-hidden="true"

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <link rel="preload" href="Menlo-Regular.woff" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWKBXyIfDnIV7nFrXyi0A.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWKBXyIfDnIV7nDrXyi0A.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWKBXyIfDnIV7nPrXyi0A.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWKBXyIfDnIV7nBrXw.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWHBXyIfDnIV7EyjmmZ8WDm7Q.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWHBXyIfDnIV7Eyjmmf8WDm7Q.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWHBXyIfDnIV7EyjmmT8WDm7Q.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="iJWHBXyIfDnIV7Eyjmmd8WA.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="Menlo-Regular.woff" as="font" type="font/woff">
+    <link rel="preload" href="iJWKBXyIfDnIV7nFrXyi0A.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWKBXyIfDnIV7nDrXyi0A.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWKBXyIfDnIV7nPrXyi0A.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWKBXyIfDnIV7nBrXw.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWHBXyIfDnIV7EyjmmZ8WDm7Q.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWHBXyIfDnIV7Eyjmmf8WDm7Q.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWHBXyIfDnIV7EyjmmT8WDm7Q.woff2" as="font" type="font/woff2">
+    <link rel="preload" href="iJWHBXyIfDnIV7Eyjmmd8WA.woff2" as="font" type="font/woff2">
     <style>
       @font-face {
         font-family: 'Menlo Regular';


### PR DESCRIPTION
On desktop, the browser was emitting several errors/warnings that filled up the console. Some of these were related to React and then some of them related to HTML preload. The preload warning says, "A preload for {url} is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute." and then a little later it says, "The resource {url} was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally." Removing the crossorigin attribute on the font links removed the preload warning and it looks like everything is preloading correctly to me in dev/production (fonts load at the very beginning and no warnings). Maybe if CORS is not used then it also doesn't want crossorigin attribute.


### Pull Request Checklist

- [x] I have linked this PR to related GitHub issue.
- [x] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
