### PR TITLE
Stop Libp2p From Dialing Non-Onion Addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [5.0.0]
 
+### Fixes
+
+* Resolved an issue with malformed libp2p addresses during redialing peers you had recently been connected to [#2842](https://github.com/TryQuiet/quiet/issues/2842)
+
 ### Chores
 
 * Disables bitcode creation and strips bitcode from Tor.framework for xcode 16 compatibility

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -460,8 +460,9 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     const bootstrapPeerStats: Record<string, NetworkStats> = {}
     for (const pair of inviteData.pairs) {
       const multiaddr = createLibp2pAddress(pair.onionAddress, pair.peerId)
-      bootstrapPeerStats[multiaddr] = {
+      bootstrapPeerStats[pair.peerId] = {
         peerId: pair.peerId,
+        address: multiaddr,
         connectionTime: 0,
         lastSeen: DateTime.utc().toSeconds(),
       } as NetworkStats
@@ -577,7 +578,6 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       privKey: privateKeyFromRaw(Buffer.from(identity.networkInfo.peerId.privKey, 'base64')),
       noiseKey: Buffer.from(identity.networkInfo.peerId.noiseKey, 'base64'),
     }
-    this.logger.info(peerIdData.peerId.toString())
     const localAddress = createLibp2pAddress(onionAddress, peerIdData.peerId.toString())
 
     const params: Libp2pNodeParams = {
@@ -794,6 +794,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     })
     this.storageService.on(StorageEvents.USER_PROFILES_STORED, (payload: UserProfilesStoredEvent) => {
       this.storageService.updatePeerStore()
+      this.libp2pService.addPeersToDialQueue()
       this.serverIoProvider.io.emit(SocketEvents.USER_PROFILES_STORED, payload)
     })
   }

--- a/packages/backend/src/nest/libp2p/libp2p.service.ts
+++ b/packages/backend/src/nest/libp2p/libp2p.service.ts
@@ -109,14 +109,23 @@ export class Libp2pService extends EventEmitter {
       args[0].event != null &&
       ['LOCAL_ERROR', 'REMOTE_ERROR', 'ERROR'].includes(args[0].event.type)
     ) {
-      const innerEvent = args[0].event
-      // Check for errors related to ephemeral LFA connection isseus that warrant a redial attempt
-      const redial =
-        (innerEvent.type === 'ERROR' &&
-          innerEvent.payload.type === 'DEVICE_UNKNOWN' &&
-          innerEvent.payload.message === UNKNOWN_THIS_PEER) ||
-        (innerEvent.type === 'LOCAL_ERROR' && innerEvent.payload.type === 'TIMEOUT')
-      this.hangUpPeer(args[0].connection.remoteAddr.toString(), redial)
+      try {
+        const innerEvent = args[0].event
+        // Check for errors related to ephemeral LFA connection isseus that warrant a redial attempt
+        const redial =
+          (innerEvent.type === 'ERROR' &&
+            innerEvent.payload.type === 'DEVICE_UNKNOWN' &&
+            innerEvent.payload.message === UNKNOWN_THIS_PEER) ||
+          (innerEvent.type === 'LOCAL_ERROR' && innerEvent.payload.type === 'TIMEOUT')
+
+        const remotePeerId = args[0].connection?.remotePeerId?.toString()
+        const peerAddress = this.connectedPeers.get(remotePeerId)?.address
+        if (peerAddress) {
+          this.hangUpPeer(peerAddress, redial)
+        }
+      } catch (e) {
+        this.logger.error('Error while deciding to redial', e)
+      }
     }
     return super.emit(event, ...args)
   }
