### PR TITLE
Persist skin tone in local storage

### DIFF
--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -91,7 +91,7 @@
         "electron-builder": "^23.6.0",
         "electron-devtools-installer": "^3.1.1",
         "electron-store-webpack-wrapper": "^0.0.2",
-        "emoji-picker-react": "^4.4.5",
+        "emoji-picker-react": "^4.12.2",
         "enzyme": "^3.8.0",
         "enzyme-to-json": "^3.3.5",
         "factory-girl": "^5.0.4",
@@ -25404,12 +25404,12 @@
       }
     },
     "node_modules/emoji-picker-react": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.4.5.tgz",
-      "integrity": "sha512-0iwtqg2WyNIQ+uCUUlEQ/UlJ8uOLbAo7jZ5MX0VEYe/NXsrphIQHZhuwC1h85REsCI9eYj60yuGIdvzFRnOkmQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.13.2.tgz",
+      "integrity": "sha512-azaJQLTshEOZVhksgU136izJWJyZ4Clx6xQ6Vctzk1gOdPPAUbTa/JYDwZJ8rh97QxnjpyeftXl99eRlYr3vNA==",
       "dev": true,
       "dependencies": {
-        "clsx": "^1.2.1"
+        "flairup": "1.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -25417,6 +25417,12 @@
       "peerDependencies": {
         "react": ">=16"
       }
+    },
+    "node_modules/emoji-picker-react/node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
@@ -66159,12 +66165,20 @@
       "dev": true
     },
     "emoji-picker-react": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.4.5.tgz",
-      "integrity": "sha512-0iwtqg2WyNIQ+uCUUlEQ/UlJ8uOLbAo7jZ5MX0VEYe/NXsrphIQHZhuwC1h85REsCI9eYj60yuGIdvzFRnOkmQ==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.13.2.tgz",
+      "integrity": "sha512-azaJQLTshEOZVhksgU136izJWJyZ4Clx6xQ6Vctzk1gOdPPAUbTa/JYDwZJ8rh97QxnjpyeftXl99eRlYr3vNA==",
       "dev": true,
       "requires": {
-        "clsx": "^1.2.1"
+        "flairup": "1.0.0"
+      },
+      "dependencies": {
+        "flairup": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+          "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -219,7 +219,7 @@
     "electron-devtools-installer": "^3.1.1",
     "electron-store": "^5.2.0",
     "electron-store-webpack-wrapper": "^0.0.2",
-    "emoji-picker-react": "^4.4.5",
+    "emoji-picker-react": "^4.12.2",
     "enzyme": "^3.8.0",
     "enzyme-to-json": "^3.3.5",
     "factory-girl": "^5.0.4",

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -227,19 +227,19 @@ export interface ChannelInputProps {
 }
 
 export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
-   channelId,
-   inputPlaceholder,
-   inputState = INPUT_STATE.AVAILABLE,
-   initialMessage = '',
-   onChange,
-   onKeyPress,
-   infoClass,
-   setInfoClass,
-   children,
-   openFilesDialog,
-   handleClipboardFiles,
-   handleOpenFiles,
- }) => {
+  channelId,
+  inputPlaceholder,
+  inputState = INPUT_STATE.AVAILABLE,
+  initialMessage = '',
+  onChange,
+  onKeyPress,
+  infoClass,
+  setInfoClass,
+  children,
+  openFilesDialog,
+  handleClipboardFiles,
+  handleOpenFiles,
+}) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const fileInput = React.useRef<HTMLInputElement>(null)
 

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -14,7 +14,7 @@ import emojiBlack from '../../../../static/images/emojiBlack.svg'
 import paperclipGray from '../../../../static/images/paperclipGray.svg'
 import paperclipBlack from '../../../../static/images/paperclipBlack.svg'
 import path from 'path'
-import { emojify, emojiShortcodes, extractPartialEmojiCode, findMatchingEmojis } from './utils/emojiCodes'
+import { emojify, findMatchingEmojis, extractPartialEmojiCode, emojiShortcodes } from './utils/emojiCodes'
 
 const PREFIX = 'ChannelInput'
 const MAX_EMOJI_SUGGESTIONS = 100
@@ -227,19 +227,19 @@ export interface ChannelInputProps {
 }
 
 export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
-                                                                     channelId,
-                                                                     inputPlaceholder,
-                                                                     inputState = INPUT_STATE.AVAILABLE,
-                                                                     initialMessage = '',
-                                                                     onChange,
-                                                                     onKeyPress,
-                                                                     infoClass,
-                                                                     setInfoClass,
-                                                                     children,
-                                                                     openFilesDialog,
-                                                                     handleClipboardFiles,
-                                                                     handleOpenFiles,
-                                                                   }) => {
+   channelId,
+   inputPlaceholder,
+   inputState = INPUT_STATE.AVAILABLE,
+   initialMessage = '',
+   onChange,
+   onKeyPress,
+   infoClass,
+   setInfoClass,
+   children,
+   openFilesDialog,
+   handleClipboardFiles,
+   handleOpenFiles,
+ }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const fileInput = React.useRef<HTMLInputElement>(null)
 
