### PR TITLE
Fix/user profile race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+### Fixes
+* Fixes race condition with initial user profile entry on joining [#2887](https://github.com/TryQuiet/quiet/issues/2887)
+
 ### Chores
 
 * Quiet Desktop now uses Tor 0.4.8.16
@@ -36,7 +39,7 @@
 
 ### Fixes
 
-* Resolved an issue where messages autocorrected by iOS were remaining unsent in the message input, after the uncorrected message was sent [#2858](https://github.com/TryQuiet/quiet/issues/2858) 
+* Resolved an issue where messages autocorrected by iOS were remaining unsent in the message input, after the uncorrected message was sent [#2858](https://github.com/TryQuiet/quiet/issues/2858)
 * Resolved an issue with event handlers not attaching to the Team object when joining a community for the first time [#2845](https://github.com/TryQuiet/quiet/issues/2845)
 * Resolved an issue with malformed libp2p addresses during redialing peers you had recently been connected to [#2842](https://github.com/TryQuiet/quiet/issues/2842)
 * Fixed an issue with failing to reconnect to users who had dialed you and then disconnected [#2854](https://github.com/TryQuiet/quiet/issues/2854)

--- a/packages/backend/src/nest/auth/sigchain.service.ts
+++ b/packages/backend/src/nest/auth/sigchain.service.ts
@@ -112,13 +112,13 @@ export class SigChainService extends EventEmitter {
         isDuplicated: false,
       })) as User[]
     this.socketService.emit(SocketEvents.USERS_UPDATED, { users })
+    this.emit('updated')
     this.saveChain(this.activeChainTeamName!)
   }
 
   private attachSocketListeners(chain: SigChain): void {
     this.logger.info('Attaching socket listeners')
     chain.on('updated', this.handleChainUpdate)
-    this.emit('updated')
   }
 
   private detachSocketListeners(chain: SigChain): void {

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -70,6 +70,7 @@ import { createLogger } from '../common/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { privateKeyFromRaw } from '@libp2p/crypto/keys'
 import { SigChainService } from '../auth/sigchain.service'
+import { RoleName } from '../auth/services/roles/roles'
 
 /**
  * A monolith service that handles lots of events received from the state-manager.
@@ -623,11 +624,12 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       await this.storageService.init(peerIdData.peerId)
     }
 
-    if (this.sigChainService.getActiveChain().team != null) {
+    const activeChain = this.sigChainService.getActiveChain()
+    if (activeChain.team != null && activeChain.roles.amIMemberOfRole(RoleName.MEMBER)) {
       await setupStorage()
     } else {
       this.libp2pService.once(Libp2pEvents.AUTH_JOINED, async (payload: { peer: string }) => {
-        this.logger.info('Handling AUTH_JOINED event', payload)
+        this.logger.info(`Handling ${Libp2pEvents.AUTH_JOINED} event`, payload)
         await setupStorage()
       })
     }

--- a/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
+++ b/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
@@ -36,18 +36,17 @@ export class UserProfileStore extends EncryptedKeyValueStoreBase<EncryptedAndSig
       AccessController: IPFSAccessController({ write: ['*'] }),
     })
 
-    // Try to post entries that were deferred when team state changes
-    this.auth.on('update', async payload => {
-      this.flushDeferredEntries()
-    })
-
     this.store.events.on('update', async (entry: LogEntry) => {
       logger.info('Database update')
       this.emit(StorageEvents.USER_PROFILES_STORED, {
         profiles: await this.getUserProfiles(),
       })
     })
-    this.flushDeferredEntries()
+
+    this.auth.on('updated', async payload => {
+      this.flushDeferredEntries()
+    })
+
     this.emit(StorageEvents.USER_PROFILES_STORED, {
       profiles: await this.getUserProfiles(),
     })

--- a/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
+++ b/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
@@ -47,7 +47,7 @@ export class UserProfileStore extends EncryptedKeyValueStoreBase<EncryptedAndSig
         profiles: await this.getUserProfiles(),
       })
     })
-
+    this.flushDeferredEntries()
     this.emit(StorageEvents.USER_PROFILES_STORED, {
       profiles: await this.getUserProfiles(),
     })
@@ -59,11 +59,19 @@ export class UserProfileStore extends EncryptedKeyValueStoreBase<EncryptedAndSig
   }
 
   public async flushDeferredEntries() {
-    if (!this.auth.team || this.deferredProfiles.length === 0) return
-    if (!this.auth.team.memberHasRole(this.auth.user.userId, RoleName.MEMBER)) {
-      logger.error('User does not have permission to write to the user profiles store')
+    if (this.deferredProfiles.length === 0) {
+      logger.info('No deferred user profiles to flush')
       return
     }
+    if (!this.auth.team) {
+      logger.info('No team found, cannot flush deferred user profiles')
+      return
+    }
+    if (!this.auth.team.memberHasRole(this.auth.user.userId, RoleName.MEMBER)) {
+      logger.warn('User does not have permission to write to the user profiles store')
+      return
+    }
+    logger.info('Flushing deferred user profiles:', this.deferredProfiles.length)
 
     for (const profile of this.deferredProfiles) {
       try {


### PR DESCRIPTION
Fixes the event listeners for flushing deferred entries to the userProfile store

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
