### PR TITLE
backport: fix: Make community name field text visible on create community page

### DIFF
--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
@@ -285,4 +285,26 @@ describe('Create community', () => {
     expect(handleRedirection).toBeCalled()
     expect(handleCommunityAction).not.toBeCalled()
   })
+
+  it('has visible community name text', async () => {
+    const { store } = await prepareStore({
+      [StoreKeys.Modals]: {
+        ...new ModalsInitialState(),
+        [ModalName.createCommunityModal]: { open: true },
+      },
+    })
+
+    renderComponent(
+      <>
+        <JoinCommunity />
+        <CreateCommunity />
+      </>,
+      store
+    )
+
+    const dictionary = CreateCommunityDictionary()
+    const createCommunityInput = screen.getByPlaceholderText(dictionary.placeholder)
+
+    expect(createCommunityInput).toHaveAttribute('type', 'text')
+  })
 })

--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.tsx
@@ -50,6 +50,7 @@ const CreateCommunity = () => {
       isConnectionReady={isConnected}
       isCloseDisabled={!currentCommunity}
       hasReceivedResponse={Boolean(currentIdentity && !currentIdentity.userCertificate)}
+      revealInputValue={true}
     />
   )
 }


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
