### PR TITLE
fix: Use useLegacyPackaging feature in Gradle

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -180,6 +180,10 @@ android {
         pickFirst 'lib/x86_64/libfbjni.so'
         pickFirst 'lib/armeabi-v7a/libfbjni.so'
         pickFirst 'lib/arm64-v8a/libfbjni.so'
+
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
 
     namespace "com.quietmobile"


### PR DESCRIPTION
This is a replacement for the deprecated
android.bundle.enableUncompressedNativeLibs option that we had been relying on before upgrading React Native and Gradle.


### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
