### PR TITLE
feat(#1281): Platform-aware download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,26 +130,26 @@
       <p>Quiet is available for all major platforms. (And eventually the web, too!)</p>
       <div class="badges">
         <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.dmg" class="qt-hero-badge w-inline-block">
-          <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS download button">
+          <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS download">
         </a>
         <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet.Setup.2.3.1.exe" class="qt-hero-badge w-inline-block">
-          <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download button">
+          <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
         </a>
         <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.AppImage" class="qt-hero-badge w-inline-block">
-          <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download button">
+          <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
         </a>
         <a href="https://play.google.com/store/apps/details?id=com.quietmobile" class="qt-hero-badge w-inline-block">
-          <img src="images/badge-google-play.png" loading="lazy" srcset="images/badge-google-play-p-500.png 500w, images/badge-google-play.png 712w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Google Play store download button">
+          <img src="images/badge-google-play.png" loading="lazy" srcset="images/badge-google-play-p-500.png 500w, images/badge-google-play.png 712w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Google Play store download">
         </a>
         <div class="hide-badge">
-          <a href="#" class="qt-hero-badge w-inline-block"><img src="images/badge-f-droid.png" loading="lazy" srcset="images/badge-f-droid-p-500.png 500w, images/badge-f-droid.png 730w" sizes="100vw" alt="Quiet for F-Droid download button">
+          <a href="#" class="qt-hero-badge w-inline-block"><img src="images/badge-f-droid.png" loading="lazy" srcset="images/badge-f-droid-p-500.png 500w, images/badge-f-droid.png 730w" sizes="100vw" alt="Quiet for F-Droid download">
           </a>
         </div>
         <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
-          <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download button">
+          <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
         </a>
         <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%402.3.1/app-standard-release.apk" class="qt-hero-badge w-inline-block">
-          <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download button">
+          <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download">
         </a>
       </div>
       <p class="qt-caption">⚠ Quiet is in beta and shouldn&#x27;t be used for activities requiring security.</p>

--- a/join/index.html
+++ b/join/index.html
@@ -99,8 +99,9 @@ input[type=text] {
       </div>
       <div class="divider"></div>
       <div>
-        <h2 class="qt-community-invite-h2">Don&#x27;t have Quiet yet?</h2>
-        <a href="../index.html#Downloads" target="_blank">Download</a>
+        <h2 class="qt-community-invite-h2" style="margin-bottom: 20px;">Don&#x27;t have Quiet yet?</h2>
+        <div id="qt-download-action">
+        </div>
       </div>
     </div>
   </div>

--- a/js/invite.js
+++ b/js/invite.js
@@ -34,3 +34,58 @@ document.addEventListener(
   },
   false
 )
+
+// Detects platform and display correct links on tryquiet.org/join
+function getPlatform() {
+  const primaryActionEl = document.getElementById("qt-download-action")
+  const platform = navigator.userAgent
+
+  if (/iPhone|iPad|iPod/i.test(platform)) {
+    primaryActionEl.innerHTML = `
+  <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
+          <img src="../images/badge-app-store.png" loading="lazy" srcset="../images/badge-app-store-p-500.png 500w, ../images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
+          </a>
+  `;
+
+} else if (/Macintosh|Mac OS X/i.test(platform)) {
+    primaryActionEl.innerHTML = `
+    <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.dmg" class="qt-hero-badge w-inline-block">
+      <img src="../images/badge-mac.png" loading="lazy" srcset="../images/badge-mac-p-500.png 500w, ../images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS download">
+      </a>
+  `;
+
+} else if (/Windows/i.test(platform)) {
+  primaryActionEl.innerHTML = `
+ <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet.Setup.2.3.1.exe" class="qt-hero-badge w-inline-block">
+        <img src="../images/badge-windows.png" loading="lazy" srcset="../images/badge-windows-p-500.png 500w, ../images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
+        </a>
+`;
+
+} else if (/Linux/i.test(platform) && !/Android/i.test(platform)) {
+  primaryActionEl.innerHTML = `
+<a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.AppImage" class="qt-hero-badge w-inline-block">
+        <img src="../images/badge-linux.png" loading="lazy" srcset="../images/badge-linux-p-500.png 500w, ../images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
+        </a>
+`;
+
+} else if (/Android/i.test(platform)) {
+  primaryActionEl.innerHTML = `
+    <a href="https://play.google.com/store/apps/details?id=com.quietmobile" class="qt-hero-badge w-inline-block" style="display: block; margin: 0 auto 20px; text-align: center;">
+      <img src="../images/badge-google-play.png" loading="lazy" srcset="../images/badge-google-play-p-500.png 500w, ../images/badge-google-play.png 712w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Google Play store download button">
+    </a>
+    <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%402.3.1/app-standard-release.apk" target="_blank">
+      Or you can download the Quiet .apk directly
+    </a>
+`;
+
+} else {
+  primaryActionEl.innerHTML = `
+  <a href="../index.html#Downloads" target="_blank">Download
+  </a>
+`;
+}
+    
+  }
+
+
+onload = getPlatform

--- a/js/invite.js
+++ b/js/invite.js
@@ -42,46 +42,39 @@ function getPlatform() {
 
   if (/iPhone|iPad|iPod/i.test(platform)) {
     primaryActionEl.innerHTML = `
-  <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
-          <img src="../images/badge-app-store.png" loading="lazy" srcset="../images/badge-app-store-p-500.png 500w, ../images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
+  <a href="https://testflight.apple.com/join/yaUjeiW7" target="_blank" aria-label="Download at App Store">Download
           </a>
   `;
 
 } else if (/Macintosh|Mac OS X/i.test(platform)) {
     primaryActionEl.innerHTML = `
-    <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.dmg" class="qt-hero-badge w-inline-block">
-      <img src="../images/badge-mac.png" loading="lazy" srcset="../images/badge-mac-p-500.png 500w, ../images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS download">
-      </a>
+<a href="../index.html#Downloads" target="_blank" aria-label="Go to download section, opens in a new tab">Download
+</a>
   `;
 
 } else if (/Windows/i.test(platform)) {
   primaryActionEl.innerHTML = `
- <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet.Setup.2.3.1.exe" class="qt-hero-badge w-inline-block">
-        <img src="../images/badge-windows.png" loading="lazy" srcset="../images/badge-windows-p-500.png 500w, ../images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
-        </a>
+<a href="../index.html#Downloads" target="_blank" aria-label="Go to download section, opens in a new tab">Download
+</a>
 `;
 
 } else if (/Linux/i.test(platform) && !/Android/i.test(platform)) {
   primaryActionEl.innerHTML = `
-<a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%402.3.1/Quiet-2.3.1.AppImage" class="qt-hero-badge w-inline-block">
-        <img src="../images/badge-linux.png" loading="lazy" srcset="../images/badge-linux-p-500.png 500w, ../images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
-        </a>
+<a href="../index.html#Downloads" target="_blank" aria-label="Go to download section, opens in a new tab">Download
+</a>
 `;
 
 } else if (/Android/i.test(platform)) {
   primaryActionEl.innerHTML = `
-    <a href="https://play.google.com/store/apps/details?id=com.quietmobile" class="qt-hero-badge w-inline-block" style="display: block; margin: 0 auto 20px; text-align: center;">
-      <img src="../images/badge-google-play.png" loading="lazy" srcset="../images/badge-google-play-p-500.png 500w, ../images/badge-google-play.png 712w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Google Play store download button">
-    </a>
-    <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%402.3.1/app-standard-release.apk" target="_blank">
-      Or you can download the Quiet .apk directly
-    </a>
+<a href="https://play.google.com/store/apps/details?id=com.quietmobile" style="display: block; margin-bottom: 30px;" aria-label="Download at Play Store">
+  Download
+</a>
 `;
 
 } else {
   primaryActionEl.innerHTML = `
-  <a href="../index.html#Downloads" target="_blank">Download
-  </a>
+<a href="../index.html#Downloads" target="_blank" aria-label="Go to download section, opens in a new tab">Download
+</a>
 `;
 }
     


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md). - this is a change to gh-pages and it will not be published in any of Quiet versions. 

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests

For screenshots from all platform check - https://github.com/TryQuiet/quiet/issues/1281