### PR TITLE
Make onboarding activities mutually exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Minor design fixes on the left side panel [2948](https://github.com/TryQuiet/quiet/issues/2948)
 * Fixes crashes on QSS disconnects [#2803](https://github.com/TryQuiet/quiet/issues/2803)
+* Users can now abort joining and creating communities halfway without issue [#3001](https://github.com/TryQuiet/quiet/issues/3001)
 
 ### Chores
 

--- a/packages/state-manager/src/sagas/communities/communities.master.saga.test.ts
+++ b/packages/state-manager/src/sagas/communities/communities.master.saga.test.ts
@@ -1,0 +1,70 @@
+import { testSaga } from 'redux-saga-test-plan'
+import { handleCommunityOnboarding } from './communities.master.saga'
+import { communitiesActions } from './communities.slice'
+import { CreateCommunityPayload, InvitationDataVersion, JoinCommunityPayload } from '@quiet/types'
+import { createCommunitySaga } from './createCommunity/createCommunity.saga'
+import { joinCommunitySaga } from './joinCommunity/joinCommunity.saga'
+import type { Socket } from '../../types'
+import type { Task } from 'redux-saga'
+import { TASK } from '@redux-saga/symbols'
+
+const createTaskMock = (overrides: Partial<Task> = {}): Task => {
+  const task = {
+    isRunning: () => true,
+    isCancelled: () => false,
+    result: () => undefined,
+    error: () => undefined,
+    toPromise: () => Promise.resolve(undefined),
+    cancel: () => undefined,
+    setContext: () => undefined,
+    ...overrides,
+  } as Task & { [TASK]?: boolean }
+
+  task[TASK] = true
+
+  return task
+}
+
+describe('handleCommunityOnboarding', () => {
+  const socket = {} as Socket
+
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('cancels the in-progress onboarding before starting a new one', () => {
+    const createAction = communitiesActions.createCommunity({
+      name: 'Test',
+      useServer: false,
+    } as CreateCommunityPayload)
+    const joinAction = communitiesActions.joinCommunity({
+      inviteData: {
+        version: InvitationDataVersion.v1,
+        pairs: [],
+        psk: 'psk',
+        ownerOrbitDbIdentity: 'owner',
+      },
+    } as JoinCommunityPayload)
+
+    const createTask = createTaskMock()
+    const joinTask = createTaskMock()
+
+    testSaga(handleCommunityOnboarding, socket)
+      .next()
+      .take([communitiesActions.createCommunity.type, communitiesActions.joinCommunity.type])
+      .next(createAction)
+      .fork(createCommunitySaga, socket, createAction)
+      .next(createTask)
+      .take([communitiesActions.createCommunity.type, communitiesActions.joinCommunity.type])
+      .next(joinAction)
+      .cancel(createTask)
+      .next()
+      .fork(joinCommunitySaga, socket, joinAction)
+      .next(joinTask)
+      .take([communitiesActions.createCommunity.type, communitiesActions.joinCommunity.type])
+  })
+})

--- a/packages/state-manager/src/sagas/communities/communities.master.saga.test.ts
+++ b/packages/state-manager/src/sagas/communities/communities.master.saga.test.ts
@@ -18,9 +18,9 @@ const createTaskMock = (overrides: Partial<Task> = {}): Task => {
     cancel: () => undefined,
     setContext: () => undefined,
     ...overrides,
-  } as Task & { [TASK]?: boolean }
+  } as Task
 
-  task[TASK] = true
+  ;(task as any)[TASK] = true
 
   return task
 }

--- a/packages/state-manager/src/sagas/communities/communities.master.saga.ts
+++ b/packages/state-manager/src/sagas/communities/communities.master.saga.ts
@@ -1,11 +1,12 @@
 import { type Socket } from '../../types'
-import { all, takeEvery, cancelled, takeLatest } from 'typed-redux-saga'
+import { all, takeEvery, cancelled, fork, cancel, join, take } from 'typed-redux-saga'
 import { communitiesActions } from './communities.slice'
 import { connectionActions } from '../appConnection/connection.slice'
 import { createCommunitySaga } from './createCommunity/createCommunity.saga'
 import { initCommunitySaga, launchCommunitySaga } from './launchCommunity/launchCommunity.saga'
 import { createLogger } from '../../utils/logger'
 import { joinCommunitySaga } from './joinCommunity/joinCommunity.saga'
+import type { Task } from 'redux-saga'
 
 const logger = createLogger('communitiesMasterSage')
 
@@ -14,14 +15,42 @@ export function* communitiesMasterSaga(socket: Socket): Generator {
   try {
     yield all([
       takeEvery(connectionActions.setTorInitialized.type, initCommunitySaga),
-      takeLatest(communitiesActions.createCommunity.type, createCommunitySaga, socket),
-      takeLatest(communitiesActions.joinCommunity.type, joinCommunitySaga, socket),
+      fork(handleCommunityOnboarding, socket),
       takeEvery(communitiesActions.launchCommunity.type, launchCommunitySaga, socket),
     ])
   } finally {
     logger.info('communitiesMasterSaga stopping')
     if (yield cancelled()) {
       logger.info('communitiesMasterSaga cancelled')
+    }
+  }
+}
+
+type CreateCommunityAction = ReturnType<typeof communitiesActions.createCommunity>
+type JoinCommunityAction = ReturnType<typeof communitiesActions.joinCommunity>
+type OnboardingAction = CreateCommunityAction | JoinCommunityAction
+
+function* handleCommunityOnboarding(socket: Socket): Generator {
+  let activeTask: Task | undefined
+
+  while (true) {
+    const action = (yield* take([
+      communitiesActions.createCommunity.type,
+      communitiesActions.joinCommunity.type,
+    ])) as OnboardingAction
+
+    if (activeTask) {
+      logger.info('Cancelling active onboarding saga')
+      yield* cancel(activeTask)
+      yield* join(activeTask)
+    }
+
+    if (action.type === communitiesActions.createCommunity.type) {
+      logger.info('Starting createCommunitySaga')
+      activeTask = yield* fork(createCommunitySaga, socket, action)
+    } else {
+      logger.info('Starting joinCommunitySaga')
+      activeTask = yield* fork(joinCommunitySaga, socket, action)
     }
   }
 }

--- a/packages/state-manager/src/sagas/communities/communities.master.saga.ts
+++ b/packages/state-manager/src/sagas/communities/communities.master.saga.ts
@@ -1,5 +1,5 @@
 import { type Socket } from '../../types'
-import { all, takeEvery, cancelled, fork, cancel, join, take } from 'typed-redux-saga'
+import { all, takeEvery, cancelled, fork, cancel, take } from 'typed-redux-saga'
 import { communitiesActions } from './communities.slice'
 import { connectionActions } from '../appConnection/connection.slice'
 import { createCommunitySaga } from './createCommunity/createCommunity.saga'
@@ -30,7 +30,7 @@ type CreateCommunityAction = ReturnType<typeof communitiesActions.createCommunit
 type JoinCommunityAction = ReturnType<typeof communitiesActions.joinCommunity>
 type OnboardingAction = CreateCommunityAction | JoinCommunityAction
 
-function* handleCommunityOnboarding(socket: Socket): Generator {
+export function* handleCommunityOnboarding(socket: Socket): Generator {
   let activeTask: Task | undefined
 
   while (true) {
@@ -40,9 +40,11 @@ function* handleCommunityOnboarding(socket: Socket): Generator {
     ])) as OnboardingAction
 
     if (activeTask) {
-      logger.info('Cancelling active onboarding saga')
-      yield* cancel(activeTask)
-      yield* join(activeTask)
+      if (activeTask.isRunning()) {
+        logger.info('Cancelling active onboarding saga')
+        yield* cancel(activeTask)
+      }
+      activeTask = undefined
     }
 
     if (action.type === communitiesActions.createCommunity.type) {


### PR DESCRIPTION
Fixes an edge case not addressed in #2995 where aborting creating a community and then joining a community would cause the createCommunitySaga to finish when the username was entered. This PR replaces the use of takeLatest on createCommunitySaga and joinCommunitySaga with a handleCommunityOnboarding watcher saga which cancels ongoing onboarding tasks when a new onboarding action is dispatched.

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
