### PR TITLE
chore: E2E test fixes and tweaks

### DIFF
--- a/.github/workflows/e2e-back-compat-linux.yml
+++ b/.github/workflows/e2e-back-compat-linux.yml
@@ -1,4 +1,4 @@
-name: E2E linux
+name: E2E linux (Backwards Compatibility)
 
 on: [workflow_call]
 jobs:
@@ -67,30 +67,12 @@ jobs:
         working-directory: ./packages/e2e-tests/Quiet
         run: chmod +x $FILE_NAME
 
-      - name: Run one client test
+      - name: Run Backwards Compatibility test
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+        if: ${{ steps.major-ver.outputs.match == 'false' }}
         with:
           timeout_minutes: 15
           max_attempts: 3
-          command: cd packages/e2e-tests && npm run test oneClient.test.ts
-
-      - name: Run user profile test
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 25
-          max_attempts: 3
-          command: cd packages/e2e-tests && npm run test userProfile.test.ts
-
-      - name: Run multiple clients test
-        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
-        with:
-          timeout_minutes: 25
-          max_attempts: 3
-          command: cd packages/e2e-tests && npm run test multipleClients.test.ts
-
-      - name: Run invitation link test - Includes 2 separate application clients
-        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
-        with:
-          timeout_minutes: 25
-          max_attempts: 1
-          command: cd packages/e2e-tests && npm run test invitationLink.test.ts
+          command: |
+            echo "Running backwards compatibility test for branch $GITHUB_HEAD_REF"
+            cd packages/e2e-tests && npm run test backwardsCompatibility.test.ts

--- a/.github/workflows/e2e-crossplatform.yml
+++ b/.github/workflows/e2e-crossplatform.yml
@@ -15,6 +15,10 @@ jobs:
     uses: ./.github/workflows/e2e-mac.yml
   linux:
     uses: ./.github/workflows/e2e-linux.yml
-  windows:
-    uses: ./.github/workflows/e2e-win.yml
+  # separated out from other linux tests since this fails the most
+  linux-back-compat:
+    uses: ./.github/workflows/e2e-back-compat-linux.yml
+  # the windows runners are garbage and always fail on long running tests (sometimes don't even make it past setup)
+  # windows:
+  #   uses: ./.github/workflows/e2e-win.yml
     

--- a/.github/workflows/e2e-mac.yml
+++ b/.github/workflows/e2e-mac.yml
@@ -3,7 +3,7 @@ name: E2E Mac
 on: [workflow_call]
 jobs:
   mac:
-    runs-on: macos-13
+    runs-on: macos-15
     timeout-minutes: 180
     env:
       TEST_MODE: true
@@ -36,7 +36,7 @@ jobs:
 
       - name: FILE_NAME env
         working-directory: ./packages/desktop/dist
-        run: echo "FILE_NAME="Quiet-$VERSION.dmg"" >> $GITHUB_ENV
+        run: echo "FILE_NAME="Quiet-$VERSION-arm64.dmg"" >> $GITHUB_ENV
 
       - name: List dist dir content
         working-directory: ./packages/desktop/dist
@@ -51,7 +51,7 @@ jobs:
         run: hdiutil mount $FILE_NAME
 
       - name: Add App file to applications
-        run: cd ~ && cp -R "/Volumes/Quiet $VERSION/Quiet.app" /Applications
+        run: cd ~ && cp -R "/Volumes/Quiet $VERSION-arm64/Quiet.app" /Applications
 
       - name: Run one client test
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start:desktop": "lerna run --scope @quiet/desktop start",
     "lint:all": "lerna run lint",
     "distAndRunE2ETests:mac:local": "lerna run --scope @quiet/desktop distMac:local && npm run e2e:mac:local",
