### PR TITLE
Chore: Use macos-12 on 2.2.0

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -96,7 +96,7 @@ jobs:
 
   build-macos:
     # needs: run-e2e-tests-mac
-    runs-on: macos-latest
+    runs-on: macos-12
     if: |
       startsWith(github.ref, 'refs/tags/@quiet/desktop')
 

--- a/.github/workflows/desktop-rtl-tests.yml
+++ b/.github/workflows/desktop-rtl-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   detox-android:
-    timeout-minutes: 10
-    runs-on: [self-hosted, macOS, ARM64, android]
+    timeout-minutes: 25
+    runs-on: [macos-14-xlarge]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-crossplatform.yml
+++ b/.github/workflows/e2e-crossplatform.yml
@@ -8,6 +8,7 @@ on:
       - packages/state-manager/**
       - packages/identity/**
       - packages/common/**
+      - .github/workflows/e2e**
 
 jobs:
   mac:

--- a/.github/workflows/e2e-mac.yml
+++ b/.github/workflows/e2e-mac.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: FILE_NAME env
         working-directory: ./packages/desktop/dist
-        run: echo "FILE_NAME="Quiet-$VERSION-arm64.dmg"" >> $GITHUB_ENV
+        run: echo "FILE_NAME="Quiet-$VERSION.dmg"" >> $GITHUB_ENV
 
       - name: Chmod
         working-directory: ./packages/desktop/dist
@@ -45,7 +45,7 @@ jobs:
         run: hdiutil mount $FILE_NAME
 
       - name: Add App file to applications
-        run: cd ~ && cp -R "/Volumes/Quiet $VERSION-arm64/Quiet.app" /Applications
+        run: cd ~ && cp -R "/Volumes/Quiet $VERSION/Quiet.app" /Applications
 
       - name: Run invitation link test - Includes 2 separate application clients
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0

--- a/.github/workflows/e2e-mac.yml
+++ b/.github/workflows/e2e-mac.yml
@@ -3,7 +3,7 @@ name: E2E Mac
 on: [workflow_call]
 jobs:
   mac:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 180
     env:
       ELECTRON_CUSTOM_VERSION: 23.0.0

--- a/.github/workflows/identity-tests.yml
+++ b/.github/workflows/identity-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/mobile-deploy-ios.yml
+++ b/.github/workflows/mobile-deploy-ios.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest]
+        os: [macos-12]
 
     steps:
       - name: "Print OS"

--- a/.github/workflows/state-manager-tests.yml
+++ b/.github/workflows/state-manager-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/utils-tests.yml
+++ b/.github/workflows/utils-tests.yml
@@ -1,0 +1,29 @@
+name: Common package tests
+
+on:
+  pull_request:
+    paths:
+      - packages/common/**
+
+jobs:
+  utils-tests:
+    timeout-minutes: 25
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-12, windows-2019]
+
+    steps:
+      - name: "Print OS"
+        run: echo ${{ matrix.os }}
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: "Setup environment"
+        uses: ./.github/actions/setup-env
+        with:
+          bootstrap-packages: "@quiet/eslint-config,@quiet/logger,@quiet/types,@quiet/common"
+
+      - name: "Unit tests"
+        run: lerna run test --scope @quiet/common --stream


### PR DESCRIPTION
This just pulls in Emi's changes from develop and reverts the changes I made to use arm64 images in e2e tests.  This should fix the broken dmg generation on releases we've seen in the past couple of alphas.

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
