### PR TITLE
Fix/2766-mobile-message-date-time-display

### DIFF
--- a/packages/mobile/src/components/Message/Message.component.tsx
+++ b/packages/mobile/src/components/Message/Message.component.tsx
@@ -14,6 +14,7 @@ import Markdown, { MarkdownIt, ASTNode } from '@ronradtke/react-native-markdown-
 import { defaultTheme } from '../../styles/themes/default.theme'
 import UserLabel from '../UserLabel/UserLabel.component'
 import { UserLabelType } from '../UserLabel/UserLabel.types'
+import { DateTime } from 'luxon'
 
 const MessageProfilePhoto: React.FC<{ message: DisplayableMessage }> = ({ message }) => {
   const imgStyle = {
@@ -115,6 +116,20 @@ export const Message: FC<MessageProps & FileActionsProps> = ({
 
   const representativeMessage = data[0]
 
+  const formatDateTime = (createdAt: number): string => {
+    // get timezone offset from native Date, for correct local timezone
+    const tzOffsetHours = -new Date().getTimezoneOffset() / 60
+    const formattedOffset = `UTC${tzOffsetHours >= 0 ? '+' : ''}${tzOffsetHours}`
+
+    const messageTime = DateTime.fromSeconds(createdAt).setZone(formattedOffset)
+    const now = DateTime.now().setZone(formattedOffset)
+
+    // Use DateTime.DATETIME_MED to properly respect locale settings including 12h/24h preference
+    return messageTime.toLocaleString(DateTime.DATETIME_MED)
+  }
+
+  const representativeMessageDateTime = formatDateTime(representativeMessage.createdAt)
+
   const info = representativeMessage.type === MessageType.Info
   const pending: boolean = pendingMessages?.[representativeMessage.id] !== undefined
 
@@ -177,7 +192,7 @@ export const Message: FC<MessageProps & FileActionsProps> = ({
               }}
             >
               <Typography fontSize={14} color={'subtitle'}>
-                {representativeMessage.date}
+                {representativeMessageDateTime}
               </Typography>
             </View>
           </View>


### PR DESCRIPTION
Solves one of the remaining issues in [#2766]

### Pull Request Checklist

- [X] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
