### PR TITLE
Update storage locations for version 6.0.0

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -106,8 +106,11 @@ QA will test according to the following checklists:
 
 ## Breaking changes
 
-While Quiet is in its early stages and does not have known communities of active users, we have the luxury of releasing breaking changes, e.g. changes that require users to start a new community. 
+While Quiet is in its early stages and does not have known communities of active users, we have the luxury of releasing breaking changes, e.g. changes that require users to start a new community. However, we still take some reasonable steps to make breaking changes comfortable for users.
 
-1. Do not automatically update Desktop users. Instead, follow the approach in this issue: https://github.com/TryQuiet/quiet/issues/2039 (make a final release with message asking them to update manually, and use a new default storage location, e.g. "Quiet 4", so that users can potentially run both versions side-by-side to access old messages.) 
+1. Update storage location on Desktop (see: https://github.com/TryQuiet/quiet/pull/2829) and Mobile (see: https://github.com/TryQuiet/quiet/pull/2831/files).
+2. Create a new S3 bucket for the new major release (the new release will fail without this step)
+3. Once the new release is available for download on our website, push a final release of the previous major branch with a notice to desktop users (e.g: https://github.com/TryQuiet/quiet/pull/2827)
+4. Do not automatically update iOS users
 2. Do not automatically update iOS users. Instead, create a new release branch in TestFlight such that users must update manually. See: https://github.com/TryQuiet/quiet/issues/1980
 3. On Android, we currently have no great way to avoid automatic updates. In this case, decide whether to show a message a few days or weeks in advance, or not. See: https://github.com/TryQuiet/quiet/issues/1980#issuecomment-1795028313

--- a/packages/common/src/const.ts
+++ b/packages/common/src/const.ts
@@ -1,5 +1,5 @@
 export const DESKTOP_DEV_DATA_DIR = 'Quietdev'
-export const DESKTOP_DATA_DIR = 'Quiet5'
+export const DESKTOP_DATA_DIR = 'Quiet6'
 
 export enum Site {
   DOMAIN = 'tryquiet.org',

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
@@ -108,7 +108,7 @@ public class CommunicationModule extends ReactContextBaseJavaModule {
     private static void deleteBackendData() {
         Context context = reactContext.getApplicationContext();
         try {
-            FileUtils.deleteDirectory(new File(context.getFilesDir(), "backend/files5"));
+            FileUtils.deleteDirectory(new File(context.getFilesDir(), "backend/files6"));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Utils/Utils.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Utils/Utils.kt
@@ -24,7 +24,7 @@ object Utils {
     }
 
     fun createDirectory(context: Context): String {
-        val dataDirectory = File(context.filesDir, "backend/files5")
+        val dataDirectory = File(context.filesDir, "backend/files6")
         dataDirectory.mkdirs()
 
         return dataDirectory.absolutePath

--- a/packages/mobile/ios/DataDirectory.swift
+++ b/packages/mobile/ios/DataDirectory.swift
@@ -6,7 +6,7 @@ class DataDirectory: NSObject {
     let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
     let documentsDirectory = paths[0]
     let docURL = URL(string: documentsDirectory)!
-    let dataPath = docURL.appendingPathComponent("backend/files5")
+    let dataPath = docURL.appendingPathComponent("backend/files6")
     if !FileManager.default.fileExists(atPath: dataPath.path) {
       do {
         try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)


### PR DESCRIPTION
## Summary
- Updated storage locations to use version 6 directories to allow side-by-side installation with version 5

## Changes
- Desktop: Changed from 'Quiet5' to 'Quiet6' in `packages/common/src/const.ts`
- Android: Changed from "backend/files5" to "backend/files6" in:
  - `packages/mobile/android/app/src/main/java/com/quietmobile/Utils/Utils.kt`
  - `packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java`
- iOS: Changed from "backend/files5" to "backend/files6" in `packages/mobile/ios/DataDirectory.swift`

## Context
This implements the breaking changes policy documented in PUBLISHING.md, allowing users to run both versions side-by-side to access old messages while transitioning to the new version.

🤖 Generated with [Claude Code](https://claude.ai/code)