### PR TITLE
Feat/2472-encrypt-other-stores

### DIFF
--- a/packages/backend/src/nest/registration/registration.service.spec.ts
+++ b/packages/backend/src/nest/registration/registration.service.spec.ts
@@ -21,10 +21,13 @@ import { Libp2pModule } from '../libp2p/libp2p.module'
 import { IpfsModule } from '../ipfs/ipfs.module'
 import { IpfsService } from '../ipfs/ipfs.service'
 import { sleep } from '../common/sleep'
+import { SigChainService } from '../auth/sigchain.service'
+import { SigChainModule } from '../auth/sigchain.service.module'
 
 describe('RegistrationService', () => {
   let module: TestingModule
   let registrationService: RegistrationService
+  let sigchainService: SigChainService
 
   let tmpDir: DirResult
   let certRoot: RootCA
@@ -34,9 +37,11 @@ describe('RegistrationService', () => {
 
   beforeEach(async () => {
     module = await Test.createTestingModule({
-      imports: [TestModule, RegistrationModule],
+      imports: [TestModule, RegistrationModule, SigChainModule],
     }).compile()
 
+    sigchainService = await module.resolve(SigChainService)
+    sigchainService.createChain('team', 'user', true)
     registrationService = await module.resolve(RegistrationService)
 
     jest.clearAllMocks()
@@ -160,8 +165,11 @@ describe('RegistrationService', () => {
 
   it('only issues one group of certs at a time', async () => {
     const module = await Test.createTestingModule({
-      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule],
+      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule, SigChainModule],
     }).compile()
+    const sigchainService = await module.resolve(SigChainService)
+    sigchainService.createChain('team', 'user', true)
+
     const libp2pService = await module.resolve(Libp2pService)
     const libp2pParams = await libp2pInstanceParams()
     await libp2pService.createInstance(libp2pParams)

--- a/packages/backend/src/nest/storage/base.store.ts
+++ b/packages/backend/src/nest/storage/base.store.ts
@@ -28,10 +28,10 @@ abstract class StoreBase<V, S extends KeyValueType<V> | EventsType<V>> extends E
   abstract clean(): void
 }
 
-export abstract class KeyValueStoreBase<V> extends StoreBase<V, KeyValueType<V>> {
+export abstract class KeyValueStoreBase<V, U = V> extends StoreBase<V, KeyValueType<V>> {
   protected store: KeyValueType<V> | undefined
-  abstract setEntry(key: string, value: V): Promise<V>
-  abstract getEntry(key?: string): Promise<V | null>
+  abstract setEntry(key: string, value: U): Promise<V>
+  abstract getEntry(key?: string): Promise<U | null>
 }
 
 export abstract class EventStoreBase<V, U = V> extends StoreBase<V, EventsType<V>> {

--- a/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.spec.ts
+++ b/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.spec.ts
@@ -14,6 +14,8 @@ import { IpfsService } from '../../ipfs/ipfs.service'
 import { Libp2pService } from '../../libp2p/libp2p.service'
 import { libp2pInstanceParams } from '../../common/utils'
 import { sleep } from '../../common/sleep'
+import { SigChainModule } from '../../auth/sigchain.service.module'
+import { SigChainService } from '../../auth/sigchain.service'
 
 const updateEvent = async (certificatesRequestsStore: any) => {
   certificatesRequestsStore.events.emit('update')
@@ -23,6 +25,7 @@ const updateEvent = async (certificatesRequestsStore: any) => {
 describe('CertificatesRequestsStore', () => {
   let module: TestingModule
   let certificatesRequestsStore: CertificatesRequestsStore
+  let sigchainService: SigChainService
   let orbitDb: OrbitDbService
   let ipfsService: IpfsService
   let libp2pService: Libp2pService
@@ -31,8 +34,11 @@ describe('CertificatesRequestsStore', () => {
     jest.clearAllMocks()
 
     module = await Test.createTestingModule({
-      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule],
+      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule, SigChainModule],
     }).compile()
+
+    sigchainService = await module.resolve(SigChainService)
+    await sigchainService.createChain('team', 'user', true)
 
     libp2pService = await module.resolve(Libp2pService)
     const libp2pParams = await libp2pInstanceParams()

--- a/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
+++ b/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
@@ -127,7 +127,13 @@ export class CertificatesRequestsStore extends EventStoreBase<EncryptedAndSigned
 
     await Promise.all(
       allEntries.map(async csr => {
-        const decCsr = await this.decryptEntry(csr)
+        let decCsr: string
+        try {
+          decCsr = await this.decryptEntry(csr)
+        } catch (err) {
+          this.logger.error('Failed to decrypt csr:', err)
+          return
+        }
         const validation = await this.validateUserCsr(decCsr)
         if (!validation) {
           this.logger.warn(`Skipping csr due to validation error`, decCsr)

--- a/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
+++ b/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
@@ -12,6 +12,7 @@ import { EventStoreBase } from '../base.store'
 import { EventsWithStorage } from '../orbitDb/eventsWithStorage'
 import { SigChainService } from '../../auth/sigchain.service'
 import { EncryptedAndSignedPayload, EncryptionScopeType } from '../../auth/services/crypto/types'
+import { RoleName } from '../../auth/services/roles/roles'
 
 @Injectable()
 export class CertificatesRequestsStore extends EventStoreBase<EncryptedAndSignedPayload | string> {
@@ -51,7 +52,7 @@ export class CertificatesRequestsStore extends EventStoreBase<EncryptedAndSigned
       const chain = this.chains.getActiveChain()
       const encryptedPayload = chain.crypto.encryptAndSign(
         payload,
-        { type: EncryptionScopeType.TEAM },
+        { type: EncryptionScopeType.ROLE, name: RoleName.MEMBER },
         chain.localUserContext
       )
       return encryptedPayload

--- a/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
+++ b/packages/backend/src/nest/storage/certifacteRequests/certificatesRequestsStore.ts
@@ -10,19 +10,24 @@ import { OrbitDbService } from '../orbitDb/orbitDb.service'
 import { createLogger } from '../../common/logger'
 import { EventStoreBase } from '../base.store'
 import { EventsWithStorage } from '../orbitDb/eventsWithStorage'
+import { SigChainService } from '../../auth/sigchain.service'
+import { EncryptedAndSignedPayload, EncryptionScopeType } from '../../auth/services/crypto/types'
 
 @Injectable()
-export class CertificatesRequestsStore extends EventStoreBase<string> {
+export class CertificatesRequestsStore extends EventStoreBase<EncryptedAndSignedPayload | string> {
   protected readonly logger = createLogger(CertificatesRequestsStore.name)
 
-  constructor(private readonly orbitDbService: OrbitDbService) {
+  constructor(
+    private readonly orbitDbService: OrbitDbService,
+    private readonly chains: SigChainService
+  ) {
     super()
   }
 
   public async init() {
     this.logger.info('Initializing certificates requests store')
 
-    this.store = await this.orbitDbService.orbitDb.open<EventsType<string>>('csrs', {
+    this.store = await this.orbitDbService.orbitDb.open<EventsType<EncryptedAndSignedPayload | string>>('csrs', {
       type: 'events',
       sync: false,
       Database: EventsWithStorage(),
@@ -41,6 +46,36 @@ export class CertificatesRequestsStore extends EventStoreBase<string> {
     await this.getStore().sync.start()
   }
 
+  private async encryptEntry(payload: string): Promise<EncryptedAndSignedPayload> {
+    try {
+      const chain = this.chains.getActiveChain()
+      const encryptedPayload = chain.crypto.encryptAndSign(
+        payload,
+        { type: EncryptionScopeType.TEAM },
+        chain.localUserContext
+      )
+      return encryptedPayload
+    } catch (err) {
+      this.logger.error('Failed to encrypt user entry:', err)
+      throw err
+    }
+  }
+
+  private async decryptEntry(payload: EncryptedAndSignedPayload): Promise<string> {
+    try {
+      const chain = this.chains.getActiveChain()
+      const decryptedPayload = chain.crypto.decryptAndVerify<string>(
+        payload.encrypted,
+        payload.signature,
+        chain.localUserContext
+      )
+      return decryptedPayload.contents
+    } catch (err) {
+      this.logger.error('Failed to decrypt user entry:', err)
+      throw err
+    }
+  }
+
   public async loadedCertificateRequests() {
     const csrs = await this.getEntries()
     this.emit(StorageEvents.CSRS_STORED, {
@@ -52,8 +87,9 @@ export class CertificatesRequestsStore extends EventStoreBase<string> {
     if (!this.store) {
       throw new Error('Store is not initialized')
     }
+    const encryptedCsr = await this.encryptEntry(csr)
     this.logger.info('Adding CSR to database')
-    await this.store.add(csr)
+    await this.store.add(encryptedCsr)
     return csr
   }
 
@@ -82,8 +118,7 @@ export class CertificatesRequestsStore extends EventStoreBase<string> {
 
   public async getEntries() {
     const filteredCsrsMap: Map<string, string> = new Map()
-    const allEntries: string[] = []
-
+    const allEntries: EncryptedAndSignedPayload[] = []
     for await (const x of this.getStore().iterator()) {
       allEntries.push(x.value)
     }
@@ -91,22 +126,22 @@ export class CertificatesRequestsStore extends EventStoreBase<string> {
     this.logger.info('Total CSRs:', allEntries.length)
 
     await Promise.all(
-      allEntries
-        .filter(async csr => {
-          const validation = await this.validateUserCsr(csr)
-          if (validation) return true
-          return false
-        })
-        .map(async csr => {
-          const parsedCsr = await loadCSR(csr)
-          const pubKey = keyFromCertificate(parsedCsr)
+      allEntries.map(async csr => {
+        const decCsr = await this.decryptEntry(csr)
+        const validation = await this.validateUserCsr(decCsr)
+        if (!validation) {
+          this.logger.warn(`Skipping csr due to validation error`, decCsr)
+          return
+        }
+        const parsedCsr = await loadCSR(decCsr)
+        const pubKey = keyFromCertificate(parsedCsr)
 
-          if (filteredCsrsMap.has(pubKey)) {
-            this.logger.warn(`Skipping csr due to existing pubkey`, pubKey)
-            return
-          }
-          filteredCsrsMap.set(pubKey, csr)
-        })
+        if (filteredCsrsMap.has(pubKey)) {
+          this.logger.warn(`Skipping csr due to existing pubkey`, pubKey)
+          return
+        }
+        filteredCsrsMap.set(pubKey, decCsr)
+      })
     )
     const validCsrs = [...filteredCsrsMap.values()]
     this.logger.info('Valid CSRs:', validCsrs.length)

--- a/packages/backend/src/nest/storage/certificates/certificates.store.spec.ts
+++ b/packages/backend/src/nest/storage/certificates/certificates.store.spec.ts
@@ -13,6 +13,8 @@ import { Libp2pModule } from '../../libp2p/libp2p.module'
 import { IpfsModule } from '../../ipfs/ipfs.module'
 import { Libp2pService } from '../../libp2p/libp2p.service'
 import { IpfsService } from '../../ipfs/ipfs.service'
+import { SigChainModule } from '../../auth/sigchain.service.module'
+import { SigChainService } from '../../auth/sigchain.service'
 
 const communityMetadata: CommunityMetadata = {
   id: '39F7485441861F4A2A1A512188F1E0AA',
@@ -52,13 +54,17 @@ describe('CertificatesStore', () => {
   let orbitDb: OrbitDbService
   let libp2pService: Libp2pService
   let ipfsService: IpfsService
+  let sigchainService: SigChainService
 
   beforeEach(async () => {
     jest.clearAllMocks()
 
     module = await Test.createTestingModule({
-      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule],
+      imports: [TestModule, StorageModule, Libp2pModule, IpfsModule, SigChainModule],
     }).compile()
+
+    sigchainService = await module.resolve(SigChainService)
+    await sigchainService.createChain('team', 'user', true)
 
     libp2pService = await module.resolve(Libp2pService)
     const libp2pParams = await libp2pInstanceParams()

--- a/packages/backend/src/nest/storage/certificates/certificates.store.ts
+++ b/packages/backend/src/nest/storage/certificates/certificates.store.ts
@@ -17,16 +17,20 @@ import { Injectable } from '@nestjs/common'
 import { createLogger } from '../../common/logger'
 import { EventStoreBase } from '../base.store'
 import { EventsWithStorage } from '../orbitDb/eventsWithStorage'
-
+import { SigChainService } from '../../auth/sigchain.service'
+import { EncryptedAndSignedPayload, EncryptionScopeType } from '../../auth/services/crypto/types'
 @Injectable()
-export class CertificatesStore extends EventStoreBase<string> {
+export class CertificatesStore extends EventStoreBase<EncryptedAndSignedPayload | string> {
   protected readonly logger = createLogger(CertificatesStore.name)
 
   private metadata: CommunityMetadata | undefined
   private filteredCertificatesMapping: Map<string, Partial<UserData>>
   private usernameMapping: Map<string, string>
 
-  constructor(private readonly orbitDbService: OrbitDbService) {
+  constructor(
+    private readonly orbitDbService: OrbitDbService,
+    private readonly chains: SigChainService
+  ) {
     super()
     this.filteredCertificatesMapping = new Map()
     this.usernameMapping = new Map()
@@ -35,12 +39,15 @@ export class CertificatesStore extends EventStoreBase<string> {
   public async init() {
     this.logger.info('Initializing certificates log store')
 
-    this.store = await this.orbitDbService.orbitDb.open<EventsType<string>>('certificates', {
-      type: 'events',
-      sync: false,
-      Database: EventsWithStorage(),
-      AccessController: IPFSAccessController({ write: ['*'] }),
-    })
+    this.store = await this.orbitDbService.orbitDb.open<EventsType<EncryptedAndSignedPayload | string>>(
+      'certificates',
+      {
+        type: 'events',
+        sync: false,
+        Database: EventsWithStorage(),
+        AccessController: IPFSAccessController({ write: ['*'] }),
+      }
+    )
 
     this.store.events.on('update', async (event: LogEntry) => {
       this.logger.info('Database update')
@@ -57,6 +64,36 @@ export class CertificatesStore extends EventStoreBase<string> {
     await this.getStore().sync.start()
   }
 
+  private async encryptEntry(payload: string): Promise<EncryptedAndSignedPayload> {
+    try {
+      const chain = this.chains.getActiveChain()
+      const encryptedPayload = chain.crypto.encryptAndSign(
+        payload,
+        { type: EncryptionScopeType.TEAM },
+        chain.localUserContext
+      )
+      return encryptedPayload
+    } catch (err) {
+      this.logger.error('Failed to encrypt user entry:', err)
+      throw err
+    }
+  }
+
+  private async decryptEntry(payload: EncryptedAndSignedPayload): Promise<string> {
+    try {
+      const chain = this.chains.getActiveChain()
+      const decryptedPayload = chain.crypto.decryptAndVerify<string>(
+        payload.encrypted,
+        payload.signature,
+        chain.localUserContext
+      )
+      return decryptedPayload.contents
+    } catch (err) {
+      this.logger.error('Failed to decrypt user entry:', err)
+      throw err
+    }
+  }
+
   public async loadedCertificates() {
     this.emit(StorageEvents.CERTIFICATES_STORED, {
       certificates: await this.getEntries(),
@@ -65,8 +102,16 @@ export class CertificatesStore extends EventStoreBase<string> {
 
   public async addEntry(certificate: string): Promise<string> {
     this.logger.info('Adding user certificate')
-    await this.store?.add(certificate)
-    return certificate
+    if (!this.store) {
+      throw new Error('Store not initialized')
+    }
+    try {
+      const encEntry = await this.encryptEntry(certificate)
+      return await this.store?.add(encEntry)
+    } catch (err) {
+      this.logger.error('Failed to add user certificate:', err)
+      return certificate
+    }
   }
 
   public updateMetadata(metadata: CommunityMetadata) {
@@ -129,7 +174,7 @@ export class CertificatesStore extends EventStoreBase<string> {
   public async getEntries(): Promise<string[]> {
     this.logger.info('Getting certificates')
 
-    const allCertificates: string[] = []
+    const allCertificates: EncryptedAndSignedPayload[] = []
 
     for await (const x of this.getStore().iterator()) {
       allCertificates.push(x.value)
@@ -139,13 +184,14 @@ export class CertificatesStore extends EventStoreBase<string> {
 
     const validCertificates = await Promise.all(
       allCertificates.map(async certificate => {
-        if (this.filteredCertificatesMapping.has(certificate)) {
-          return certificate // Only validate certificates
+        const decCert = await this.decryptEntry(certificate)
+        if (this.filteredCertificatesMapping.has(decCert)) {
+          return decCert // Only validate certificates
         }
 
-        const validation = await this.validateCertificate(certificate)
+        const validation = await this.validateCertificate(decCert)
         if (validation) {
-          const parsedCertificate = parseCertificate(certificate)
+          const parsedCertificate = parseCertificate(decCert)
           const pubkey = keyFromCertificate(parsedCertificate)
 
           const username = getCertFieldValue(parsedCertificate, CertFieldsTypes.nickName)
@@ -158,9 +204,9 @@ export class CertificatesStore extends EventStoreBase<string> {
             username: username,
           }
 
-          this.filteredCertificatesMapping.set(certificate, data)
+          this.filteredCertificatesMapping.set(decCert, data)
 
-          return certificate
+          return decCert
         }
       })
     )

--- a/packages/backend/src/nest/storage/certificates/certificates.store.ts
+++ b/packages/backend/src/nest/storage/certificates/certificates.store.ts
@@ -184,7 +184,13 @@ export class CertificatesStore extends EventStoreBase<EncryptedAndSignedPayload 
 
     const validCertificates = await Promise.all(
       allCertificates.map(async certificate => {
-        const decCert = await this.decryptEntry(certificate)
+        let decCert: string
+        try {
+          decCert = await this.decryptEntry(certificate)
+        } catch (err) {
+          this.logger.error('Failed to decrypt certificate:', err)
+          return
+        }
         if (this.filteredCertificatesMapping.has(decCert)) {
           return decCert // Only validate certificates
         }

--- a/packages/backend/src/nest/storage/certificates/certificates.store.ts
+++ b/packages/backend/src/nest/storage/certificates/certificates.store.ts
@@ -19,6 +19,7 @@ import { EventStoreBase } from '../base.store'
 import { EventsWithStorage } from '../orbitDb/eventsWithStorage'
 import { SigChainService } from '../../auth/sigchain.service'
 import { EncryptedAndSignedPayload, EncryptionScopeType } from '../../auth/services/crypto/types'
+import { RoleName } from '../../auth/services/roles/roles'
 @Injectable()
 export class CertificatesStore extends EventStoreBase<EncryptedAndSignedPayload | string> {
   protected readonly logger = createLogger(CertificatesStore.name)
@@ -69,7 +70,7 @@ export class CertificatesStore extends EventStoreBase<EncryptedAndSignedPayload 
       const chain = this.chains.getActiveChain()
       const encryptedPayload = chain.crypto.encryptAndSign(
         payload,
-        { type: EncryptionScopeType.TEAM },
+        { type: EncryptionScopeType.ROLE, name: RoleName.MEMBER },
         chain.localUserContext
       )
       return encryptedPayload

--- a/packages/backend/src/nest/storage/communityMetadata/communityMetadata.store.ts
+++ b/packages/backend/src/nest/storage/communityMetadata/communityMetadata.store.ts
@@ -17,6 +17,7 @@ import { createLogger } from '../../common/logger'
 import { KeyValueStoreBase } from '../base.store'
 import { EncryptedAndSignedPayload, EncryptionScopeType } from '../../auth/services/crypto/types'
 import { SigChainService } from '../../auth/sigchain.service'
+import { RoleName } from '../../auth/services/roles/roles'
 
 const logger = createLogger('communityMetadataStore')
 
@@ -87,7 +88,7 @@ export class CommunityMetadataStore extends KeyValueStoreBase<EncryptedAndSigned
       const chain = this.sigchainService.getActiveChain()
       const encryptedPayload = chain.crypto.encryptAndSign(
         payload,
-        { type: EncryptionScopeType.TEAM },
+        { type: EncryptionScopeType.ROLE, name: RoleName.MEMBER },
         chain.localUserContext
       )
       return encryptedPayload

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -21,7 +21,6 @@ import {
   type Identity,
 } from '@quiet/types'
 import { createLibp2pAddress } from '@quiet/common'
-import fs from 'fs'
 import { IPFS_REPO_PATCH, ORBIT_DB_DIR, QUIET_DIR } from '../const'
 import { LocalDbService } from '../local-db/local-db.service'
 import { createLogger } from '../common/logger'

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -206,8 +206,10 @@ export class StorageService extends EventEmitter {
     })
   }
 
-  public async updateCommunityMetadata(communityMetadata: CommunityMetadata): Promise<CommunityMetadata | undefined> {
-    const meta = await this.communityMetadataStore?.setEntry(communityMetadata.id, communityMetadata)
+  public async updateCommunityMetadata(communityMetadata: CommunityMetadata): Promise<CommunityMetadata | null> {
+    await this.communityMetadataStore?.setEntry(communityMetadata.id, communityMetadata)
+    const meta = await this.communityMetadataStore?.getEntry(communityMetadata.id)
+
     if (meta) {
       this.certificatesStore.updateMetadata(meta)
     }


### PR DESCRIPTION
Encrypts non-message orbit db stores. Pauses syncing orbitdb until a chain is joined.

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
