### PR TITLE
fix: make splash screen draggable #789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Fixes
+
+* Fixed splash screen to be draggable on macOS ([#789](https://github.com/TryQuiet/quiet/issues/789))
+
 ## [2.3.3]
 
 ### New features

--- a/packages/desktop/src/renderer/splashScreen/splash.html
+++ b/packages/desktop/src/renderer/splashScreen/splash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html style="height: 100%">
 
 <head>
   <style>
@@ -19,7 +19,7 @@
   </style>
 </head>
 
-<body>
+<body style="height: 100%; -webkit-app-region: drag">
   <div id="splash">
     <svg width="96" height="96" viewBox="0 0 96 96" fill="none">
       <rect width="96" height="96" rx="15" fill="#521C74"/>


### PR DESCRIPTION
Inline styles are used, mirroring how this is handled for [the main window.](https://github.com/TryQuiet/quiet/blob/develop/packages/desktop/src/renderer/index.html#L110)

I'm not sure if it's necessary to add a test as it's a single style change and there isn't a comparable test that I could find for the main window. I'm a bit new to front-end.

Feedback is welcomed.

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