+    "distAndRunE2ETests:linux:local": "npm run e2e:linux:build && npm run e2e:linux:run",
     "e2e:mac:local": "lerna run --scope e2e-tests test:localBinary --",
     "e2e:linux:build": "lerna run --scope @quiet/backend webpack:prod && lerna run --scope @quiet/desktop distUbuntu && lerna run --scope e2e-tests linux:copy",
     "e2e:linux:run": "lerna run --scope e2e-tests test --",

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -143,7 +143,7 @@
     "../../3rd-party/js-libp2p-noise/dist/src": {},
     "../../3rd-party/orbitdb": {
       "name": "@orbitdb/core",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.6",
@@ -164,7 +164,7 @@
         "c8": "^8.0.1",
         "cross-env": "^7.0.3",
         "fs-extra": "^11.2.0",
-        "helia": "^5.1.0",
+        "helia": "^5.2.1",
         "it-all": "^3.0.4",
         "jsdoc": "^4.0.2",
         "mocha": "^10.2.0",

--- a/packages/e2e-tests/src/selectors.ts
+++ b/packages/e2e-tests/src/selectors.ts
@@ -822,7 +822,7 @@ export class Channel {
     return undefined
   }
 
-  get getAllMessages() {
+  public async getAllMessages() {
     return this.driver.wait(
       until.elementsLocated(By.xpath('//*[contains(@data-testid, "userMessages-")]')),
       15_000,
@@ -1444,7 +1444,7 @@ export class UpdateModal {
     logger.info('Waiting for update modal root element')
     return this.driver.wait(
       until.elementLocated(By.xpath("//h3[text()='Software update']/ancestor::div[contains(@class,'MuiModal-root')]")),
-      15_000,
+      20_000,
       `Update modal couldn't be found within timeout`,
       500
     )
@@ -1605,6 +1605,7 @@ export class Settings {
 
   async closeTabThenModal() {
     await this.closeTab()
+    await sleep(1_000)
     await this.close()
   }
 

--- a/packages/e2e-tests/src/tests/backwardsCompatibility.test.ts
+++ b/packages/e2e-tests/src/tests/backwardsCompatibility.test.ts
@@ -1,4 +1,7 @@
 import { WebElement } from 'selenium-webdriver'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+
 import {
   App,
   Channel,
@@ -10,7 +13,7 @@ import {
   Sidebar,
 } from '../selectors'
 import { MessageIds } from '../types'
-import { BACKWARD_COMPATIBILITY_BASE_VERSION, BuildSetup, copyInstallerFile, downloadInstaller } from '../utils'
+import { BACKWARD_COMPATIBILITY_BASE_VERSION, BuildSetup, copyInstallerFile, downloadInstaller, sleep } from '../utils'
 import { createLogger } from '../logger'
 
 const logger = createLogger('backwardsCompatibility')
@@ -24,16 +27,16 @@ describe('Backwards Compatibility', () => {
   let ownerAppNewVersion: App
   let generalChannel: Channel
   let secondChannel: Channel
-  let messagesToCompare: WebElement[]
+  const messagesToCompare: Map<string, WebElement[]> = new Map()
   let sidebar: Sidebar
   let generalChannelMessageIds: MessageIds
-  let secondChannelMessageIds: MessageIds
+  let dataDir: string
 
-  const dataDir = `e2e_${(Math.random() * 10 ** 18).toString(36)}`
   const communityName = 'testcommunity'
   const ownerUsername = 'bob'
   const ownerMessages = ['Hi', 'Hello', 'After guest leave app']
   const loopMessages = 'ąbc'.split('')
+  const generalChannelName = 'general'
   const newChannelName = 'mid-night-club'
 
   const isAlpha = BuildSetup.getEnvFileName()?.toString().includes('alpha')
@@ -42,6 +45,7 @@ describe('Backwards Compatibility', () => {
     // download the old version of the app
     const appFilename = downloadInstaller()
     const copiedFilename = copyInstallerFile(appFilename)
+    dataDir = `e2e_back_compat_${(Math.random() * 10 ** 18).toString(36)}`
     ownerAppOldVersion = new App({ dataDir, fileName: copiedFilename })
   })
 
@@ -51,160 +55,206 @@ describe('Backwards Compatibility', () => {
 
   afterAll(async () => {
     await ownerAppNewVersion?.close()
-    await ownerAppNewVersion?.cleanup()
+    await ownerAppNewVersion?.cleanup(true)
     await ownerAppOldVersion?.close()
-    await ownerAppOldVersion?.cleanup()
+    await ownerAppOldVersion?.cleanup(true)
   })
 
-  describe('User opens app for the first time', () => {
-    itif(process.platform == 'linux')('Owner opens the app', async () => {
-      await ownerAppOldVersion.open()
-    })
+  describe(`Old version - ${BACKWARD_COMPATIBILITY_BASE_VERSION}`, () => {
+    describe(`Owner opens older version of the app`, () => {
+      itif(process.platform == 'linux')('Owner opens the app', async () => {
+        await ownerAppOldVersion.open()
+      })
 
-    itif(process.platform == 'linux')('Owner closes "update available" modal if present', async () => {
-      ownerAppOldVersion
-        .closeUpdateModalIfPresent()
-        .then(async () => {
-          console.log('Closed update modal')
-        })
-        .catch(err => {
-          console.log('Could not close update modal', err)
-        })
-    })
-
-    itif(process.platform == 'linux')(
-      'Owner sees "join community" modal and switches to "create community" modal',
-      async () => {
-        const joinModal = new JoinCommunityModal(ownerAppOldVersion.driver)
-        expect(await joinModal.isReady()).toBeTruthy()
-        await joinModal.switchToCreateCommunity()
-      }
-    )
-
-    itif(process.platform == 'linux')('Owner submits valid community name', async () => {
-      const createModal = new CreateCommunityModal(ownerAppOldVersion.driver)
-      expect(await createModal.isReady()).toBeTruthy()
-      await createModal.typeCommunityName(communityName)
-      await createModal.submit()
-    })
-
-    itif(process.platform == 'linux')('Owner sees "register username" modal and submits valid username', async () => {
-      const registerModal = new RegisterUsernameModal(ownerAppOldVersion.driver)
-      expect(await registerModal.isReady()).toBeTruthy()
-      await registerModal.typeUsername(ownerUsername)
-      await registerModal.submit()
-    })
-
-    itif(process.platform == 'linux')('Owner waits for join to complete', async () => {
-      const joinPanel = new JoiningLoadingPanel(ownerAppOldVersion.driver)
-      await joinPanel.waitForJoinToComplete()
-    })
-
-    itif(process.platform == 'linux')('Owner registers successfully and sees general channel', async () => {
-      generalChannel = new Channel(ownerAppOldVersion.driver, 'general')
-      expect(await generalChannel.isReady()).toBeTruthy()
-
-      const generalChannelText = await generalChannel.element.getText()
-      expect(generalChannelText).toEqual('# general')
-    })
-
-    itif(process.platform == 'linux')(`Verify version - ${BACKWARD_COMPATIBILITY_BASE_VERSION}`, async () => {
-      const settingsModal = await new Sidebar(ownerAppOldVersion.driver).openSettings()
-      expect(await settingsModal.isReady()).toBeTruthy()
-      const settingVersion = await settingsModal.getVersion()
-      expect(settingVersion).toEqual(BACKWARD_COMPATIBILITY_BASE_VERSION)
-      await settingsModal.close()
-    })
-
-    itif(process.platform == 'linux')('Owner sends a message in the general channel', async () => {
-      expect(await generalChannel.isMessageInputReady()).toBeTruthy()
-      generalChannelMessageIds = await generalChannel.sendMessage(ownerMessages[0], ownerUsername)
-    })
-
-    itif(process.platform == 'linux')('Sent message is visible on general channel', async () => {
-      const messages = await generalChannel.getUserMessages(ownerUsername)
-      const text = await messages[1].getText()
-      expect(text).toEqual(ownerMessages[0])
-    })
-
-    itif(process.platform == 'linux')('Owner creates second channel', async () => {
-      sidebar = new Sidebar(ownerAppOldVersion.driver)
-      await sidebar.addNewChannel(newChannelName)
-      await sidebar.switchChannel(newChannelName)
-      const channels = await sidebar.getChannelList()
-      expect(channels.length).toEqual(2)
-    })
-
-    itif(process.platform == 'linux')('Owner sends a message in second channel', async () => {
-      secondChannel = new Channel(ownerAppOldVersion.driver, newChannelName)
-      expect(await secondChannel.isMessageInputReady()).toBeTruthy()
-      secondChannelMessageIds = await secondChannel.sendMessage(ownerMessages[1], ownerUsername)
-    })
-
-    itif(process.platform == 'linux')('Message is visible in second channel', async () => {
-      const messages = await secondChannel.getUserMessages(ownerUsername)
-      const text = await messages[1].getText()
-      expect(text).toEqual(ownerMessages[1])
-    })
-
-    itif(process.platform == 'linux')(
-      `User sends another ${loopMessages.length} messages to second channel`,
-      async () => {
-        for (const message of loopMessages) {
-          await secondChannel.sendMessage(message, ownerUsername)
+      itif(process.platform == 'linux')('Owner closes "update available" modal if present', async () => {
+        try {
+          await ownerAppOldVersion.closeUpdateModalIfPresent()
+          logger.info('Closed update modal')
+        } catch (e) {
+          logger.warn('Could not close update modal', e)
         }
+      })
 
-        messagesToCompare = await secondChannel.getUserMessages(ownerUsername)
-      }
-    )
-    itif(process.platform == 'linux')('User closes the old app', async () => {
-      await ownerAppOldVersion.close()
+      itif(process.platform == 'linux')(
+        'Owner sees "join community" modal and switches to "create community" modal',
+        async () => {
+          const joinModal = new JoinCommunityModal(ownerAppOldVersion.driver)
+          expect(await joinModal.isReady()).toBeTruthy()
+          await joinModal.switchToCreateCommunity()
+        }
+      )
+
+      itif(process.platform == 'linux')('Owner submits valid community name', async () => {
+        const createModal = new CreateCommunityModal(ownerAppOldVersion.driver)
+        expect(await createModal.isReady()).toBeTruthy()
+        await createModal.typeCommunityName(communityName)
+        await createModal.submit()
+      })
+
+      itif(process.platform == 'linux')('Owner sees "register username" modal and submits valid username', async () => {
+        const registerModal = new RegisterUsernameModal(ownerAppOldVersion.driver)
+        expect(await registerModal.isReady()).toBeTruthy()
+        await registerModal.typeUsername(ownerUsername)
+        await registerModal.submit()
+      })
+
+      itif(process.platform == 'linux')('Owner waits for join to complete', async () => {
+        const joinPanel = new JoiningLoadingPanel(ownerAppOldVersion.driver)
+        await joinPanel.waitForJoinToComplete()
+        try {
+          await ownerAppOldVersion.closeUpdateModalIfPresent()
+          logger.info('Closed update modal')
+        } catch (e) {
+          logger.warn('Could not close update modal', e)
+        }
+      })
+
+      itif(process.platform == 'linux')('Owner registers successfully and sees general channel', async () => {
+        generalChannel = new Channel(ownerAppOldVersion.driver, 'general')
+        expect(await generalChannel.isReady()).toBeTruthy()
+
+        const generalChannelText = await generalChannel.element.getText()
+        expect(generalChannelText).toEqual('# general')
+      })
+
+      itif(process.platform == 'linux')(`Verify version - ${BACKWARD_COMPATIBILITY_BASE_VERSION}`, async () => {
+        const settingsModal = await new Sidebar(ownerAppOldVersion.driver).openSettings()
+        expect(await settingsModal.isReady()).toBeTruthy()
+        const settingVersion = await settingsModal.getVersion()
+        expect(settingVersion).toEqual(BACKWARD_COMPATIBILITY_BASE_VERSION)
+        await settingsModal.closeTabThenModal()
+      })
     })
 
-    // ________________________________
+    describe('Owner sends a message', () => {
+      itif(process.platform == 'linux')('Owner sends a message in the general channel', async () => {
+        expect(await generalChannel.isMessageInputReady()).toBeTruthy()
+        generalChannelMessageIds = await generalChannel.sendMessage(ownerMessages[0], ownerUsername)
+      })
 
-    itif(process.platform == 'linux')('Owner opens the app in new version', async () => {
-      logger.info('New version', 1)
-      ownerAppNewVersion = new App({ dataDir })
-      await ownerAppNewVersion.open()
+      itif(process.platform == 'linux')('Sent message is visible on general channel', async () => {
+        const messages = await generalChannel.getUserMessages(ownerUsername)
+        const text = await messages[1].getText()
+        expect(text).toEqual(ownerMessages[0])
+        expect(messages.length).toBe(2)
+        messagesToCompare.set(generalChannelName, messages)
+      })
     })
 
-    if (isAlpha) {
+    describe('Second channel', () => {
+      itif(process.platform == 'linux')('Owner creates second channel', async () => {
+        sidebar = new Sidebar(ownerAppOldVersion.driver)
+        await sidebar.addNewChannel(newChannelName)
+        await sidebar.switchChannel(newChannelName)
+        const channels = await sidebar.getChannelList()
+        expect(channels.length).toEqual(2)
+      })
+
+      itif(process.platform == 'linux')('Owner sends a message in second channel', async () => {
+        secondChannel = new Channel(ownerAppOldVersion.driver, newChannelName)
+        expect(await secondChannel.isMessageInputReady()).toBeTruthy()
+        await secondChannel.sendMessage(ownerMessages[1], ownerUsername)
+      })
+
+      itif(process.platform == 'linux')('Message is visible in second channel', async () => {
+        const messages = await secondChannel.getUserMessages(ownerUsername)
+        const text = await messages[1].getText()
+        expect(text).toEqual(ownerMessages[1])
+      })
+
+      itif(process.platform == 'linux')(
+        `Owner sends another ${loopMessages.length} messages to second channel`,
+        async () => {
+          for (const message of loopMessages) {
+            await secondChannel.sendMessage(message, ownerUsername)
+          }
+
+          messagesToCompare.set(newChannelName, await secondChannel.getUserMessages(ownerUsername))
+        }
+      )
+    })
+  })
+
+  describe('New version', () => {
+    describe('Owner opens new version', () => {
+      itif(process.platform == 'linux')('Owner closes the old app', async () => {
+        await ownerAppOldVersion.close({ forceSaveState: true })
+      })
+
+      itif(process.platform == 'linux')('Owner opens the app in new version', async () => {
+        ownerAppNewVersion = new App({ dataDir })
+        await ownerAppNewVersion.openWithRetries({ timeoutMs: 60_000, attempts: 3 })
+      })
+
       itif(process.platform == 'linux')('Owner closes debug modal if opened', async () => {
-        logger.info('New version', 2)
         const debugModal = new DebugModeModal(ownerAppNewVersion.driver)
         await debugModal.close()
+        await sleep(30_000)
       })
-    }
 
-    itif(process.platform == 'linux')('Owener sees general channel', async () => {
-      logger.info('New version', 3)
-      generalChannel = new Channel(ownerAppNewVersion.driver, 'general')
-      expect(await generalChannel.isReady()).toBeTruthy()
+      itif(process.platform == 'linux')('Owner closes update modal if opened', async () => {
+        try {
+          await ownerAppNewVersion.closeUpdateModalIfPresent()
+          logger.info('Closed update modal')
+        } catch (e) {
+          // do nothing
+        }
+      })
 
-      const generalChannelText = await generalChannel.element.getText()
-      expect(generalChannelText).toEqual('# general')
+      itif(process.platform == 'linux')('Owner waits for app to finish loading', async () => {
+        generalChannel = new Channel(ownerAppNewVersion.driver, 'general')
+        expect(await generalChannel.isReady()).toBeTruthy()
+        expect(await generalChannel.isOpen()).toBeTruthy()
+        expect(await generalChannel.isMessageInputReady()).toBeTruthy()
+      })
+
+      itif(process.platform == 'linux')('Confirm that the opened app is the latest version', async () => {
+        const settingsModal = await new Sidebar(ownerAppNewVersion.driver).openSettings()
+        expect(await settingsModal.isReady()).toBeTruthy()
+        const settingVersion = await settingsModal.getVersion()
+        const envVersion = ownerAppNewVersion.buildSetup.getVersionFromEnv()
+        expect(settingVersion).toEqual(envVersion)
+        await settingsModal.closeTabThenModal()
+      })
     })
 
-    itif(process.platform == 'linux')('Confirm that the opened app is the latest version', async () => {
-      logger.info('New version', 4)
-      const settingsModal = await new Sidebar(ownerAppNewVersion.driver).openSettings()
-      expect(await settingsModal.isReady()).toBeTruthy()
-      const settingVersion = await settingsModal.getVersion()
-      const envVersion = ownerAppNewVersion.buildSetup.getVersionFromEnv()
-      expect(settingVersion).toEqual(envVersion)
-      await settingsModal.close()
-    })
+    describe('Verify channels', () => {
+      itif(process.platform == 'linux')('Owner sees general channel on new version', async () => {
+        generalChannel = new Channel(ownerAppNewVersion.driver, 'general')
+        expect(await generalChannel.isReady()).toBeTruthy()
+        expect(await generalChannel.isOpen()).toBeTruthy()
+        expect(await generalChannel.isMessageInputReady()).toBeTruthy()
 
-    itif(process.platform == 'linux')('Check number of messages on second channel', async () => {
-      logger.info('New version', 5)
-      sidebar = new Sidebar(ownerAppNewVersion.driver)
-      await sidebar.switchChannel(newChannelName)
-      secondChannel = new Channel(ownerAppNewVersion.driver, newChannelName)
-      expect(await secondChannel.isReady()).toBeTruthy()
+        const generalChannelText = await generalChannel.element.getText()
+        expect(generalChannelText).toEqual('# general')
+      })
 
-      const currentMessages = await secondChannel.getUserMessages(ownerUsername)
-      expect(currentMessages.length).toEqual(messagesToCompare.length)
+      itif(process.platform == 'linux')('Sent message is visible on general channel on new version', async () => {
+        const messages = await generalChannel.getUserMessages(ownerUsername)
+        const text = await messages[1].getText()
+        expect(text).toEqual(ownerMessages[0])
+        expect(messages.length).toEqual(messagesToCompare.get(generalChannelName)!.length)
+      })
+
+      itif(process.platform == 'linux')('Verify number of channels', async () => {
+        sidebar = new Sidebar(ownerAppNewVersion.driver)
+        const channels = await sidebar.getChannelList()
+        expect(channels.length).toEqual(2)
+      })
+
+      itif(process.platform == 'linux')('Switch to second channel', async () => {
+        sidebar = new Sidebar(ownerAppNewVersion.driver)
+        await sidebar.switchChannel(newChannelName)
+        secondChannel = new Channel(ownerAppNewVersion.driver, newChannelName)
+        expect(await secondChannel.isReady()).toBeTruthy()
+        expect(await secondChannel.isOpen()).toBeTruthy()
+        expect(await secondChannel.isMessageInputReady()).toBeTruthy()
+      })
+
+      itif(process.platform == 'linux')('Check number of messages on second channel', async () => {
+        const messagesOnNewVersion = await secondChannel.getUserMessages(ownerUsername)
+        expect(messagesOnNewVersion.length).toEqual(messagesToCompare.get(newChannelName)!.length)
+      })
     })
   })
 })

--- a/packages/e2e-tests/src/tests/multipleClients.test.ts
+++ b/packages/e2e-tests/src/tests/multipleClients.test.ts
@@ -656,7 +656,8 @@ describe('Multiple Clients', () => {
 
     describe('Guest Closes App', () => {
       it('Owner closes app', async () => {
-        await users.owner.app.close({ forceSaveState: true })
+        const forceSaveState = process.platform !== 'darwin'
+        await users.owner.app.close({ forceSaveState })
       })
 
       it('Guest closes app', async () => {

--- a/packages/e2e-tests/src/utils.ts
+++ b/packages/e2e-tests/src/utils.ts
@@ -47,6 +47,7 @@ export class BuildSetup {
       this.dataDir = `e2e_${this.id}`
     }
     this.dataDirPath = getAppDataPath({ dataDir: this.dataDir })
+    logger.info('Running app from directory', this.dataDirPath)
   }
 
   async initPorts() {

--- a/packages/e2e-tests/src/utils.ts
+++ b/packages/e2e-tests/src/utils.ts
@@ -13,7 +13,7 @@ import { createLogger } from './logger'
 
 const logger = createLogger('utils')
 
-export const BACKWARD_COMPATIBILITY_BASE_VERSION = '4.0.2' // Pre-latest production version
+export const BACKWARD_COMPATIBILITY_BASE_VERSION = '5.0.0' // version to test against
 const appImagesPath = `${__dirname}/../Quiet`
 
 export interface BuildSetupInit {
@@ -62,18 +62,25 @@ export class BuildSetup {
     return process.env.FILE_NAME
   }
 
-  private getBinaryLocation() {
+  private getBinaryLocation(): string {
+    let binaryPath: string | undefined = undefined
     switch (process.platform) {
       case 'linux':
         logger.info('filename', this.fileName)
-        return `${__dirname}/../Quiet/${this.fileName ? this.fileName : BuildSetup.getEnvFileName()}`
+        binaryPath = `${__dirname}/../Quiet/${this.fileName ? this.fileName : BuildSetup.getEnvFileName()}`
+        break
       case 'win32':
-        return `${process.env.LOCALAPPDATA}\\Programs\\@quietdesktop\\Quiet.exe`
+        binaryPath = `${process.env.LOCALAPPDATA}\\Programs\\@quietdesktop\\Quiet.exe`
+        break
       case 'darwin':
-        return this.getMacBinaryDir()
+        binaryPath = this.getMacBinaryDir()
+        break
       default:
-        throw new Error('wrong SYSTEM env')
+        throw new Error(`Running on unsupported platform ${process.platform}`)
     }
+
+    logger.info('Found binary path', binaryPath, process.platform, this.fileName)
+    return binaryPath
   }
 
   private getMacBinaryDir(): string {

--- a/packages/e2e-tests/src/utils.ts
+++ b/packages/e2e-tests/src/utils.ts
@@ -117,8 +117,11 @@ export class BuildSetup {
 
   public async createChromeDriver() {
     await this.initPorts()
-    const env = {
-      DEBUG: 'backend*,quiet*,state-manager*,desktop*,utils*,identity*,common*,main,libp2p:*',
+    const env: any = {
+      DEBUG:
+        process.env.TRACE_APP_LOGS === 'true'
+          ? '*:trace'
+          : 'backend*,quiet*,state-manager*,desktop*,utils*,identity*,common*,main,libp2p:*',
       DATA_DIR: this.dataDir,
       STATIC_LOG_ID: this.id,
     }


### PR DESCRIPTION
* Fixes backwards compatibility test
* Switches mac e2e tests to use M1 runner
* Small tweaks to fix reliability of mac e2e tests in CI
* Separate backwards compatibility test from other linux tests because it is historically the least reliable

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