@@ -600,7 +600,7 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
                       ref={fileInput}
                       type='file'
                       onChange={handleFileInput}
-                      // Value needs to be cleared otherwise one can't upload same image twice
+                      // Value needs to be cleared otherwise one can't attach same image twice
                       onClick={e => {
                         ;(e.target as HTMLInputElement).value = ''
                       }} // TODO: check

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useCallback, useRef, useEffect } from 'react'
+import React, { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
-import Picker, { EmojiStyle, type Theme } from 'emoji-picker-react'
+import Picker, { EmojiStyle, SkinTones, type Theme } from 'emoji-picker-react'
 import Grid from '@mui/material/Grid'
 import { styled, useTheme } from '@mui/material/styles'
 import orange from '@mui/material/colors/orange'
@@ -14,10 +14,11 @@ import emojiBlack from '../../../../static/images/emojiBlack.svg'
 import paperclipGray from '../../../../static/images/paperclipGray.svg'
 import paperclipBlack from '../../../../static/images/paperclipBlack.svg'
 import path from 'path'
-import { emojify, findMatchingEmojis, extractPartialEmojiCode, emojiShortcodes } from './utils/emojiCodes'
+import { emojify, emojiShortcodes, extractPartialEmojiCode, findMatchingEmojis } from './utils/emojiCodes'
 
 const PREFIX = 'ChannelInput'
 const MAX_EMOJI_SUGGESTIONS = 100
+const SKIN_TONE_KEY = 'emojiPickerSkinTone'
 
 const classes = {
   root: `${PREFIX}root`,
@@ -226,19 +227,19 @@ export interface ChannelInputProps {
 }
 
 export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
-  channelId,
-  inputPlaceholder,
-  inputState = INPUT_STATE.AVAILABLE,
-  initialMessage = '',
-  onChange,
-  onKeyPress,
-  infoClass,
-  setInfoClass,
-  children,
-  openFilesDialog,
-  handleClipboardFiles,
-  handleOpenFiles,
-}) => {
+                                                                     channelId,
+                                                                     inputPlaceholder,
+                                                                     inputState = INPUT_STATE.AVAILABLE,
+                                                                     initialMessage = '',
+                                                                     onChange,
+                                                                     onKeyPress,
+                                                                     infoClass,
+                                                                     setInfoClass,
+                                                                     children,
+                                                                     openFilesDialog,
+                                                                     handleClipboardFiles,
+                                                                     handleOpenFiles,
+                                                                   }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
   const fileInput = React.useRef<HTMLInputElement>(null)
 
@@ -454,6 +455,20 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
     handleOpenFiles({ files: Object.values(target.files) })
   }
 
+  const handleSkinToneChange = (newTone: SkinTones) => {
+    setSkinTone(newTone)
+    localStorage.setItem(SKIN_TONE_KEY, newTone)
+  }
+
+  const [skinTone, setSkinTone] = useState(SkinTones.NEUTRAL)
+
+  useEffect(() => {
+    const savedTone = localStorage.getItem(SKIN_TONE_KEY)
+    if (savedTone) {
+      setSkinTone(savedTone as SkinTones)
+    }
+  }, [])
+
   return (
     <StyledChannelInput
       className={classNames({
@@ -585,7 +600,7 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
                       ref={fileInput}
                       type='file'
                       onChange={handleFileInput}
-                      // Value needs to be cleared otherwise one can't attach same image twice
+                      // Value needs to be cleared otherwise one can't upload same image twice
                       onClick={e => {
                         ;(e.target as HTMLInputElement).value = ''
                       }} // TODO: check
@@ -626,6 +641,8 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
                           // Every other emojiStyle causes downloading emojis from cdn. We do not want that.
                           // Do not change it unless using custom getEmojiUrl with local emojis.
                           emojiStyle={EmojiStyle.NATIVE}
+                          defaultSkinTone={skinTone}
+                          onSkinToneChange={handleSkinToneChange} // persist changes
                           theme={theme.palette.mode as Theme}
                         />
                       </div>


### PR DESCRIPTION
emoji-picker-react callback was only [added](https://github.com/ealush/emoji-picker-react/issues/394) in 4.9 so also update the dependency to a more recent version.

### Pull Request Checklist

- [x] I have linked this PR to a related [GitHub issue](https://github.com/TryQuiet/quiet/issues/2794).
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).
