### PR TITLE
fix(#2593): link color

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.tsx
@@ -68,7 +68,7 @@ const StyledTypography = styled(Typography)(({ theme }) => ({
   },
 
   [`& .${classes.link}`]: {
-    color: theme.palette.colors.lushSky,
+    color: theme.palette.colors.linkBlue,
     cursor: 'pointer',
     textDecoration: 'none',
     '&:hover': {

--- a/packages/desktop/src/renderer/theme.ts
+++ b/packages/desktop/src/renderer/theme.ts
@@ -98,7 +98,7 @@ const lightTheme = createTheme({
       darkPurple: '#4d1a6d', // To be replaced with theme.palette.primary.dark?
       lushSky: '#67BFD3',
       lushSky12: '#EDF7FA',
-      linkBlue: '#59c0d5', // Used in a variety of places - likely wants to be split / consolidated
+      linkBlue: '#1B6FEC', // Used in a variety of places - likely wants to be split / consolidated
       // Reds
       red: '#FF0000', // Replace with D13135 ?
       hotRed: '#E42656', // Replaced by theme.palette.secondary.main?


### PR DESCRIPTION
I changed color of links to match our designs. For most links I changed color "linkBlue" to #1B6FEC. For links that are displayed in a messages that used color "lushSky" I changed it so it uses "linkBlue" as other links. 

I made sure that those changes impact elements in all places that were listed in the issue. Please find screenshot of some of those places in #2593 


### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
