### PR TITLE
Fix leaveCommunity flow on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### Fixes
+
+* Leaving a community on android and then immediately creating/joining a new one no longer fails to reinitialize [#2940](https://github.com/TryQuiet/quiet/issues/2940)
+
 ## [6.1.0]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Changelog
 
-## [unreleased]
-
-### Fixes
-
-* Leaving a community on android and then immediately creating/joining a new one no longer fails to reinitialize [#2940](https://github.com/TryQuiet/quiet/issues/2940)
-
 ## [6.1.0]
 
 ### Fixes
 
+* Leaving a community on android and then immediately creating/joining a new one no longer fails to reinitialize [#2940](https://github.com/TryQuiet/quiet/issues/2940)
 * Abrupt closes properly clean up resources and save data [#2921](https://github.com/TryQuiet/quiet/issues/2921)
 * User Profile photo size limits now more strictly enforced [#2892](https://github.com/TryQuiet/quiet/issues/2892)
 

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -293,7 +293,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     } else if (options.saveTor) {
       this.logger.info('Saving tor')
     }
-    if (this.storageService) {
+    if (this.storageService && options.closeDatastore) {
       this.logger.info('Stopping StorageService')
       await this.storageService?.stop()
     }
@@ -317,12 +317,10 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
   public async leaveCommunity(): Promise<boolean> {
     this.logger.info('Running leaveCommunity')
 
-    await this.libp2pService.pause()
+    await this.closeAllServices({ saveTor: true, closeDatastore: false, deleteChainFromDisk: true })
 
     this.logger.info('Resetting StorageService')
     await this.storageService.clean()
-
-    await this.closeAllServices({ saveTor: true, closeDatastore: false, deleteChainFromDisk: true })
 
     this.logger.info('Cleaning libp2p datastore')
     await this.libp2pService.cleanDatastore()

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -102,6 +102,7 @@ export class StorageService extends EventEmitter {
     await this.channelsService.clean()
     await this.userProfileStore.clean()
     await this.ipfsService.destroyInstance()
+    await this.stop()
   }
 
   public purgeData() {

--- a/packages/backend/src/nest/websocketOverTor/listener.ts
+++ b/packages/backend/src/nest/websocketOverTor/listener.ts
@@ -243,7 +243,12 @@ export class WebSocketListener extends TypedEventEmitter<ListenerEvents> impleme
     // close all connections, must be done after closing the server to prevent
     // race conditions where a new connection is accepted while we are closing
     // the existing ones
-    this.http?.closeAllConnections()
+
+    // if http and closeAllConnections is defined, close all connections
+    if (this.http && typeof this.http.closeAllConnections === 'function') {
+      this.log('Closing all HTTP connections')
+      this.http.closeAllConnections()
+    }
     ;[...this.connections].forEach(connection => {
       connection.destroy()
     })

--- a/packages/mobile/e2e/starter.test.js
+++ b/packages/mobile/e2e/starter.test.js
@@ -4,6 +4,7 @@ import info from './utils/info'
 import checkVisualRegression from './utils/checkVisualRegression'
 import baseScreenshotsUpdate from './utils/baseScreenshotsUpdate'
 import { BASIC, LONG, STARTUP } from './utils/consts/timeouts'
+import { deleteChannelMessage, generalChannelDeletionMessage } from '@quiet/common'
 
 const { ios } = info
 
@@ -43,20 +44,21 @@ describe('User', () => {
 
     if (!ios) await device.pressBack()
 
+    await device.disableSynchronization()
     await press(element(by.text('Continue')), true)
-
-    await waitFor(element(by.text('Register a username')))
-      .toBeVisible()
-      .withTimeout(BASIC)
   })
 
   test('enters username', async () => {
+    await waitFor(element(by.text('Register a username')))
+      .toBeVisible()
+      .withTimeout(BASIC)
     const componentName = 'username-registration-component'
     await checkVisualRegression(componentName)
 
     await write(element(by.id('input')), 'rick')
 
     await press(element(by.text('Continue')), true)
+    await device.enableSynchronization()
   })
 
   // test('should see connection process screen', async () => {
@@ -74,8 +76,10 @@ describe('User', () => {
   test('minimizes and restores the app', async () => {
     await device.sendToHome()
 
-    await new Promise((resolve) => {
-      setTimeout(() => { resolve() }, 3000)
+    await new Promise(resolve => {
+      setTimeout(() => {
+        resolve()
+      }, 3000)
     })
 
     await device.launchApp({ newInstance: false })
@@ -212,5 +216,95 @@ describe('User', () => {
     await waitFor(element(by.text('Join community')))
       .toBeVisible()
       .withTimeout(STARTUP)
+  })
+
+  test('should see join community screen again', async () => {
+    await waitFor(element(by.text('Join community')))
+      .toBeVisible()
+      .withTimeout(STARTUP)
+
+    const componentName = 'join-community-component'
+    await checkVisualRegression(componentName)
+  })
+  test('should not see create community screen', async () => {
+    await waitFor(element(by.text('Create a community')))
+      .not.toBeVisible()
+      .withTimeout(BASIC)
+  })
+
+  test('switches to create community screen', async () => {
+    await press(element(by.text('create a new community')))
+
+    await waitFor(element(by.text('Create a community')))
+      .toBeVisible()
+      .withTimeout(BASIC)
+
+    const componentName = 'create-community-component'
+    await checkVisualRegression(componentName)
+  })
+  test('enters community name again', async () => {
+    await write(element(by.id('input')), 'rockets')
+
+    if (!ios) await device.pressBack()
+
+    await device.disableSynchronization()
+    await press(element(by.text('Continue')), true)
+  })
+
+  test('enters username again', async () => {
+    await waitFor(element(by.text('Register a username')))
+      .toBeVisible()
+      .withTimeout(BASIC)
+
+    const componentName = 'username-registration-component'
+    await checkVisualRegression(componentName)
+
+    await write(element(by.id('input')), 'rick')
+
+    await press(element(by.text('Continue')), true)
+    await device.enableSynchronization()
+  })
+
+  test('should see channels list again', async () => {
+    await waitFor(element(by.id('channels_list')))
+      .toBeVisible()
+      .withTimeout(LONG)
+  })
+  test('minimizes and restores the app', async () => {
+    await device.sendToHome()
+
+    await new Promise(resolve => {
+      setTimeout(() => {
+        resolve()
+      }, 3000)
+    })
+
+    await device.launchApp({ newInstance: false })
+
+    // User comes back to channel list
+    await waitFor(element(by.id('channels_list')))
+      .toBeVisible()
+      .withTimeout(STARTUP)
+  })
+
+  test('enters #general channel', async () => {
+    await press(element(by.text('#general')))
+
+    await waitFor(element(by.id('chat_general')))
+      .toBeVisible()
+      .withTimeout(BASIC)
+  })
+
+  test('sends message to #general channel', async () => {
+    await press(element(by.id('input')))
+    await write(element(by.id('input')), 'We are no strangers to love')
+
+    await press(element(by.id('send_message_button')), true)
+
+    await waitFor(element(by.id('We are no strangers to love')))
+      .toBeVisible()
+      .withTimeout(BASIC)
+
+    if (!ios) await device.pressBack()
   })
 })


### PR DESCRIPTION
More sensible ordering, guards against non-existent function on ws listener (only seems to throw on mobile and this check resolves that)

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [x] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
