### PR TITLE
fix: Reduce max random port on iOS

### DIFF
--- a/packages/mobile/ios/Quiet/AppDelegate.m
+++ b/packages/mobile/ios/Quiet/AppDelegate.m
@@ -73,9 +73,9 @@ static NSString *const platform = @"mobile";
 
   self.dataPort             = [findFreePort getFirstStartingFromPort:11000];
 
-  uint16_t socksPort        = [findFreePort getFirstStartingFromPort:arc4random_uniform(65535 - 1024) + 1024];
-  uint16_t controlPort      = [findFreePort getFirstStartingFromPort:arc4random_uniform(65535 - 1024) + 1024];
-  uint16_t httpTunnelPort   = [findFreePort getFirstStartingFromPort:arc4random_uniform(65535 - 1024) + 1024];
+  uint16_t socksPort        = [findFreePort getFirstStartingFromPort:arc4random_uniform(65000 - 1024) + 1024];
+  uint16_t controlPort      = [findFreePort getFirstStartingFromPort:arc4random_uniform(65000 - 1024) + 1024];
+  uint16_t httpTunnelPort   = [findFreePort getFirstStartingFromPort:arc4random_uniform(65000 - 1024) + 1024];
 
 
   // (2/6) Spawn tor with proper configuration


### PR DESCRIPTION
I received an error `Fatal error: Range requires lowerBound <= upperBound` referencing the `FindFreePort.getFirstStartingFrom` method... apparently the port parameter for that function needs to be less than or equal to 65000.

Can see the source code here:
```
@objc(FindFreePort)
class FindFreePort: NSObject {

    @objc
    func getFirstStartingFrom(port: in_port_t) -> UInt16 {
      var returned = port;
      for i in port..<65000 {
        let (result, _) = checkPort(port: port)
        if result == true {
            returned = i;
            break;
        }
      }
      return UInt16(returned)
    }
```


### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
