### PR TITLE
fix: Add retry ability to tor-control and misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Prevent channel creation with names that start with special character, then a hyphen
 * Choose random ports for Tor services (iOS)
 * Use consistent identicons for messages and profile
+* Add retry ability to tor-control and misc tor-control fixes
 
 # Other:
 

--- a/packages/backend/src/backendManager.ts
+++ b/packages/backend/src/backendManager.ts
@@ -114,8 +114,9 @@ export const runBackendMobile = async () => {
   })
   rn_bridge.channel.on('open', async (msg: OpenServices) => {
     const connectionsManager = app.get<ConnectionsManagerService>(ConnectionsManagerService)
-    const torControlParams = app.get<TorControl>(TorControl)
-    torControlParams.torControlParams.auth.value = msg.authCookie
+    const torControl = app.get<TorControl>(TorControl)
+    torControl.torControlParams.port = msg.torControlPort
+    torControl.torControlParams.auth.value = msg.authCookie
     await connectionsManager.openSocket()
   })
 }


### PR DESCRIPTION
We were getting an uncaught ECONNREFUSED exception on iOS due to the Tor control port not getting updated after the app has been resumed on iOS, so this commit fixes that and refactors the tor-control code in order to add retry ability and fix misc issues with that code.

Solution for: #2352

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
