### PR TITLE
fix: Adds a quick fix for the iOS sync issue after suspend

### DIFF
--- a/packages/backend/src/nest/app.module.ts
+++ b/packages/backend/src/nest/app.module.ts
@@ -105,7 +105,7 @@ export class AppModule {
             io.engine.use((req, res, next) => {
               const authHeader = req.headers['authorization']
               if (!authHeader) {
-                console.error('No authorization header')
+                console.error('Backend server: No authorization header')
                 res.writeHead(401, 'No authorization header')
                 res.end()
                 return
@@ -113,7 +113,7 @@ export class AppModule {
 
               const token = authHeader && authHeader.split(' ')[1]
               if (!token) {
-                console.error('No auth token')
+                console.error('Backend server: No auth token')
                 res.writeHead(401, 'No authorization token')
                 res.end()
                 return
@@ -122,7 +122,7 @@ export class AppModule {
               if (verifyToken(options.socketIOSecret, token)) {
                 next()
               } else {
-                console.error('Wrong basic token')
+                console.error('Backend server: Unauthorized')
                 res.writeHead(401, 'Unauthorized')
                 res.end()
               }

--- a/packages/backend/src/nest/websocketOverTor/index.ts
+++ b/packages/backend/src/nest/websocketOverTor/index.ts
@@ -81,6 +81,7 @@ export class WebSockets extends EventEmitter {
         websocket: {
           ...this._websocketOpts,
         },
+        signal: options.signal,
       })
     } catch (e) {
       log.error('error connecting to %s. Details: %s', ma, e.message)

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -85,7 +85,6 @@ function App(): JSX.Element {
           ref={navigationRef}
           linking={linking}
           onReady={() => {
-            dispatch(initActions.blindWebsocketConnection())
             dispatch(navigationActions.redirection())
           }}
         >


### PR DESCRIPTION
iOS appears to not be syncing correctly after resuming from suspend. It looks like this is due to the libp2p auto-dialer getting stuck connecting to the Tor HTTP tunnel port which is replaced after suspend/resume. This commit enables the WebsocketOverTor transport to use the `dialTimeout` correctly. But still this means the current dialer waits for `dialTimeout` to try another peer, and we currently have `dialTimeout` set to 2 minutes. Ideally, we can find a better approach for closing any sockets when suspending the app or detecting when we are trying to connect to a port that nothing is listening on, if that's possible. Using the `dialTimeout` correctly, is still important regardless.

This is sort of a solution for #2396

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
