### PR TITLE
Fix(2526): Fix images on ios and clean up some logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@
 * Use server for downloading initial community metadata if v2 invitation link is detected ([#2295](https://github.com/TryQuiet/quiet/issues/2295))
 
 # Refactorings:
+
 * Consolidate colors and align theme with MUI standards ([#2445](https://github.com/TryQuiet/quiet/issues/2445))
 
 # Fixes:
+
 * Disable spellCheck/autoCorrect on non-spelling sensitive fields like usernames and channels ([#373](https://github.com/TryQuiet/quiet/issues/373))
 * Fixes issue with reconnecting to peers on resume on iOS ([#2424](https://github.com/TryQuiet/quiet/issues/2424))
-
 * Fixes references to 'invite code' to be 'invite link' in UI ([#2441](https://github.com/TryQuiet/quiet/issues/2441))
+* Fixes issue with image messages not displaying/throwing errors on iOS ([#2526](https://github.com/TryQuiet/quiet/issues/2526))
 
 # Chores
 

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -699,7 +699,6 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       if (this.communityId) {
         this.serverIoProvider.io.emit(SocketActionTypes.COMMUNITY_LAUNCHED, { id: this.communityId })
         this.logger.info('this.libp2pService.connectedPeers', this.libp2pService.connectedPeers)
-        this.logger.info('this.libp2pservice', this.libp2pService)
         this.logger.info('this.libp2pService.dialedPeers', this.libp2pService.dialedPeers)
         this.serverIoProvider.io.emit(
           SocketActionTypes.CONNECTED_PEERS,

--- a/packages/backend/src/nest/socket/socket.service.ts
+++ b/packages/backend/src/nest/socket/socket.service.ts
@@ -158,7 +158,7 @@ export class SocketService extends EventEmitter implements OnModuleInit {
       socket.on(
         SocketActionTypes.CREATE_COMMUNITY,
         async (payload: InitCommunityPayload, callback: (response: Community | undefined) => void) => {
-          this.logger.info(`Creating community ${payload.id}`)
+          this.logger.info(`Creating community`, payload.id)
           this.emit(SocketActionTypes.CREATE_COMMUNITY, payload, callback)
         }
       )

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixes issue with reconnecting to peers on resume on iOS ([#2424](https://github.com/TryQuiet/quiet/issues/2424))
 * Update github workflows for PR gating ([#2487](https://github.com/TryQuiet/quiet/issues/2487))
 * Don't create duplicate CSRs when joining a community under certain circumstances ([#2321](https://github.com/TryQuiet/quiet/issues/2321))
+* Fixes issue with image messages not displaying/throwing errors on iOS ([#2526](https://github.com/TryQuiet/quiet/issues/2526))
 
 [2.2.0]
 

--- a/packages/mobile/ios/Quiet/Info.plist
+++ b/packages/mobile/ios/Quiet/Info.plist
@@ -39,6 +39,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -54,8 +56,16 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Quiet uses the document directory for storing files and images sent through the app.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Quiet uses the document directory for storing files and images sent through the app.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSPhotoLibraryLimitedAccessAPISupport</key>
+	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Quiet access photos for sending images through the app.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Rubik-Black.ttf</string>
@@ -75,6 +85,8 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/packages/mobile/src/components/UploadedImage/UploadedImage.component.tsx
+++ b/packages/mobile/src/components/UploadedImage/UploadedImage.component.tsx
@@ -7,15 +7,18 @@ import FastImage from 'react-native-fast-image'
 export const UploadedImage: FC<UploadedImageProps> = ({ media, openImagePreview }) => {
   const { path, width, height } = media
 
+  const aspectRatio = width && height ? width / height : undefined
   const maxWidth = width && width >= 400 ? 400 : width
 
   return (
-    <View>
+    <View style={{ padding: 5 }}>
       {!path || !width || !height ? (
         <ActivityIndicator size='small' color={defaultTheme.palette.main.brand} />
       ) : (
         <TouchableWithoutFeedback onPress={() => openImagePreview(media)}>
-          <FastImage source={{ uri: `file://${path}` }} style={{ maxWidth, aspectRatio: width / height }} />
+          <View>
+            <FastImage source={{ uri: `file://${path}` }} style={{ maxWidth, aspectRatio }} />
+          </View>
         </TouchableWithoutFeedback>
       )}
     </View>

--- a/packages/state-manager/src/sagas/socket/startConnection/startConnection.saga.ts
+++ b/packages/state-manager/src/sagas/socket/startConnection/startConnection.saga.ts
@@ -95,7 +95,7 @@ export function subscribe(socket: Socket) {
     })
     // Misc
     socket.on(SocketActionTypes.PEER_CONNECTED, (payload: { peers: string[] }) => {
-      logger.info(`${SocketActionTypes.PEER_CONNECTED}: ${payload}`)
+      logger.info(`${SocketActionTypes.PEER_CONNECTED}`, payload)
       emit(networkActions.addConnectedPeers(payload.peers))
     })
     socket.on(SocketActionTypes.PEER_DISCONNECTED, (payload: NetworkDataPayload) => {


### PR DESCRIPTION
* Wraps `FastImage` in a view to fix issue when used with `TouchableWithoutFeedback`
* Adds new items to `info.plist` to allow access to files/photos
* Fix some bad logs

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
