### PR TITLE
Improve connection speed/reliability and add more logging around connections

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/platform-express": "^10.2.10",
         "@peculiar/webcrypto": "1.4.3",
         "abortable-iterator": "^3.0.0",
+        "bufferutil": "^4.0.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.1",
         "cli-table": "^0.3.6",
@@ -57,6 +58,7 @@
         "socks-proxy-agent": "^5.0.0",
         "string-replace-loader": "3.1.0",
         "ts-jest-resolver": "^2.0.0",
+        "utf-8-validate": "^6.0.4",
         "validator": "^13.11.0"
       },
       "devDependencies": {
@@ -1511,6 +1513,20 @@
         "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/@ethersproject/providers/node_modules/ws": {
@@ -8743,6 +8759,18 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "dependencies": {
@@ -10371,6 +10399,20 @@
         "engine.io-parser": "~5.0.3",
         "ws": "~8.2.3",
         "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
@@ -22890,6 +22932,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.4.tgz",
+      "integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
       "license": "WTFPL"
@@ -24434,6 +24488,16 @@
         "ws": "7.4.6"
       },
       "dependencies": {
+        "utf-8-validate": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+          "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        },
         "ws": {
           "version": "7.4.6",
           "requires": {}
@@ -29428,6 +29492,14 @@
     "buffer-xor": {
       "version": "1.0.3"
     },
+    "bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "busboy": {
       "version": "1.6.0",
       "requires": {
@@ -30512,6 +30584,16 @@
         "xmlhttprequest-ssl": "~2.0.0"
       },
       "dependencies": {
+        "utf-8-validate": {
+          "version": "5.0.10",
+          "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+          "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        },
         "ws": {
           "version": "8.2.3",
           "requires": {}
@@ -38334,6 +38416,14 @@
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.14.2"
+      }
+    },
+    "utf-8-validate": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.4.tgz",
+      "integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
       }
     },
     "utf8-byte-length": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -98,6 +98,7 @@
     "@quiet/logger": "^2.0.2-alpha.0",
     "@quiet/types": "^2.0.2-alpha.1",
     "abortable-iterator": "^3.0.0",
+    "bufferutil": "^4.0.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.1",
     "cli-table": "^0.3.6",
@@ -139,6 +140,7 @@
     "socks-proxy-agent": "^5.0.0",
     "string-replace-loader": "3.1.0",
     "ts-jest-resolver": "^2.0.0",
+    "utf-8-validate": "^6.0.4",
     "validator": "^13.11.0"
   },
   "overrides": {

--- a/packages/backend/src/nest/app.module.ts
+++ b/packages/backend/src/nest/app.module.ts
@@ -99,8 +99,9 @@ export class AppModule {
                 allowedHeaders: ['authorization'],
                 credentials: true,
               },
-              pingInterval: 1000_000,
-              pingTimeout: 1000_000,
+              pingInterval: 10_000,
+              pingTimeout: 2_000,
+              connectTimeout: 60_000,
             })
             io.engine.use((req, res, next) => {
               const authHeader = req.headers['authorization']

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.tor.spec.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.tor.spec.ts
@@ -33,7 +33,7 @@ import { sleep } from '../common/sleep'
 import { createLibp2pAddress } from '@quiet/common'
 import { lib } from 'crypto-js'
 
-jest.setTimeout(100_000)
+jest.setTimeout(120_000)
 
 let tmpDir: DirResult
 let tmpAppDataPath: string

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -66,6 +66,7 @@ import { emitError } from '../socket/socket.errors'
 import { createLibp2pAddress, isPSKcodeValid } from '@quiet/common'
 import { CertFieldsTypes, createRootCA, getCertFieldValue, loadCertificate } from '@quiet/identity'
 import { DateTime } from 'luxon'
+import { platform } from 'os'
 
 @Injectable()
 export class ConnectionsManagerService extends EventEmitter implements OnModuleInit {
@@ -75,6 +76,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
   private ports: GetPorts
   isTorInit: TorInitState = TorInitState.NOT_STARTED
   private peerInfo: Libp2pPeerInfo | undefined = undefined
+  private initializationInterval: NodeJS.Timer
 
   private readonly logger = Logger(ConnectionsManagerService.name)
   constructor(
@@ -93,6 +95,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
   }
 
   async onModuleInit() {
+    this.logger('Initializing connection manager')
     process.on('unhandledRejection', error => {
       console.error(error)
       throw new Error()
@@ -264,6 +267,19 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     this.logger('Resuming!')
     await this.openSocket()
     const peersToDial = await this.getPeersOnResume()
+    if (!this.tor.isTorServiceUsed) {
+      this.logger(`We aren't using the tor service in this client, checking bootstrap status in connection manager`)
+      this.initializationInterval = setInterval(async () => {
+        console.log('Checking bootstrap interval')
+        const bootstrapDone = await this.tor.isBootstrappingFinished()
+        if (bootstrapDone) {
+          clearInterval(this.initializationInterval)
+          this.logger('Bootstrapping is finished')
+          this.libp2pService?.resume(peersToDial)
+        }
+      }, 2500)
+      return
+    }
     this.libp2pService?.resume(peersToDial)
   }
 
@@ -578,7 +594,8 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       peers: peers ? peers.slice(1) : [],
       psk: Libp2pService.generateLibp2pPSK(community.psk).fullKey,
     }
-    await this.libp2pService.createInstance(params)
+    const startDialImmediately = this.tor.isTorInitialized
+    await this.libp2pService.createInstance(params, startDialImmediately)
 
     // Libp2p event listeners
     this.libp2pService.on(Libp2pEvents.PEER_CONNECTED, async (payload: { peers: string[] }) => {
@@ -634,6 +651,21 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       SocketActionTypes.CONNECTION_PROCESS_INFO,
       ConnectionProcessInfo.CONNECTING_TO_COMMUNITY
     )
+
+    if (!this.tor.isTorServiceUsed) {
+      this.logger(`We aren't using the tor service in this client, checking bootstrap status in connection manager`)
+      this.initializationInterval = setInterval(async () => {
+        console.log('Checking bootstrap interval')
+        const bootstrapDone = await this.tor.isBootstrappingFinished()
+        if (bootstrapDone) {
+          console.log(`Sending ${SocketActionTypes.TOR_INITIALIZED}`)
+          this.serverIoProvider.io.emit(SocketActionTypes.TOR_INITIALIZED)
+          console.log(`Sending ${SocketActionTypes.INITIAL_DIAL}`)
+          this.libp2pService?.emit(Libp2pEvents.INITIAL_DIAL)
+          clearInterval(this.initializationInterval)
+        }
+      }, 2500)
+    }
   }
 
   private attachTorEventsListeners() {
@@ -642,10 +674,9 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     this.tor.on(SocketActionTypes.CONNECTION_PROCESS_INFO, data => {
       this.serverIoProvider.io.emit(SocketActionTypes.CONNECTION_PROCESS_INFO, data)
     })
-    this.tor.on(SocketActionTypes.REDIAL_PEERS, async data => {
-      this.logger(`Socket - ${SocketActionTypes.REDIAL_PEERS}`)
-      const peerInfo = this.libp2pService?.getCurrentPeerInfo()
-      await this.libp2pService?.redialPeers([...peerInfo.connected, ...peerInfo.dialed])
+    this.tor.on(SocketActionTypes.INITIAL_DIAL, async () => {
+      this.logger(`Socket - ${SocketActionTypes.INITIAL_DIAL}`)
+      this.libp2pService?.emit(Libp2pEvents.INITIAL_DIAL)
     })
     this.socketService.on(SocketActionTypes.CONNECTION_PROCESS_INFO, data => {
       this.serverIoProvider.io.emit(SocketActionTypes.CONNECTION_PROCESS_INFO, data)

--- a/packages/backend/src/nest/libp2p/libp2p.service.ts
+++ b/packages/backend/src/nest/libp2p/libp2p.service.ts
@@ -41,13 +41,22 @@ export class Libp2pService extends EventEmitter {
     super()
   }
 
-  private dialPeer = async (peerAddress: string) => {
-    if (this.dialedPeers.has(peerAddress)) {
+  private dialPeer = async (peerAddress: string): Promise<boolean> => {
+    const ma = multiaddr(peerAddress)
+    const peerId = peerIdFromString(ma.getPeerId()!)
+
+    const libp2pHasPeer = await this.libp2pInstance?.peerStore.has(peerId as any)
+    const weHaveDialedPeer = this.dialedPeers.has(peerAddress)
+
+    if (weHaveDialedPeer || libp2pHasPeer) {
       this.logger(`Skipping dial of ${peerAddress} because its already been dialed`)
-      return
+      return true
     }
     this.dialedPeers.add(peerAddress)
-    await this.libp2pInstance?.dial(multiaddr(peerAddress))
+    const connection = await this.libp2pInstance?.dial(multiaddr(peerAddress))
+
+    if (connection) return true
+    return false
   }
 
   public getCurrentPeerInfo = (): Libp2pPeerInfo => {
@@ -153,7 +162,7 @@ export class Libp2pService extends EventEmitter {
     this.processInChunksService.updateQueue(toDial)
   }
 
-  public async createInstance(params: Libp2pNodeParams): Promise<Libp2p> {
+  public async createInstance(params: Libp2pNodeParams, startDialImmediately: boolean = false): Promise<Libp2p> {
     if (this.libp2pInstance) {
       return this.libp2pInstance
     }
@@ -166,7 +175,7 @@ export class Libp2pService extends EventEmitter {
         connectionManager: {
           minConnections: 3, // TODO: increase?
           maxConnections: 20, // TODO: increase?
-          dialTimeout: 120_000,
+          dialTimeout: 120000,
           maxParallelDials: 10,
           autoDial: true, // It's a default but let's set it to have explicit information
         },
@@ -205,11 +214,11 @@ export class Libp2pService extends EventEmitter {
       throw err
     }
     this.libp2pInstance = libp2p
-    await this.afterCreation(params.peers, params.peerId)
+    await this.afterCreation(params.peers, params.peerId, startDialImmediately)
     return libp2p
   }
 
-  private async afterCreation(peers: string[], peerId: PeerId) {
+  private async afterCreation(peers: string[], peerId: PeerId, startDialImmediately: boolean) {
     if (!this.libp2pInstance) {
       this.logger.error('libp2pInstance was not created')
       throw new Error('libp2pInstance was not created')
@@ -222,9 +231,20 @@ export class Libp2pService extends EventEmitter {
       this.processInChunksService.updateQueue(nonDialedAddresses)
     })
 
+    this.on(Libp2pEvents.INITIAL_DIAL, async () => {
+      this.logger('Starting initial dial')
+      this.processInChunksService.resume()
+    })
+
     this.logger(`Initializing libp2p for ${peerId.toString()}, bootstrapping with ${peers.length} peers`)
     this.serverIoProvider.io.emit(SocketActionTypes.CONNECTION_PROCESS_INFO, ConnectionProcessInfo.INITIALIZING_LIBP2P)
-    this.processInChunksService.init([], this.dialPeer)
+
+    this.logger(`Initializing processInChunksService and adding ${peers.length} peers to dial initially`)
+    this.processInChunksService.init({
+      initialData: peers,
+      processItem: this.dialPeer,
+      startImmediately: startDialImmediately,
+    })
 
     this.libp2pInstance.addEventListener('peer:discovery', peer => {
       this.logger(`${peerId.toString()} discovered ${peer.detail.id}`)
@@ -277,8 +297,6 @@ export class Libp2pService extends EventEmitter {
       }
       this.emit(Libp2pEvents.PEER_DISCONNECTED, peerStat)
     })
-
-    this.processInChunksService.updateQueue(peers)
 
     this.logger(`Initialized libp2p for peer ${peerId.toString()}`)
   }

--- a/packages/backend/src/nest/libp2p/libp2p.service.ts
+++ b/packages/backend/src/nest/libp2p/libp2p.service.ts
@@ -208,7 +208,10 @@ export class Libp2pService extends EventEmitter {
           }),
         ],
         dht: kadDHT(),
-        pubsub: gossipsub({ allowPublishToZeroPeers: true }),
+        pubsub: gossipsub({
+          allowPublishToZeroPeers: true,
+          doPX: true,
+        }),
       })
     } catch (err) {
       this.logger.error('Create libp2p:', err)

--- a/packages/backend/src/nest/libp2p/libp2p.types.ts
+++ b/packages/backend/src/nest/libp2p/libp2p.types.ts
@@ -6,6 +6,7 @@ export enum Libp2pEvents {
   PEER_DISCONNECTED = 'peerDisconnected',
   NETWORK_STATS = 'networkStats',
   DIAL_PEERS = 'dialPeers',
+  INITIAL_DIAL = 'initialDial',
 }
 
 export interface Libp2pNodeParams {

--- a/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
+++ b/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
@@ -15,7 +15,7 @@ type ProcessTask<T> = {
 
 export type ProcessInChunksServiceOptions<T> = {
   initialData: T[]
-  processItem: (arg: T) => Promise<any>
+  processItem: (arg: T) => Promise<boolean>
   chunkSize?: number | undefined
   startImmediately?: boolean
 }

--- a/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
+++ b/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events'
 import fastq, { queueAsPromised } from 'fastq'
 
 import Logger from '../common/logger'
-import CryptoJS, { MD5 } from 'crypto-js'
+import CryptoJS from 'crypto-js'
 
 const DEFAULT_CHUNK_SIZE = 10
 export const DEFAULT_NUM_TRIES = 2
@@ -146,7 +146,7 @@ export class ProcessInChunksService<T> extends EventEmitter {
   }
 
   private generateTaskId(data: T): string {
-    return MD5(JSON.stringify(data)).toString(CryptoJS.enc.Hex)
+    return CryptoJS.MD5(JSON.stringify(data)).toString(CryptoJS.enc.Hex)
   }
 
   public resume() {

--- a/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
+++ b/packages/backend/src/nest/libp2p/process-in-chunks.service.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events'
 import fastq, { queueAsPromised } from 'fastq'
 
 import Logger from '../common/logger'
-import { randomUUID } from 'crypto'
+import CryptoJS, { MD5 } from 'crypto-js'
 
 const DEFAULT_CHUNK_SIZE = 10
 export const DEFAULT_NUM_TRIES = 2
@@ -13,24 +13,38 @@ type ProcessTask<T> = {
   taskId: string
 }
 
+export type ProcessInChunksServiceOptions<T> = {
+  initialData: T[]
+  processItem: (arg: T) => Promise<any>
+  chunkSize?: number | undefined
+  startImmediately?: boolean
+}
+
 export class ProcessInChunksService<T> extends EventEmitter {
   private isActive: boolean
   private chunkSize: number
   private taskQueue: queueAsPromised<ProcessTask<T>>
   private deadLetterQueue: ProcessTask<T>[] = []
-  private processItem: (arg: T) => Promise<any>
+  private processItem: (arg: T) => Promise<boolean>
   private readonly logger = Logger(ProcessInChunksService.name)
   constructor() {
     super()
   }
 
-  public init(data: T[], processItem: (arg: T) => Promise<any>, chunkSize: number = DEFAULT_CHUNK_SIZE) {
-    this.logger(`Initializing process-in-chunks.service with peers ${JSON.stringify(data, null, 2)}`)
-    this.processItem = processItem
-    this.chunkSize = chunkSize
+  public init(options: ProcessInChunksServiceOptions<T>) {
+    this.logger(`Initializing process-in-chunks.service with peers ${JSON.stringify(options.initialData, null, 2)}`)
+    this.processItem = options.processItem
+    this.chunkSize = options.chunkSize ?? DEFAULT_CHUNK_SIZE
     this.taskQueue = fastq.promise(this, this.processOneItem, this.chunkSize)
-    this.isActive = true
-    this.updateQueue(data)
+    const startImmediately = options.startImmediately ?? true
+    if (startImmediately) {
+      this.logger(`Starting processing immediately`)
+      this.isActive = true
+    } else {
+      this.logger(`Deferring processing`)
+      this.pause()
+    }
+    this.updateQueue(options.initialData)
   }
 
   public updateQueue(items: T[]) {
@@ -51,13 +65,19 @@ export class ProcessInChunksService<T> extends EventEmitter {
       task = itemOrTask as ProcessTask<T>
     } else {
       this.logger(`Creating new task for ${itemOrTask}`)
-      task = { data: itemOrTask as T, tries: 0, taskId: randomUUID() }
+      task = { data: itemOrTask as T, tries: 0, taskId: this.generateTaskId(itemOrTask as T) }
     }
 
     if (!this.isActive) {
       this.logger(
         'ProcessInChunksService is not active, adding tasks to the dead letter queue!\n\nWARNING: You must call "resume" on the ProcessInChunksService to process the dead letter queue!!!'
       )
+      if (this.deadLetterQueue.find(thisTask => thisTask.taskId === task.taskId)) {
+        this.logger(
+          `Skipping task with ID ${task.taskId} because there is another task with the same ID already in the dead letter queue.`
+        )
+        return
+      }
       this.deadLetterQueue.push(task)
       this.logger(`There are now ${this.deadLetterQueue.length} items in the dead letter queue`)
       return
@@ -79,8 +99,7 @@ export class ProcessInChunksService<T> extends EventEmitter {
     let success: boolean = false
     try {
       this.logger(`Processing task ${task.taskId} with data ${task.data}`)
-      await this.processItem(task.data)
-      success = true
+      success = await this.processItem(task.data)
     } catch (e) {
       this.logger.error(`Processing task ${task.taskId} with data ${task.data} failed`, e)
     } finally {
@@ -90,6 +109,13 @@ export class ProcessInChunksService<T> extends EventEmitter {
   }
 
   private async pushToQueueAndRun(task: ProcessTask<T>): Promise<boolean> {
+    if (this.taskQueue.getQueue().find(thisTask => thisTask.taskId === task.taskId)) {
+      this.logger(
+        `Skipping task with ID ${task.taskId} because there is another task with the same ID already in the task queue.`
+      )
+      return true
+    }
+
     this.logger(
       `Pushing task ${task.taskId} to queue, there will now be ${this.taskQueue.length() + 1} items in the queue`
     )
@@ -100,6 +126,10 @@ export class ProcessInChunksService<T> extends EventEmitter {
       this.logger(`Task ${task.taskId} failed`)
     }
     return success
+  }
+
+  private generateTaskId(data: T): string {
+    return MD5(JSON.stringify(data)).toString(CryptoJS.enc.Hex)
   }
 
   public resume() {

--- a/packages/backend/src/nest/libp2p/process-in-chunks.spec.ts
+++ b/packages/backend/src/nest/libp2p/process-in-chunks.spec.ts
@@ -25,7 +25,7 @@ describe('ProcessInChunks', () => {
       .mockRejectedValueOnce(new Error('Rejected 1'))
       .mockResolvedValueOnce()
       .mockRejectedValueOnce(new Error('Rejected 2'))
-    processInChunks.init(['a', 'b', 'c', 'd'], mockProcessItem)
+    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem })
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(6)
     })
@@ -38,7 +38,7 @@ describe('ProcessInChunks', () => {
       })
       .mockResolvedValueOnce()
       .mockRejectedValueOnce(new Error('Rejected 1'))
-    processInChunks.init(['a', 'b'], mockProcessItem)
+    processInChunks.init({ initialData: ['a', 'b'], processItem: mockProcessItem })
     processInChunks.updateQueue(['e', 'f'])
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(5)
@@ -55,7 +55,7 @@ describe('ProcessInChunks', () => {
       .mockResolvedValueOnce()
       .mockRejectedValueOnce(new Error('Rejected 2'))
     const chunkSize = 2
-    processInChunks.init(['a', 'b', 'c', 'd'], mockProcessItem, chunkSize)
+    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem, chunkSize })
     await sleep(10000)
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(6)
@@ -64,7 +64,7 @@ describe('ProcessInChunks', () => {
 
   it('does not process more data if stopped', async () => {
     const mockProcessItem = jest.fn(async () => {})
-    processInChunks.init([], mockProcessItem)
+    processInChunks.init({ initialData: [], processItem: mockProcessItem })
     processInChunks.pause()
     processInChunks.updateQueue(['a', 'b', 'c', 'd'])
     expect(mockProcessItem).not.toBeCalled()
@@ -72,9 +72,21 @@ describe('ProcessInChunks', () => {
 
   it('processes tasks after resuming from pause', async () => {
     const mockProcessItem = jest.fn(async () => {})
-    processInChunks.init([], mockProcessItem)
+    processInChunks.init({ initialData: [], processItem: mockProcessItem })
     processInChunks.pause()
     processInChunks.updateQueue(['a', 'b', 'c', 'd'])
+    processInChunks.resume()
+    await waitForExpect(() => {
+      expect(mockProcessItem).toBeCalledTimes(4)
+    })
+  })
+
+  it('processes tasks when deferred', async () => {
+    const mockProcessItem = jest.fn(async () => {})
+    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem, startImmediately: false })
+    await waitForExpect(() => {
+      expect(mockProcessItem).toBeCalledTimes(0)
+    })
     processInChunks.resume()
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(4)

--- a/packages/backend/src/nest/libp2p/process-in-chunks.spec.ts
+++ b/packages/backend/src/nest/libp2p/process-in-chunks.spec.ts
@@ -20,12 +20,13 @@ describe('ProcessInChunks', () => {
     const mockProcessItem = jest
       .fn(async a => {
         console.log('processing', a)
+        return true
       })
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce(true)
       .mockRejectedValueOnce(new Error('Rejected 1'))
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce(true)
       .mockRejectedValueOnce(new Error('Rejected 2'))
-    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem })
+    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem, chunkSize: 10 })
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(6)
     })
@@ -35,10 +36,11 @@ describe('ProcessInChunks', () => {
     const mockProcessItem = jest
       .fn(async a => {
         console.log('processing', a)
+        return true
       })
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce(true)
       .mockRejectedValueOnce(new Error('Rejected 1'))
-    processInChunks.init({ initialData: ['a', 'b'], processItem: mockProcessItem })
+    processInChunks.init({ initialData: ['a', 'b'], processItem: mockProcessItem, chunkSize: 10 })
     processInChunks.updateQueue(['e', 'f'])
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(5)
@@ -49,10 +51,11 @@ describe('ProcessInChunks', () => {
     const mockProcessItem = jest
       .fn(async a => {
         console.log('processing', a)
+        return true
       })
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce(true)
       .mockRejectedValueOnce(new Error('Rejected 1'))
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce(true)
       .mockRejectedValueOnce(new Error('Rejected 2'))
     const chunkSize = 2
     processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem, chunkSize })
@@ -63,16 +66,20 @@ describe('ProcessInChunks', () => {
   })
 
   it('does not process more data if stopped', async () => {
-    const mockProcessItem = jest.fn(async () => {})
-    processInChunks.init({ initialData: [], processItem: mockProcessItem })
+    const mockProcessItem = jest.fn(async () => {
+      return true
+    })
+    processInChunks.init({ initialData: [], processItem: mockProcessItem, chunkSize: 10 })
     processInChunks.pause()
     processInChunks.updateQueue(['a', 'b', 'c', 'd'])
     expect(mockProcessItem).not.toBeCalled()
   })
 
   it('processes tasks after resuming from pause', async () => {
-    const mockProcessItem = jest.fn(async () => {})
-    processInChunks.init({ initialData: [], processItem: mockProcessItem })
+    const mockProcessItem = jest.fn(async () => {
+      return true
+    })
+    processInChunks.init({ initialData: [], processItem: mockProcessItem, chunkSize: 10 })
     processInChunks.pause()
     processInChunks.updateQueue(['a', 'b', 'c', 'd'])
     processInChunks.resume()
@@ -82,8 +89,15 @@ describe('ProcessInChunks', () => {
   })
 
   it('processes tasks when deferred', async () => {
-    const mockProcessItem = jest.fn(async () => {})
-    processInChunks.init({ initialData: ['a', 'b', 'c', 'd'], processItem: mockProcessItem, startImmediately: false })
+    const mockProcessItem = jest.fn(async () => {
+      return true
+    })
+    processInChunks.init({
+      initialData: ['a', 'b', 'c', 'd'],
+      processItem: mockProcessItem,
+      startImmediately: false,
+      chunkSize: 10,
+    })
     await waitForExpect(() => {
       expect(mockProcessItem).toBeCalledTimes(0)
     })

--- a/packages/backend/src/nest/tor/tor.service.tor.spec.ts
+++ b/packages/backend/src/nest/tor/tor.service.tor.spec.ts
@@ -131,10 +131,6 @@ describe('TorControl', () => {
     expect(spyOnInit).toHaveBeenCalledTimes(2)
   })
 
-  it('tor is initializing correctly with 40 seconds timeout', async () => {
-    await torService.init()
-  })
-
   it('creates and destroys hidden service', async () => {
     await torService.init()
     const hiddenService = await torService.createNewHiddenService({ targetPort: 4343 })

--- a/packages/backend/src/nest/tor/tor.service.ts
+++ b/packages/backend/src/nest/tor/tor.service.ts
@@ -140,7 +140,7 @@ export class Tor extends EventEmitter implements OnModuleInit {
                 clearInterval(this.interval)
                 resolve()
               }
-            }, 2500)
+            }, 5000)
 
             this.logger(`Spawned tor with pid(s): ${this.getTorProcessIds()}`)
             // resolve()

--- a/packages/backend/src/nest/tor/tor.service.ts
+++ b/packages/backend/src/nest/tor/tor.service.ts
@@ -49,7 +49,6 @@ export class Tor extends EventEmitter implements OnModuleInit {
       console.warn('No tor binary path, not running the tor service')
       return
     }
-    this.isTorServiceUsed = true
     await this.init()
   }
 
@@ -79,6 +78,7 @@ export class Tor extends EventEmitter implements OnModuleInit {
   }
 
   public async init(timeout = 120_000): Promise<void> {
+    this.isTorServiceUsed = true
     if (!this.socksPort) this.socksPort = await getPort()
     this.logger('Initializing tor...')
 
@@ -134,12 +134,11 @@ export class Tor extends EventEmitter implements OnModuleInit {
               this.logger(`Sending ${SocketActionTypes.INITIAL_DIAL}`)
               this.emit(SocketActionTypes.INITIAL_DIAL)
               clearInterval(this.interval)
+              resolve()
             }
           }, 2500)
 
           this.logger(`Spawned tor with pid(s): ${this.getTorProcessIds()}`)
-
-          resolve()
         } catch (e) {
           this.logger('Killing tor due to error', e)
           this.clearHangingTorProcess()

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -116,7 +116,7 @@
     "build:renderer:prod": "webpack --config webpack/webpack.config.renderer.prod.js",
     "postBuild": "node scripts/postBuild.js",
     "prestart": "npm run build:main",
-    "start": "cross-env DEBUG='backend*,quiet*,state-manager*,desktop*,utils*,libp2p:websockets:listener:backend,libp2p:connection-manager:auto-dialler,libp2p:pnet' npm run start:renderer",
+    "start": "cross-env DEBUG='backend*,quiet*,state-manager*,desktop*,utils*,libp2p:websockets:listener:backend,libp2p:connection-manager:auto-dialler,libp2p:pnet,libp2p:upgrader' npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electron .",
     "start:renderer": "cross-env NODE_ENV=development webpack-dev-server --config webpack/webpack.config.renderer.dev.js",
     "storybook": "export NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -116,7 +116,7 @@
     "build:renderer:prod": "webpack --config webpack/webpack.config.renderer.prod.js",
     "postBuild": "node scripts/postBuild.js",
     "prestart": "npm run build:main",
-    "start": "cross-env DEBUG='backend*,quiet*,state-manager*,desktop*,utils*,libp2p:websockets:listener:backend,libp2p:connection-manager:auto-dialler' npm run start:renderer",
+    "start": "cross-env DEBUG='backend*,quiet*,state-manager*,desktop*,utils*,libp2p:websockets:listener:backend,libp2p:connection-manager:auto-dialler,libp2p:pnet' npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electron .",
     "start:renderer": "cross-env NODE_ENV=development webpack-dev-server --config webpack/webpack.config.renderer.dev.js",
     "storybook": "export NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",

--- a/packages/mobile/ios/NodeJsMobile/NodeRunner.mm
+++ b/packages/mobile/ios/NodeJsMobile/NodeRunner.mm
@@ -205,7 +205,7 @@ id appPauseEventsManagerSetLock = [[NSObject alloc] init];
     nodePath = [nodePath stringByAppendingString:builtinModulesPath];
   }
   setenv([@"NODE_PATH" UTF8String], (const char*)[nodePath UTF8String], 1);
-  setenv([@"DEBUG" UTF8String], "backend:*,state-manager:*,libp2p:pnet", 1);
+  setenv([@"DEBUG" UTF8String], "backend:*,state-manager:*,libp2p:websockets:listener:backend,libp2p:connection-manager:auto-dialler,libp2p:pnet,libp2p:upgrader", 1);
 
   int c_arguments_size=0;
 

--- a/packages/mobile/ios/Quiet/Info.plist
+++ b/packages/mobile/ios/Quiet/Info.plist
@@ -36,26 +36,26 @@
 	<key>CFBundleVersion</key>
 	<string>375</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false />
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
-	<true />
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false />
+		<false/>
 		<key>NSAllowsLocalNetworking</key>
-		<true />
+		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true />
+				<true/>
 			</dict>
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string />
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Rubik-Black.ttf</string>
@@ -74,7 +74,7 @@
 		<string>Rubik-SemiBoldItalic.ttf</string>
 	</array>
 	<key>UIBackgroundModes</key>
-	<array />
+	<array/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -88,6 +88,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false />
+	<false/>
 </dict>
 </plist>

--- a/packages/types/src/socket.ts
+++ b/packages/types/src/socket.ts
@@ -71,7 +71,7 @@ export enum SocketActionTypes {
   PEER_CONNECTED = 'peerConnected',
   PEER_DISCONNECTED = 'peerDisconnected',
   TOR_INITIALIZED = 'torInitialized',
-  REDIAL_PEERS = 'redialPeers',
+  INITIAL_DIAL = 'initialDial',
 
   // ====== Misc ======
 


### PR DESCRIPTION
This should make connecting to new peers, especially when opening the app or resuming the app (iOS), noticeably faster with fewer errors when connecting to peers that are online.

* Wait to dial peers until we know tor is fully bootstrapped
* Deduplicate tasks in processInChunksService to avoid clutter
* Reduce the number of parallel dials on libp2p
* Update some timeouts/ping intervals and use `doPX` on libp2p connection manager (PX allows peers to share peer information with each other)
* Add more logging internally and on libp2p packages

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
