### PR TITLE
Update GitHub Actions Windows runners from 2019 to 2022

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022]
 
     steps:
       - name: "Print OS"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -24,7 +24,7 @@ jobs:
             source_path: darwin
             build_cmd: "--mac"
             artifact_glob: "packages/desktop/dist/*.dmg"
-          - os: windows-2019
+          - os: windows-2022
             target: win
             source_path: win32
             build_cmd: "--win"
@@ -302,7 +302,7 @@ jobs:
 
   build-windows-prod:
     # needs: run-e2e-tests-win
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: |
       startsWith(github.ref, 'refs/tags/@quiet/desktop')
 

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -3,7 +3,7 @@ name: E2E Windows
 on: [workflow_call]
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     timeout-minutes: 180
 

--- a/.github/workflows/identity-tests.yml
+++ b/.github/workflows/identity-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
 
     steps:
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04] #, macos-13, windows-2019]
+        os: [ubuntu-22.04] #, macos-13, windows-2022]
 
     steps:
       - name: 'Print OS'

--- a/.github/workflows/utils-tests.yml
+++ b/.github/workflows/utils-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
 
     steps:
       - name: "Print OS"


### PR DESCRIPTION
## Summary
• Updates all GitHub Actions workflow files to use `windows-2022` instead of `windows-2019`
• GitHub is phasing out Windows Server 2019 runners in favor of Windows Server 2022

Fixes #2881

## Files Changed
- `.github/workflows/backend-tests.yml`
- `.github/workflows/check.yml` 
- `.github/workflows/desktop-build.yml`
- `.github/workflows/e2e-win.yml`
- `.github/workflows/identity-tests.yml`
- `.github/workflows/integration-tests.yml`
- `.github/workflows/utils-tests.yml`

## Test plan
- [ ] Verify GitHub Actions workflows run successfully with windows-2022 runners
- [ ] Check that Windows builds and tests complete without issues

🤖 Generated with [Claude Code](https://claude.ai/code)