### PR TITLE
fix: hanging process functionality killing wrong processes

### DIFF
--- a/packages/common/src/process.ts
+++ b/packages/common/src/process.ts
@@ -1,5 +1,8 @@
 import { type SupportedPlatform } from '@quiet/types'
 
+/**
+ *  Commands should output hanging backend pid
+ */
 export const hangingBackendProcessCommand = ({
   backendBundlePath,
   dataDir,
@@ -7,13 +10,10 @@ export const hangingBackendProcessCommand = ({
   backendBundlePath: string
   dataDir: string
 }): string => {
-  /**
-   *  Commands should output hanging backend pid
-   */
   const byPlatform = {
-    android: `pgrep -af "${backendBundlePath}" | grep -v pgrep | grep "${dataDir}" | awk '{print $1}'`,
-    linux: `pgrep -af "${backendBundlePath}" | grep -v egrep | grep "${dataDir}" | awk '{print $1}'`,
-    darwin: `ps -A | grep "${backendBundlePath}" | grep -v egrep | grep "${dataDir}" | awk '{print $1}'`,
+    android: `pgrep -af "${backendBundlePath}" | grep -v pgrep | grep -e "${dataDir}$" -e "${dataDir}[[:space:]]" | awk '{print $1}'`,
+    linux: `pgrep -af "${backendBundlePath}" | grep -v egrep | grep -e "${dataDir}$" -e "${dataDir}[[:space:]]" | awk '{print $1}'`,
+    darwin: `ps -A | grep "${backendBundlePath}" | grep -v egrep | grep -e "${dataDir}$" -e "${dataDir}[[:space:]]" | awk '{print $1}'`,
     win32: `powershell "Get-WmiObject Win32_process -Filter {commandline LIKE '%${backendBundlePath.replace(
       /\\/g,
       '\\\\'


### PR DESCRIPTION
When using backend data directories like `Quietdev`, `Quietdev1`, `Quietdev2', restarting the process using `Quietdev` can result in that process killing the other backend processes due to the grep command used for finding hanging processes. Example:

```
user (Quietdev1):
desktop:main:main Forked backend, PID: 214543

owner (Quietdev):
Found 1 hanging backend process(es) with pid(s) 214543. Killing...
```

Maybe related to https://github.com/TryQuiet/quiet/issues/2412


### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
