### PR TITLE
Fix(2321): No Duplicate CSRs

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -15,16 +15,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Install dependencies
         run: |
           npm i
           npm run lerna bootstrap --scope @quiet/eslint-config,@quiet/logger,@quiet/common,@quiet/types,@quiet/state-manager,@quiet/backend,@quiet/identity,@quiet/mobile,backend-bundle
-
-      - name: Pull binaries
-        run: |
-          git lfs install
-          git lfs pull
 
       - name: Pass local config
         run : |

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -14,16 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Install dependencies
         run: |
           npm i
           npm run lerna bootstrap --scope @quiet/eslint-config,@quiet/logger,@quiet/common,@quiet/types,@quiet/state-manager,@quiet/backend,@quiet/identity,@quiet/mobile,backend-bundle
-
-      - name: Pull binaries
-        run: |
-          git lfs install
-          git lfs pull
 
       - name: Install pods
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 # Fixes:
 
+* Don't create duplicate CSRs when joining a community under certain circumstances ([#2321](https://github.com/TryQuiet/quiet/issues/2321))
+
 [2.2.0]
 
 # New features:

--- a/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
+++ b/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
@@ -29,6 +29,7 @@ export class CertificatesRequestsStore extends EventEmitter {
         write: ['*'],
       },
     })
+    await this.store.load()
 
     this.store.events.on('write', async (_address, entry) => {
       this.logger('Added CSR to database')

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -314,7 +314,7 @@ export class StorageService extends EventEmitter {
 
   public async updatePeersList() {
     const users = this.getAllUsers()
-    const peers = users.map(peer => createLibp2pAddress(peer.onionAddress, peer.peerId))
+    const peers = Array.from(new Set(users.map(peer => createLibp2pAddress(peer.onionAddress, peer.peerId))))
     console.log('updatePeersList, peers count:', peers.length)
 
     const community = await this.localDbService.getCurrentCommunity()


### PR DESCRIPTION
The issue seemed to be that we were syncing another user's database before we had loaded ours and the new CSR was being erased, recreated, and the old one would sync, then we'd repeat the process.

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
