### PR TITLE
fix(2726): Use base64url package for encoding/decoding auth data since the native decoder breaks on mobile

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -13,6 +13,7 @@
         "@formatjs/intl-datetimeformat": "^6.12.3",
         "@formatjs/intl-getcanonicallocales": "^2.3.0",
         "@formatjs/intl-locale": "^3.4.5",
+        "base64url": "^3.0.1",
         "cross-env": "^5.2.0",
         "debug": "^4.3.1",
         "validator": "^13.11.0"
@@ -1582,6 +1583,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -8190,6 +8199,11 @@
           }
         }
       }
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -36,6 +36,7 @@
     "@formatjs/intl-locale": "^3.4.5",
     "@quiet/logger": "^2.0.2-alpha.0",
     "@quiet/types": "^2.0.2-alpha.1",
+    "base64url": "^3.0.1",
     "cross-env": "^5.2.0",
     "debug": "^4.3.1",
     "validator": "^13.11.0"

--- a/packages/common/src/invitationLink/invitationLink.validator.ts
+++ b/packages/common/src/invitationLink/invitationLink.validator.ts
@@ -24,6 +24,8 @@ import {
 import { isPSKcodeValid } from '../libp2p'
 import { createLogger } from '../logger'
 
+import base64url from 'base64url'
+
 const logger = createLogger('invite:validator')
 
 const ONION_ADDRESS_REGEX = /^[a-z0-9]{56}$/g
@@ -61,7 +63,7 @@ export class UrlParamValidatorError extends Error {
  */
 export const encodeAuthData = (authData: InvitationAuthData): string => {
   const encodedAuthData = `${COMMUNITY_NAME_KEY}=${encodeURIComponent(authData.communityName)}&${INVITATION_SEED_KEY}=${encodeURIComponent(authData.seed)}`
-  return Buffer.from(encodedAuthData, 'utf8').toString('base64url')
+  return base64url.encode(Buffer.from(encodedAuthData, 'utf8'))
 }
 
 /**
@@ -76,7 +78,7 @@ export const encodeAuthData = (authData: InvitationAuthData): string => {
  * @returns {string} URL-encoded string of the InvitationAuthData object as URL with parameters
  */
 export const decodeAuthData: InvitationLinkUrlNamedParamProcessorFun<string> = (authDataString: string): string => {
-  return `${DEEP_URL_SCHEME_WITH_SEPARATOR}?${Buffer.from(authDataString, 'base64url').toString('utf8')}`
+  return `${DEEP_URL_SCHEME_WITH_SEPARATOR}?${base64url.toBuffer(authDataString).toString('utf-8')}`
 }
 
 /**


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
