### PR TITLE
fix: Add migration code for undefined userProfiles field

### DIFF
--- a/packages/state-manager/src/sagas/publicChannels/publicChannels.selectors.ts
+++ b/packages/state-manager/src/sagas/publicChannels/publicChannels.selectors.ts
@@ -21,7 +21,7 @@ import {
   type PublicChannel,
   type PublicChannelStatus,
   INITIAL_CURRENT_CHANNEL_ID,
-  UserProfile,
+  type UserProfile,
 } from '@quiet/types'
 
 const selectState: CreatedSelectors[StoreKeys.PublicChannels] = (state: StoreState) => state[StoreKeys.PublicChannels]

--- a/packages/state-manager/src/sagas/users/userProfile/userProfile.selectors.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/userProfile.selectors.ts
@@ -7,7 +7,8 @@ import { currentIdentity } from '../../identity/identity.selectors'
 
 const usersSlice: CreatedSelectors[StoreKeys.Users] = (state: StoreState) => state[StoreKeys.Users]
 
-export const userProfiles = createSelector(usersSlice, users => users.userProfiles)
+// Nullish coalescing operator for backwards compatibility with 2.0.1
+export const userProfiles = createSelector(usersSlice, users => users.userProfiles ?? {})
 
 export const myUserProfile = createSelector(userProfiles, currentIdentity, (userProfiles, identity) => {
   if (identity?.userCsr) {

--- a/packages/state-manager/src/sagas/users/users.slice.ts
+++ b/packages/state-manager/src/sagas/users/users.slice.ts
@@ -54,6 +54,10 @@ export const usersSlice = createSlice({
     },
     saveUserProfile: (state, _action: PayloadAction<{ photo?: File }>) => state,
     setUserProfiles: (state, action: PayloadAction<UserProfile[]>) => {
+      // Creating user profiles object for backwards compatibility with 2.0.1
+      if (!state.userProfiles) {
+        state.userProfiles = {}
+      }
       for (const userProfile of action.payload) {
         state.userProfiles[userProfile.pubKey] = userProfile
       }


### PR DESCRIPTION
When upgrading from 2.0.1 to 2.1.0, the user profile feature was added which included a new userProfiles field in the Redux users store. It looks like Redux Persist doesn't automatically initialize any newly added fields, so I've added a few lines to do that. Solution for #2250


### Pull Request Checklist

- [X] I have linked this PR to related GitHub issue.
- [ ] I have updated the CHANGELOG.md file with relevant changes (the file is located at the root of monorepo).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