@@ -498,46 +507,45 @@ export class Libp2pService extends EventEmitter {
       const remotePeerId = event.detail.toString()
       const localPeerId = peerId.peerId.toString()
       const connection = this.libp2pInstance?.getConnections(event.detail)
+      this.logger.info(`Connection established with ${remotePeerId}`, JSON.stringify(connection))
       this.logger.info(`${localPeerId} connected to ${remotePeerId}`)
       this.logger.info(`Local: ${localPeerId} is connected to ${this.connectedPeers.size} peers`)
       this.logger.info(`Local: ${localPeerId} has ${this.libp2pInstance?.getConnections().length} open connections`)
 
-      if (!connection) {
-        this.logger.error('Cannot update peer stats, connection not found')
-        return
-      }
-      const remoteAddr = connection[0].remoteAddr.toString()
       // update peer stats
       const peerPrevStats = await this.localDbService.getPeerStats(remotePeerId)
       const peerStats: Record<string, NetworkStats> = {}
-      peerStats[remoteAddr] = {
+      peerStats[remotePeerId] = {
         peerId: remotePeerId,
         connectionTime: peerPrevStats?.connectionTime ?? 0,
         lastSeen: DateTime.utc().valueOf(),
       } as NetworkStats
-      this.connectedPeers.set(remotePeerId, {
-        peerId: remotePeerId,
-        address: remoteAddr,
-        connectedAtSeconds: DateTime.utc().toSeconds(),
-      } as Libp2pConnectedPeer)
       await this.localDbService.updatePeerStats(peerStats)
+
+      if (connection) {
+        const remoteAddr = connection[0].remoteAddr.toString()
+        this.connectedPeers.set(remotePeerId, {
+          peerId: remotePeerId,
+          address: remoteAddr,
+          connectedAtSeconds: DateTime.utc().toSeconds(),
+        } as Libp2pConnectedPeer)
+      }
 
       this.serverIoProvider.io.emit(SocketEvents.PEER_CONNECTED, {
         peer: remotePeerId,
-        lastSeen: peerStats[remoteAddr].lastSeen,
+        lastSeen: peerStats[remotePeerId].lastSeen,
         connectionDuration: 0,
       } as NetworkDataPayload)
 
       this.emit(Libp2pEvents.PEER_CONNECTED, {
         peers: [remotePeerId],
       })
-      await this.addPeersToDialQueue()
     })
 
     this.libp2pInstance.addEventListener('peer:disconnect', async event => {
       const remotePeerId = event.detail.toString()
-      const remoteAddr = this.connectedPeers.get(remotePeerId)?.address
       const localPeerId = peerId.peerId.toString()
+      this.logger.info(`Connection closed with ${remotePeerId}`, JSON.stringify(event))
       this.logger.info(`${localPeerId} disconnected from ${remotePeerId}`)
       if (!this.libp2pInstance) {
         this.logger.error('libp2pInstance was not created')
@@ -562,12 +570,16 @@ export class Libp2pService extends EventEmitter {
         lastSeen: connectionEndTime,
       }
       this.emit(Libp2pEvents.PEER_DISCONNECTED, peerStat)
-      const peerPrevStats = await this.localDbService.find(LocalDBKeys.PEERS, remoteAddr!)
+      const peerPrevStats = await this.localDbService.getPeerStats(remotePeerId)
+      if (!peerPrevStats) {
+        this.logger.info(`No previous stats for peer ${remotePeerId}. Not updating stats`)
+        return
+      }
       const prev = peerPrevStats?.connectionTime || 0
 
       const peerStats: Record<string, NetworkStats> = {}
-      peerStats[remoteAddr!] = {
-        peerId: remotePeerId,
+      peerStats[remotePeerId] = {
+        ...peerPrevStats,
         connectionTime: prev + connectionDuration,
         lastSeen: connectionEndTime,
       } as NetworkStats

--- a/packages/backend/src/nest/local-db/local-db.service.spec.ts
+++ b/packages/backend/src/nest/local-db/local-db.service.spec.ts
@@ -27,16 +27,18 @@ describe('LocalDbService', () => {
   const addr2 = createLibp2pAddress('zl37gnntp64dhnisddftypxbt5cqx6cum65vdv6oeaffrbqmemwc52ad.onion', peer2Id)
 
   const stats1: Record<string, NetworkStats> = {
-    [addr1]: {
+    [peer1Id]: {
       peerId: peer1Id,
+      address: addr1,
       connectionTime: 50,
       lastSeen: 1_000,
     },
   }
 
   const stats2: Record<string, NetworkStats> = {
-    [addr2]: {
+    [peer2Id]: {
       peerId: peer2Id,
+      address: addr2,
       connectionTime: 500,
       lastSeen: 500,
     },

--- a/packages/backend/src/nest/local-db/local-db.service.spec.ts
+++ b/packages/backend/src/nest/local-db/local-db.service.spec.ts
@@ -159,8 +159,8 @@ describe('LocalDbService', () => {
       })
 
       // single peer – key by peerId
-      expect(await service.getPeerStats(peer1Id)).toEqual(stats1[addr1])
-      expect(await service.getPeerStats(peer2Id)).toEqual(stats2[addr2])
+      expect(await service.getPeerStats(peer1Id)).toEqual(stats1[peer1Id])
+      expect(await service.getPeerStats(peer2Id)).toEqual(stats2[peer2Id])
     })
 
     it('getSortedPeers returns addresses sorted alphabetically', async () => {

--- a/packages/backend/src/nest/local-db/local-db.service.ts
+++ b/packages/backend/src/nest/local-db/local-db.service.ts
@@ -101,12 +101,6 @@ export class LocalDbService {
    */
   public async setPeerStats(stats: Record<string, NetworkStats>) {
     this.logger.debug('Setting peer stats', stats)
-    for (const addr of Object.keys(stats)) {
-      if (!isMultiaddr(multiaddr(addr))) {
-        this.logger.error('Invalid multiaddr', addr)
-        continue
-      }
-    }
     this.put(LocalDBKeys.PEERS, stats)
   }
 
@@ -115,14 +109,7 @@ export class LocalDbService {
    * @param stats
    */
   public async updatePeerStats(stats: Record<string, NetworkStats>) {
-    this.logger.debug('Updating peer stats', stats)
-    for (const addr of Object.keys(stats)) {
-      if (!isMultiaddr(multiaddr(addr))) {
-        this.logger.error('Invalid multiaddr', addr)
-        delete stats[addr]
-        continue
-      }
-    }
+    this.logger.debug('Updating peer stats', JSON.stringify(stats, null, 2))
     const existingStats = await this.get(LocalDBKeys.PEERS)
     if (!existingStats) {
       this.put(LocalDBKeys.PEERS, stats)
@@ -135,21 +122,15 @@ export class LocalDbService {
   /**
    * Get the local db entry for peers
    */
-  public async getPeerStats(peerId: string): Promise<NetworkStats | undefined>
+  public async getPeerStats(peerId: string): Promise<NetworkStats | null>
   public async getPeerStats(): Promise<Record<string, NetworkStats>>
-  public async getPeerStats(peerId?: string): Promise<NetworkStats | Record<string, NetworkStats> | undefined> {
+  public async getPeerStats(peerId?: string): Promise<NetworkStats | Record<string, NetworkStats> | null> {
+    if (peerId) {
+      return await this.find(LocalDBKeys.PEERS, peerId)
+    }
     const peers = await this.get(LocalDBKeys.PEERS)
     if (!peers) {
-      return peerId ? undefined : {}
-    }
-    if (peerId) {
-      // find the stats entry matching the given peerId
-      for (const stats of Object.values(peers) as NetworkStats[]) {
-        if (stats.peerId === peerId) {
-          return stats
-        }
-      }
-      return undefined
+      return null
     }
     return peers
   }
@@ -163,8 +144,10 @@ export class LocalDbService {
    */
   public async getSortedPeers(includeLocalPeerAddress: boolean = true): Promise<string[]> {
     const entries = (await this.get(LocalDBKeys.PEERS)) || {}
-    const addresses: string[] = Object.keys(entries)
     const stats: NetworkStats[] = Object.values(entries)
+    const addresses: string[] = stats
+      .map((peer: NetworkStats) => peer.address)
+      .filter((address): address is string => address !== undefined)
 
     if (includeLocalPeerAddress) {
       const identity = await this.getIdentity(await this.get(LocalDBKeys.CURRENT_COMMUNITY_ID))

--- a/packages/backend/src/nest/storage/storage.service.spec.ts
+++ b/packages/backend/src/nest/storage/storage.service.spec.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals'
 
 import { Test, TestingModule } from '@nestjs/testing'
 import { prepareStore, getReduxStoreFactory, publicChannels, Store } from '@quiet/state-manager'
-import { Community, Identity, PublicChannel, UserProfile } from '@quiet/types'
+import { Community, Identity, NetworkStats, PublicChannel, UserProfile } from '@quiet/types'
 
 import path from 'path'
 import { type PeerId } from '@libp2p/interface'
@@ -25,6 +25,7 @@ import { createLogger } from '../common/logger'
 import { UserProfileStore } from './userProfile/userProfile.store'
 import { SigChainService } from '../auth/sigchain.service'
 import { SigChainModule } from '../auth/sigchain.service.module'
+import { Network } from '@libp2p/kad-dht/dist/src/network'
 
 const logger = createLogger('storageService:test')
 
@@ -193,8 +194,13 @@ describe('StorageService', () => {
 
     it('updatePeerStore should merge existing and new peers', async () => {
       const existingPeerStats = {
-        '/dns4/oldpeer.onion/tcp/80/ws/p2p/peerOld': { peerId: 'peerOld', lastSeen: 0, connectionTime: 0 },
-      }
+        peerOld: {
+          peerId: 'peerOld',
+          address: '/dns4/oldpeer.onion/tcp/80/ws/p2p/peerOld',
+          lastSeen: 0,
+          connectionTime: 0,
+        },
+      } as Record<string, NetworkStats>
       jest.spyOn(localDbService, 'getPeerStats').mockResolvedValue(existingPeerStats as any)
 
       const members = [{ userId: 'user1' }]
@@ -219,8 +225,9 @@ describe('StorageService', () => {
       const expectedMultiaddr = `/dns4/addr1.onion/tcp/80/ws/p2p/peer1`
       expect(setPeerStatsSpy).toHaveBeenCalled()
       const arg = setPeerStatsSpy.mock.calls[0][0]
-      expect(arg[expectedMultiaddr]).toBeDefined()
-      expect(arg[expectedMultiaddr].peerId).toEqual('peer1')
+      expect(arg['peer1']).toBeDefined()
+      expect(arg['peer1'].peerId).toEqual('peer1')
+      expect(arg['peer1'].address).toEqual(expectedMultiaddr)
     })
   })
 })

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -74,6 +74,9 @@ export class StorageService extends EventEmitter {
     this.logger.info(`Starting database sync`)
     await this.startSync()
 
+    this.logger.info('Updating peer store')
+    await this.updatePeerStore()
+
     this.logger.info('Initialized storage')
   }
 
@@ -181,12 +184,16 @@ export class StorageService extends EventEmitter {
     const peers: Record<string, NetworkStats> = {}
     for (const userData of currentUserData) {
       const multiaddr = createLibp2pAddress(userData.onionAddress, userData.peerId)
-      const existingStats = existingPeers[multiaddr]
+      const existingStats = existingPeers[userData.peerId]
       if (existingStats) {
-        peers[multiaddr] = existingPeers[multiaddr]
+        peers[userData.peerId] = existingPeers[userData.peerId]
+        if (!existingPeers.address) {
+          peers[userData.peerId].address = multiaddr
+        }
       } else {
-        peers[multiaddr] = {
+        peers[userData.peerId] = {
           peerId: userData.peerId,
+          address: multiaddr,
           lastSeen: DateTime.utc().toSeconds(),
           connectionTime: 0,
         }

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -7,12 +7,14 @@ export type ConnectedPeers = string[]
 // event.
 export interface NetworkDataPayload {
   peer: string
+  address?: string // multiaddr
   connectionDuration: number
   lastSeen: number
 }
 
 export interface NetworkStats {
   peerId: string
+  address?: string // multiaddr
   lastSeen: number // last time the peer was seen
   connectionTime: number // time spent connected
 }


### PR DESCRIPTION
Refactors peer management and storage handling assuming that Libp2pService will only know peerId. Makes sure that dial queue is derived from UserProfileStore


### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
