### PR TITLE
Final 5.x release with deprecation notice

### DIFF
--- a/packages/desktop/src/renderer/containers/widgets/breakingChangesWarning/BreakingChangesWarning.tsx
+++ b/packages/desktop/src/renderer/containers/widgets/breakingChangesWarning/BreakingChangesWarning.tsx
@@ -15,10 +15,14 @@ const BreakingChangesWarning = () => {
 
   const title = 'Update available'
   const message =
-    'Quiet’s next release makes joining communities faster and more reliable by letting people join when the owner is offline! 🎉 However, these changes are not backwards compatible, so you must re-install Quiet from tryquiet.org and re-create or re-join your community. 😥 This version of Quiet will no longer receive any updates or security fixes, so please re-install soon. We apologize for the inconvenience.'
+    'Quiet 6.0 includes a security fix that is not backwards compatible, so you must re-install Quiet from tryquiet.org and re-create or re-join your community. This version of Quiet (5.x) will no longer receive any updates or security fixes, so please re-install soon. We apologize for the inconvenience.'
 
   const updateAction = useCallback(() => {
     shell.openExternal(`${Site.MAIN_PAGE}#Downloads`)
+  }, [])
+
+  useEffect(() => {
+    modal.handleOpen() // Open modal once per app start
   }, [])
 
   const updateButton = (
@@ -35,7 +39,7 @@ const BreakingChangesWarning = () => {
       }}
       fullWidth
     >
-      Install Quiet 2.x
+      Install Quiet 6.x
     </Button>
   )
 


### PR DESCRIPTION
## Summary
- Adds deprecation notice for 5.x users informing them about the security fix in 6.0
- Shows modal on app startup directing users to download Quiet 6.x from tryquiet.org
- This is the final release for the 5.x branch

## Context
Following the pattern from the final 4.x release, this PR adds a breaking changes warning modal that will inform users they need to upgrade to Quiet 6.0.

## Test plan
- [ ] Build and run Quiet from this branch
- [ ] Verify the deprecation modal appears on startup
- [ ] Verify the "Install Quiet 6.x" button opens the download page
- [ ] Verify the "Later" button dismisses the modal

🤖 Generated with [Claude Code](https://claude.ai/code)