### PR TITLE
Fix 2858 ios autocorrected message unsent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+* Resolved an issue where messages autocorrected by iOS were remaining unsent in the message input, after the uncorrected message was sent [#2858](https://github.com/TryQuiet/quiet/issues/2858) 
 * Resolved an issue with event handlers not attaching to the Team object when joining a community for the first time [#2845](https://github.com/TryQuiet/quiet/issues/2845)
 * Resolved an issue with malformed libp2p addresses during redialing peers you had recently been connected to [#2842](https://github.com/TryQuiet/quiet/issues/2842)
 * Resolved an issue with logger duplication [#2853](https://github.com/TryQuiet/quiet/issues/2853)

--- a/packages/mobile/docs/ios-autocorrect-workaround.md
+++ b/packages/mobile/docs/ios-autocorrect-workaround.md
@@ -1,0 +1,52 @@
+<!--
+  Documentation: iOS Autocorrect Workaround for Chat Input
+  Explains the append-space hack to commit pending autocorrect suggestions
+  and outlines how to test it via unit and e2e tests.
+-->
+
+# iOS Autocorrect Workaround in Chat Component
+
+## Problem
+
+On iOS, React Native’s `TextInput` does not always commit the last autocorrect suggestion when the user taps send, leading to:
+
+- Sending the uncorrected text (e.g., “sendd” instead of “send”).
+- Leaving the corrected suggestion in the input after send.
+- Unexpected keyboard behavior if blurred/refocused.
+
+This is a known issue: facebook/react-native#2552, #9273, keybase/client#19574.
+
+## Workaround
+
+In our `Chat` component we implement the following on send:
+
+1. Check for pending text or attached files.
+2. If there is text, append a space via `setNativeProps({ text: original + ' ' })`.  This forces iOS to commit any pending autocorrect.
+3. In a short `setTimeout` (e.g. 50ms), read the trimmed text (`.trim()`), call `sendMessageAction(correctedText)`, then clear the input via `.clear()` and reset React state.
+4. If no text but files are uploaded, send an empty string to represent a files-only message.
+
+```ts
+// Chat.component.tsx (simplified)
+const onPress = () => {
+  if (messageInputValueRef.current.length > 0 || areFilesUploaded) {
+    if (messageInputValueRef.current.length > 0) {
+      // commit autocorrect
+      const original = messageInputValueRef.current
+      const commit = original + ' '
+      inputRef.current?.setNativeProps({ text: commit })
+      messageInputValueRef.current = commit
+      setTimeout(() => {
+        const textToSend = messageInputValueRef.current.trim()
+        sendMessageAction(textToSend)
+        inputRef.current?.clear()
+        messageInputValueRef.current = ''
+        setMessageInput('')
+      }, 50)
+    } else {
+      sendMessageAction('')
+    }
+  }
+}
+```
+
+This approach avoids blur/focus hacks (and keyboard bounce) while ensuring the corrected word is sent.

--- a/packages/mobile/src/components/Chat/Chat.component.tsx
+++ b/packages/mobile/src/components/Chat/Chat.component.tsx
@@ -1,5 +1,15 @@
 import React, { FC, useRef, useState, useEffect, useCallback } from 'react'
-import { Keyboard, View, FlatList, TextInput, KeyboardAvoidingView, Platform } from 'react-native'
+import {
+  Keyboard,
+  View,
+  FlatList,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+  NativeSyntheticEvent,
+  TextInputChangeEventData,
+  TextInputEndEditingEventData,
+} from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Appbar } from '../../components/Appbar/Appbar.component'
 import { Loading } from '../Loading/Loading.component'
@@ -46,6 +56,8 @@ export const Chat: FC<ChatProps & FileActionsProps> = ({
   const [messageInput, setMessageInput] = useState<string>('')
 
   const messageInputRef = useRef<null | TextInput>(null)
+  // keep latest input text (including any pending autocorrect) in a ref
+  const messageInputValueRef = useRef<string>('')
 
   const insets = useSafeAreaInsets()
 
@@ -85,8 +97,22 @@ export const Chat: FC<ChatProps & FileActionsProps> = ({
   }, [messageInput?.length, setKeyboardShow])
 
   const onInputTextChange = (value: string) => {
+    // track current text on manual entry
+    messageInputValueRef.current = value
     setMessageInput(value)
   }
+  // capture native change events (e.g., autocorrect commit)
+  const onInputChange = useCallback((e: NativeSyntheticEvent<TextInputChangeEventData>) => {
+    const value = e.nativeEvent.text
+    messageInputValueRef.current = value
+    setMessageInput(value)
+  }, [])
+  // capture end of editing (e.g., on blur)
+  const onInputEndEditing = useCallback((e: NativeSyntheticEvent<TextInputEndEditingEventData>) => {
+    const value = e.nativeEvent.text
+    messageInputValueRef.current = value
+    setMessageInput(value)
+  }, [])
 
   const openAttachments = async () => {
     let response: DocumentPickerResponse[]
@@ -110,10 +136,28 @@ export const Chat: FC<ChatProps & FileActionsProps> = ({
   }
 
   const onPress = () => {
-    if ((messageInputRef.current && messageInput?.length > 0) || areFilesUploaded) {
-      messageInputRef?.current?.clear()
-      sendMessageAction(messageInput)
-      setMessageInput('')
+    // only send if there's text or uploaded files
+    if (messageInputValueRef.current.length > 0 || areFilesUploaded) {
+      if (messageInputValueRef.current.length > 0) {
+        // append space to force iOS to commit any pending autocorrect
+        const original = messageInputValueRef.current
+        const commitText = original + ' '
+        // update native text to trigger autocorrect commit
+        messageInputRef.current?.setNativeProps({ text: commitText })
+        messageInputValueRef.current = commitText
+        // after commit, send trimmed text and clear input
+        setTimeout(() => {
+          const textToSend = messageInputValueRef.current.trim()
+          sendMessageAction(textToSend)
+          // clear native input and reset state
+          messageInputRef.current?.clear()
+          messageInputValueRef.current = ''
+          setMessageInput('')
+        }, 50)
+      } else {
+        // no text but files attached
+        sendMessageAction('')
+      }
     }
   }
 
@@ -192,7 +236,10 @@ export const Chat: FC<ChatProps & FileActionsProps> = ({
                     <View style={{ justifyContent: 'center' }}>
                       <Input
                         ref={messageInputRef}
+                        // uncontrolled: do not pass value to allow native setNativeProps to work
                         onChangeText={onInputTextChange}
+                        onChange={onInputChange}
+                        onEndEditing={onInputEndEditing}
                         placeholder={`Message #${channel?.name}`}
                         multiline={true}
                         style={{ paddingRight: 50 }}

--- a/packages/mobile/src/components/Input/Input.component.tsx
+++ b/packages/mobile/src/components/Input/Input.component.tsx
@@ -10,6 +10,9 @@ export const Input = forwardRef<TextInput, InputProps>(
   (
     {
       onChangeText,
+      onChange,
+      onEndEditing,
+      value,
       label,
       placeholder,
       capitalize,
@@ -53,7 +56,10 @@ export const Input = forwardRef<TextInput, InputProps>(
           }}
         >
           <StyledTextInput
+            value={value}
             onChangeText={onChangeText}
+            onChange={onChange}
+            onEndEditing={onEndEditing}
             onContentSizeChange={event => {
               if (multiline) {
                 setHeight(event.nativeEvent.contentSize.height)

--- a/packages/mobile/src/components/Input/Input.types.ts
+++ b/packages/mobile/src/components/Input/Input.types.ts
@@ -1,8 +1,13 @@
 import { ReactElement } from 'react'
 import { ViewStyle } from 'react-native'
 
+import { NativeSyntheticEvent, TextInputChangeEventData, TextInputEndEditingEventData } from 'react-native'
 export interface InputProps {
   onChangeText?: (value: string) => void
+  /** Called on native text change events (e.g., autocorrect commit) */
+  onChange?: (e: NativeSyntheticEvent<TextInputChangeEventData>) => void
+  /** Called when text input ends editing (e.g., on blur) */
+  onEndEditing?: (e: NativeSyntheticEvent<TextInputEndEditingEventData>) => void
   label?: string
   placeholder: string
   capitalize?: 'none' | 'sentences' | 'words' | 'characters'
@@ -16,4 +21,6 @@ export interface InputProps {
   wrapperStyle?: ViewStyle
   children?: ReactElement
   autoCorrect?: boolean
+  /** Controlled text value */
+  value?: string
 }


### PR DESCRIPTION
### Pull Request Checklist

https://github.com/TryQuiet/quiet/issues/2858

- [X] I have linked this PR to a related GitHub issue.
- [X] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
