### PR TITLE
Feat: Use skinTone in emoji shortcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * User profiles and their connection status now appear in the sidebar [#2920](https://github.com/TryQuiet/quiet/issues/2920)
 * In development mode, a debug panel now exposes some state parameters to assist debugging [#2924](https://github.com/TryQuiet/quiet/issues/2924)
+* Persist SkinTone choices and use in emoji shortcodes [#2794](https://github.com/TryQuiet/quiet/issues/2794)
 
 ### Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "root",
+      "dependencies": {
+        "unicode-emoji-json": "^0.8.0"
+      },
       "devDependencies": {
         "husky": "^9.0.11",
         "lerna": "^6.6.2",
@@ -8338,6 +8341,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/unicode-emoji-json": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.8.0.tgz",
+      "integrity": "sha512-3wDXXvp6YGoKGhS2O2H7+V+bYduOBydN1lnI0uVfr1cIdY02uFFiEH1i3kE5CCE4l6UqbLKVmEFW9USxTAMD1g=="
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "npm": "10.7.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-jest": "^29.0.1",
+    "eslint-plugin-prettier": "^5.5.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^9.0.11",
     "lerna": "^6.6.2",
     "pnpm": "10.6.0",
@@ -39,5 +44,8 @@
   "volta": {
     "node": "18.20.4",
     "npm": "10.7.0"
+  },
+  "dependencies": {
+    "unicode-emoji-json": "^0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,6 @@
     "npm": "10.7.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.37.0",
-    "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-jest": "^29.0.1",
-    "eslint-plugin-prettier": "^5.5.1",
-    "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^9.0.11",
     "lerna": "^6.6.2",
     "pnpm": "10.6.0",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -219,6 +219,7 @@
     "electron-devtools-installer": "^3.1.1",
     "electron-store": "^5.2.0",
     "electron-store-webpack-wrapper": "^0.0.2",
+    "unicode-emoji-json": "^0.8.0",
     "emoji-picker-react": "^4.12.2",
     "enzyme": "^3.8.0",
     "enzyme-to-json": "^3.3.5",

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -14,7 +14,7 @@ import emojiBlack from '../../../../static/images/emojiBlack.svg'
 import paperclipGray from '../../../../static/images/paperclipGray.svg'
 import paperclipBlack from '../../../../static/images/paperclipBlack.svg'
 import path from 'path'
-import { emojify, findMatchingEmojis, extractPartialEmojiCode, emojiShortcodes } from './utils/emojiCodes'
+import { emojify, findMatchingEmojis, extractPartialEmojiCode, getEmojiFromShortcode, } from './utils/emojiCodes'
 
 const PREFIX = 'ChannelInput'
 const MAX_EMOJI_SUGGESTIONS = 100
@@ -386,7 +386,7 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
           const selectedSuggestion = emojiSuggestions[selectedSuggestionIndex]
 
           // Get the actual emoji character
-          const emoji = emojiShortcodes[selectedSuggestion]
+          const emoji = getEmojiFromShortcode(selectedSuggestion)
 
           // Calculate the new text with emoji inserted
           const beforeText = target.value.substring(0, partial.startPos)
@@ -528,7 +528,7 @@ export const ChannelInputComponent: React.FC<ChannelInputProps> = ({
 
                       if (partial) {
                         // Replace the partial emoji code with the actual emoji
-                        const emoji = emojiShortcodes[suggestion]
+                        const emoji = getEmojiFromShortcode(suggestion)
 
                         // Calculate the new text with emoji inserted
                         const beforeText = message.substring(0, partial.startPos)

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/EmojiDropdown.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/EmojiDropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { styled, useTheme } from '@mui/material/styles'
 import ClickAwayListener from '@mui/material/ClickAwayListener'
-import { emojiShortcodes } from './utils/emojiCodes'
+import { getEmojiFromShortcode } from './utils/emojiCodes'
 
 const PREFIX = 'EmojiDropdown'
 
@@ -171,7 +171,7 @@ export const EmojiDropdown: React.FC<EmojiDropdownProps> = ({
             onClick={() => onEmojiSelect(suggestion)}
           >
             <span>{suggestion}</span>
-            <span>{emojiShortcodes[suggestion]}</span>
+            <span>{getEmojiFromShortcode(suggestion)}</span>
           </div>
         ))}
       </StyledRoot>

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/utils/emojiCodes.ts
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/utils/emojiCodes.ts
@@ -1,4 +1,6 @@
 import { is } from 'ramda'
+import emojiDataJson from "unicode-emoji-json";
+const emojiData = emojiDataJson as EmojiData;
 
 // Emoji shortcode mapping
 export interface EmojiMapping {
@@ -1081,13 +1083,50 @@ function isLastWordProtected(text: string): boolean {
   return false
 }
 
+type EmojiInfo = {
+  name: string;
+  slug: string;
+  group: string;
+  emoji_version: string;
+  unicode_version: string;
+  skin_tone_support: boolean;
+  skin_tone_support_unicode_version?: string;
+};
+
+type EmojiData = {
+  [emoji: string]: EmojiInfo;
+};
+
+function supportsSkinTone(emoji: string): boolean {
+  const data: EmojiInfo = emojiData[emoji]
+  return data ? data.skin_tone_support : false;
+}
+
+function getSkinToneEmoji(emoji: string): string {
+  if (supportsSkinTone(emoji) ) {
+    const code = localStorage.getItem(SKIN_TONE_KEY)
+    if (code) {
+      // Need to convert the stored modifier to Unicode.
+      return emoji +  String.fromCodePoint(parseInt(code, 16));
+    }
+  }
+  // If emoji doesn't support skin tone modifiers return it as is
+  return emoji
+}
+
+const SKIN_TONE_KEY = 'emojiPickerSkinTone'
+
+export function getEmojiFromShortcode(word: string) {
+  return getSkinToneEmoji(emojiShortcodes[word])
+}
+
 // -------------------------------------------
 // 5) While-typing replacement
 // -------------------------------------------
 function replaceIfEmoji(word: string, delimiter: string): { replaced: string; offset: number } {
   // shortcodes => always replace
   if (emojiShortcodes[word]) {
-    const replacedWord = emojiShortcodes[word]
+    const replacedWord = getEmojiFromShortcode(word)
     const offset = replacedWord.length - word.length
     return { replaced: replacedWord, offset }
   }
@@ -1097,7 +1136,7 @@ function replaceIfEmoji(word: string, delimiter: string): { replaced: string; of
     if (!delimiter) {
       return { replaced: word, offset: 0 }
     }
-    const replacedWord = emoticons[word]
+    const replacedWord = getSkinToneEmoji(emoticons[word])
     let offset = replacedWord.length - word.length
     // tests want an extra -1 if emoticon had trailing space/punct
     offset -= 1
@@ -1149,10 +1188,10 @@ function replaceAllEmojisInUnprotected(segment: string): string {
 
   return segment.replace(tokenRegex, match => {
     if (emojiShortcodes[match]) {
-      return emojiShortcodes[match]
+      return getEmojiFromShortcode(match)
     }
     if (emoticons[match]) {
-      return emoticons[match]
+      return getSkinToneEmoji(emoticons[match])
     }
     return match
   })


### PR DESCRIPTION
To enable this, brought in a package that supports checking if a given emoji supports a shortcode or not. Follow-up now that we're [persisting](https://github.com/TryQuiet/quiet/pull/2938) the skinTone.


### Pull Request Checklist

- [x] I have linked this PR to a related [GitHub issue](https://github.com/TryQuiet/quiet/issues/2794).
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
