### PR TITLE
dedupe file logger; de-colorize log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Resolved an issue with event handlers not attaching to the Team object when joining a community for the first time [#2845](https://github.com/TryQuiet/quiet/issues/2845)
 * Resolved an issue with malformed libp2p addresses during redialing peers you had recently been connected to [#2842](https://github.com/TryQuiet/quiet/issues/2842)
+* Resolved an issue with logger duplication [#2853](https://github.com/TryQuiet/quiet/issues/2853)
 
 ### Chores
 

--- a/packages/node-common/src/logger.ts
+++ b/packages/node-common/src/logger.ts
@@ -13,24 +13,30 @@ import {
   LogFormatters,
 } from '@quiet/logger'
 
+// Singleton instance for winston logger
+let _winstonLogger: Logger | undefined = undefined
+
 const initWinstonLogger = (): Logger | undefined => {
-  const baseFormat = format.combine(
+  if (_winstonLogger) return _winstonLogger
+  // Add a non-colorized format for file logs
+  const fileFormat = format.combine(
     format.splat(),
     format.timestamp(),
     format.errors(),
+    format.uncolorize(), // Remove ANSI color codes
     format.printf(info => info.message as string)
   )
   const logDir = process.env.LOG_DIR
   const logToFile = (process.env.LOG_TO_FILE ?? 'true') === 'true'
   if (logToFile && logDir != null) {
-    return winston.createLogger({
+    _winstonLogger = winston.createLogger({
       level: 'silly', // this is just because we are doing the log level checking via debug
       transports: [
         new transports.DailyRotateFile({
           // %DATE will be replaced by the current date
           filename: path.join(logDir, `error_%DATE%.log`),
           level: 'error',
-          format: baseFormat,
+          format: fileFormat, // Use non-colorized format for file
           datePattern: 'YYYY-MM-DD',
           zippedArchive: false, // don't want to zip our logs
           maxFiles: '3d', // will keep log until they are older than 7 days
@@ -38,15 +44,15 @@ const initWinstonLogger = (): Logger | undefined => {
         // same for all levels
         new transports.DailyRotateFile({
           filename: path.join(logDir, `log_%DATE%.log`),
-          format: baseFormat,
+          format: fileFormat, // Use non-colorized format for file
           datePattern: 'YYYY-MM-DD',
           zippedArchive: false,
           maxFiles: '3d',
         }),
       ],
     })
+    return _winstonLogger
   }
-
   return undefined
 }
 


### PR DESCRIPTION
Makes the winston logger a singleton, and removes ANSI color codes from log file.

Fixes every instance of a logger opening the log file itself, potentially blowing up the number of open files in a process.

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
