### PR TITLE
Fix(2570): Close and back functions in the User Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Improves speed, reliability, and documentation for Cypress tests
 
+### Fixes
+
+* Fixes back button navigation issues in user profile/edit screens ([#2570]https://github.com/TryQuiet/quiet/issues/2570)
+
 ## [4.0.3]
 
 ### New features

--- a/packages/desktop/src/renderer/components/ContextMenu/ContextMenu.component.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/ContextMenu.component.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useRef } from 'react'
 import { Grid, List, Typography, useTheme } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import {
   ContextMenuProps,
   ContextMenuHintProps,
@@ -48,7 +49,7 @@ export const ContextMenu: FC<ContextMenuProps> = ({ visible, handleClose, handle
             onClick={handleBack || handleClose}
             dataTestId={`contextMenu-close-button-${title.split(' ').join('')}`}
           >
-            <CloseIcon />
+            {handleBack ? <ArrowBackIcon style={{ fontSize: '24px' }} /> : <CloseIcon />}
           </IconButton>
           <Grid style={{ flex: 5, justifyContent: 'center' }}>
             <Typography fontSize={16} fontWeight={'medium'} style={{ alignSelf: 'center' }}>

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
@@ -327,6 +327,13 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
     }
   }
 
+  const { handleClose, ...ctxMenu } = contextMenu
+
+  const handleCloseWrapped = () => {
+    setRoute('userProfile')
+    handleClose()
+  }
+
   const getImageSize = (file: File) => {
     return new Promise<{ width: number; height: number }>((resolve, reject) => {
       const img = new Image()
@@ -389,7 +396,12 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
   }, [contentRef])
 
   return (
-    <ContextMenu title='Edit profile' handleBack={() => setRoute('userProfile')} {...contextMenu}>
+    <ContextMenu
+      title='Edit profile'
+      handleBack={() => setRoute('userProfile')}
+      handleClose={handleCloseWrapped}
+      {...ctxMenu}
+    >
       <StyledContextMenuContent
         container
         ref={ref => {


### PR DESCRIPTION
Pull Request Checklist

Fixes issue: https://github.com/TryQuiet/quiet/issues/2570

Back button navigation in user profile:

- Close button changed to back button in Edit Profile view,

- When the user closes the side menu by clicking in the area outside of the menu and opens the menu again, the view will be User Profile.

- [x]  I have linked this PR to a related GitHub issue.

- [x]  I have added a description of the change (and Github issue number, if any) 