### PR TITLE
fix: Rewire httpTunnelPort when iOS resumes

### DIFF
--- a/packages/backend/src/backendManager.ts
+++ b/packages/backend/src/backendManager.ts
@@ -11,6 +11,7 @@ import initRnBridge from './rn-bridge'
 import { INestApplicationContext } from '@nestjs/common'
 import logger from './nest/common/logger'
 import { OpenServices, validateOptions } from './options'
+import { SOCKS_PROXY_AGENT } from './nest/const'
 
 const log = logger('backendManager')
 
@@ -112,11 +113,16 @@ export const runBackendMobile = async () => {
     const connectionsManager = app.get<ConnectionsManagerService>(ConnectionsManagerService)
     connectionsManager.closeSocket()
   })
+
   rn_bridge.channel.on('open', async (msg: OpenServices) => {
     const connectionsManager = app.get<ConnectionsManagerService>(ConnectionsManagerService)
     const torControl = app.get<TorControl>(TorControl)
+    const proxyAgent = app.get<{ proxy: { port: string } }>(SOCKS_PROXY_AGENT)
+
     torControl.torControlParams.port = msg.torControlPort
     torControl.torControlParams.auth.value = msg.authCookie
+    proxyAgent.proxy.port = msg.httpTunnelPort
+
     await connectionsManager.openSocket()
   })
 }


### PR DESCRIPTION
Solution for: https://github.com/TryQuiet/quiet/issues/2373

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
