### PR TITLE
Chore(1977): Fix e2e tests on windows

### DIFF
--- a/.github/workflows/e2e-crossplatform.yml
+++ b/.github/workflows/e2e-crossplatform.yml
@@ -8,6 +8,7 @@ on:
       - packages/state-manager/**
       - packages/identity/**
       - packages/common/**
+      - packages/e2e-tests/**
 
 jobs:
   mac:

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -92,6 +92,23 @@ jobs:
           max_attempts: 3
           shell: bash
           command: cd packages/e2e-tests && npm run test oneClient.test.ts
+      
+      - name: Run user profile test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 25
+          max_attempts: 3
+          shell: bash
+          command: cd packages/e2e-tests && npm run test userProfile.test.ts
+        
+      - name: Run invitation link test - Includes 2 separate application clients
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: cd packages/e2e-tests && npm run test invitationLink.test.ts
+  
 
       - name: Run multiple clients test
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
@@ -100,19 +117,3 @@ jobs:
           max_attempts: 3
           shell: bash
           command: cd packages/e2e-tests && npm run test multipleClients.test.ts
-
-      - name: Run user profile test
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 25
-          max_attempts: 3
-          shell: bash
-          command: cd packages/e2e-tests && npm run test userProfile.test.ts
-
-      - name: Run invitation link test - Includes 2 separate application clients
-        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          shell: bash
-          command: cd packages/e2e-tests && npm run test invitationLink.test.ts

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run invitation link test - Includes 2 separate application clients
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
-          timeout_minutes: 25
+          timeout_minutes: 10
           max_attempts: 3
           shell: bash
           command: cd packages/e2e-tests && npm run test invitationLink.test.ts

--- a/packages/e2e-tests/src/selectors.ts
+++ b/packages/e2e-tests/src/selectors.ts
@@ -51,12 +51,12 @@ export class App {
     console.log('App closed', this.buildSetup.dataDir)
   }
 
-  async cleanup() {
+  async cleanup(force: boolean = false) {
     console.log(`Performing app cleanup`, this.buildSetup.dataDir)
     if (this.isOpened) {
       throw new Error(`App with dataDir ${this.buildSetup.dataDir} is still open, close before cleaning up!`)
     }
-    this.buildSetup.clearDataDir()
+    this.buildSetup.clearDataDir(force)
   }
 
   get saveStateButton() {

--- a/packages/e2e-tests/src/tests/invitationLink.test.ts
+++ b/packages/e2e-tests/src/tests/invitationLink.test.ts
@@ -26,6 +26,9 @@ describe('New user joins using invitation link while having app opened', () => {
   beforeAll(async () => {
     ownerApp = new App()
     guestApp = new App({ defaultDataDir: true })
+    if (process.platform === 'win32') {
+      await guestApp.cleanup(true)
+    }
   })
 
   beforeEach(async () => {
@@ -143,7 +146,7 @@ describe('New user joins using invitation link while having app opened', () => {
       const copiedCode = url.hash.substring(1)
       expect(() => parseInvitationCode(copiedCode)).not.toThrow()
       const data = parseInvitationCode(copiedCode)
-      const commandFull = `${command[process.platform as SupportedPlatformDesktop]} "${composeInvitationDeepUrl(data)}"`
+      const commandFull = `${command[process.platform as SupportedPlatformDesktop]} ${process.platform === 'win32' ? '""' : ''} "${composeInvitationDeepUrl(data)}"`
       console.log(`Calling ${commandFull}`)
       execSync(commandFull)
       console.log('Guest opened invitation link')

--- a/packages/e2e-tests/src/tests/multipleClients.test.ts
+++ b/packages/e2e-tests/src/tests/multipleClients.test.ts
@@ -341,7 +341,7 @@ describe('Multiple Clients', () => {
       await new Promise<void>(resolve =>
         setTimeout(() => {
           resolve()
-        }, 2000)
+        }, 20000)
       )
       const channels = await sidebarOwner.getChannelList()
       expect(channels.length).toEqual(2)

--- a/packages/e2e-tests/src/utils.ts
+++ b/packages/e2e-tests/src/utils.ts
@@ -53,9 +53,9 @@ export class BuildSetup {
   }
 
   private getBinaryLocation() {
-    console.log('filename', this.fileName)
     switch (process.platform) {
       case 'linux':
+        console.log('filename', this.fileName)
         return `${__dirname}/../Quiet/${this.fileName ? this.fileName : BuildSetup.getEnvFileName()}`
       case 'win32':
         return `${process.env.LOCALAPPDATA}\\Programs\\@quietdesktop\\Quiet.exe`
@@ -233,8 +233,8 @@ export class BuildSetup {
     await this.driver?.close()
   }
 
-  public clearDataDir() {
-    if (process.env.IS_CI === 'true') {
+  public clearDataDir(force: boolean = false) {
+    if (process.env.IS_CI === 'true' && !force) {
       console.warn('Not deleting data directory because we are running in CI')
       return
     }


### PR DESCRIPTION
* Reorder test runs on windows so we are more likely to run the majority of tests
* Clear out default app directory before starting invitation link tests (this is because we start the app before we run the tests and its populating with data not related to the tests and throwing things off)

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
