### PR TITLE
Fix function that locates tor in development mode

### DIFF
--- a/packages/backend/src/nest/common/utils.ts
+++ b/packages/backend/src/nest/common/utils.ts
@@ -152,40 +152,26 @@ export const torBinForPlatform = (basePath = '', binName = 'tor'): string => {
   }
   const ext = process.platform === 'win32' ? '.exe' : ''
   // Wrap path in quotes to handle spaces in path
-  let pathCandidate = path.join(torDirForPlatform(basePath), `${binName}`.concat(ext))
+  const pathCandidate = path.join(torDirForPlatform(basePath), `${binName}`.concat(ext))
   logger.info(`Checking for Tor binary at: ${pathCandidate}`)
   if (fs.existsSync(pathCandidate)) {
     return pathCandidate
-  } else if (basePath === '') {
+  } else {
     throw new Error(
       `Tor binary not found at ${pathCandidate}. Please ensure the Tor binary is installed and the path is correct.`
     )
-  } else {
-    logger.info(`Tor binary not found at ${pathCandidate}, trying local tor directory.`)
-    pathCandidate = path.join(torDirForPlatform(), `${binName}`.concat(ext))
   }
-  if (fs.existsSync(pathCandidate)) {
-    return pathCandidate
-  } else {
-    // check if the parent dir exists
-    if (fs.existsSync(path.dirname(pathCandidate))) {
-      throw new Error(
-        `Tor binary not found at ${pathCandidate}. Please ensure the Tor binary is installed and the path is correct.`
-      )
-    }
-  }
-  return `"${pathCandidate}"`
 }
 
 export const torDirForPlatform = (basePath?: string): string => {
-  let torPath: string
-  if (!basePath) {
-    basePath = path.join(process.cwd(), '..', '..', '3rd-party')
-    torPath = path.join(basePath, 'tor', process.platform)
+  const devPath = path.join(process.cwd(), '..', '..', '3rd-party', 'tor', process.platform)
+  const prodPath = basePath ? path.join(basePath, 'tor') : undefined
+  if (!prodPath || !fs.existsSync(prodPath)) {
+    logger.info(`Tor directory not found in ${basePath}, falling back to dev directory ${devPath}.`)
+    return devPath
   } else {
-    torPath = path.join(basePath, 'tor')
+    return prodPath
   }
-  return torPath
 }
 
 export const getUsersAddresses = async (users: UserData[]): Promise<string[]> => {


### PR DESCRIPTION
The previous function that is used to set `LD_LIBRARY_PATH` was broken in a subtle way that was only an issue when developing Quiet, and only exposed the problem with the system-provided dynamic libraries were incompatible with the pre-compiled Tor.

In Linux, this showed up as an error where certain `libevent` functions were missing, crashing Tor and Quiet.

Also included is a second optional commit that's slightly more invasive but reduces the extra logic in the sister executable-finding function.