### PR TITLE
remove build time env-var plugin

### DIFF
--- a/packages/desktop/webpack/webpack.config.renderer.dev.js
+++ b/packages/desktop/webpack/webpack.config.renderer.dev.js
@@ -54,7 +54,6 @@ module.exports = {
     index: './src/renderer/index.tsx',
   },
   plugins: [
-    new webpack.EnvironmentPlugin(envKeys),
     new HtmlWebpackPlugin({
       title: 'Quiet',
       template: 'src/renderer/index.html',
@@ -64,7 +63,6 @@ module.exports = {
       template: 'src/renderer/splashScreen/splash.html',
       filename: 'splash.html',
     }),
-    new webpack.EnvironmentPlugin(envKeys),
     new WebpackOnBuildPlugin(async () => {
       if (!mainRunning) {
         console.log('Starting main process...')

--- a/packages/desktop/webpack/webpack.config.renderer.prod.js
+++ b/packages/desktop/webpack/webpack.config.renderer.prod.js
@@ -50,7 +50,6 @@ module.exports = {
     index: './src/renderer/index.tsx',
   },
   plugins: [
-    new webpack.EnvironmentPlugin(envKeys),
     new HtmlWebpackPlugin({
       title: 'Quiet',
       template: 'src/renderer/index.html',
@@ -60,7 +59,6 @@ module.exports = {
       template: 'src/renderer/splashScreen/splash.html',
       filename: 'splash.html',
     }),
-    new webpack.EnvironmentPlugin(envKeys),
     new WebpackOnBuildPlugin(async () => {
       await new Promise((resolve, reject) => {
         spawn('npm', ['run', 'copyFonts'], {


### PR DESCRIPTION
Using webpack.EnvironmentPlugin could cause environment disagreements where the packed renderer environment disagrees with the environment of the main process.

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
