### PR TITLE
add mise-en-place support for simpler SDK dependency management

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,119 @@
+min_version = "2024.9.5"
+
+[env]
+
+[hooks]
+
+[tools]
+# general dev/sdk tools & dependencies
+usage = "latest" # needed by mise for shell completions
+yq = "latest" # needed by mise for android-sdk
+git-lfs = "latest"
+
+# project-wide dependencies
+node = "18.20.4"
+npm = "10.7.0"
+"npm:lerna" = "6.6.2"
+"npm:typescript" = "4.9.5"
+"npm:pnpm" = "9.12.1"
+
+# android dependencies
+java = "temurin-17.0.17+10"
+android-sdk = "19"
+
+# ios dependencies
+xcodes = { version = "latest", os = ["macos"]}
+"ruby" = { version = "2.7.5", os = ["macos"]}
+
+[tasks.bootstrap]
+description = "Install base project dependencies (only needs to be run once per environment)"
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+# mise's yq has to be installed first due to a dependency issue in the android-sdk package
+mise install --jobs=1 yq
+
+# using the newly install yq, we can now install the rest of the tools
+mise exec -- mise install
+
+printf "\e[0;94;1m [*] Pulling submodules and Git LFS blobs.\e[0m\n"
+git submodule update --init --recursive --remote
+git lfs pull
+
+printf "\e[0;94;1m [*] Installing NPM dependencies.\e[0m\n"
+npm install
+npm run pull:submodules
+npm run bootstrap
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.bootstrap-android]
+confirm = "Have you read and accepted the Android SDK licenses?"
+description = "Install Android-specific dependencies (only needs to be run once per environment)"
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+mise install
+
+printf "\e[0;94;1m [*] Installing correct Android platform version.\e[0m\n"
+yes | sdkmanager --licenses
+sdkmanager "platforms;android-35" "build-tools;35.0.1"
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.bootstrap-ios]
+description = "Install iOS-specific dependencies (only needs to be run once per environment)"
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+mise install
+
+printf "\e[0;94;1m [*] Installing Xcode and iOS runtime.\e[0m\n"
+xcodes install 16.2.0
+xcodes select 16.2.0
+xcodes runtimes install 'iOS 18.4'
+
+printf "\e[0;94;1m [*] Installing Ruby and Cocoapods dependencies.\e[0m\n"
+pushd packages/mobile/ios
+gem install bundler -v 1.17.2
+bundle install
+bundle exec pod install
+echo "export NODE_BINARY=$(which node)" > .xcode.env.local
+
+printf "\e[0;94;1m [*] Installing ios-deploy CLI deployment tool from Homebrew.\e[0m\n"
+brew install -q ios-deploy
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.desktop]
+description = "Run a command from within the desktop project"
+dir = "{{cwd}}/packages/desktop"
+run = "npm run"
+
+[tasks.mobile]
+description = "Run a command from within the mobile project"
+dir = "{{cwd}}/packages/mobile"
+run = "npm run"
+
+[tasks.clean-data-dirs]
+confirm = "Delete all Quiet data directories (both production and development)?"
+description = "Clean all data directories left over from quiet installs"
+run = '''
+find ~/Library/Application\ Support -maxdepth 1 -type d \( -name "Quiet*" -o -name "e2e_*" \) -exec rm -rf {} +
+printf "\e[0;92;1m [*] Deleted all Quiet data directories.\e[0m\n"
+'''
+
+[tasks.start]
+description = "Start Quiet Desktop with the Quietdev data directory"
+run = '''
+npm run start:desktop
+'''
+
+[tasks.start-temp]
+description = "Start Quiet Desktop with a fresh random data directory"
+run = '''
+export DATA_DIR="Quiet$(printf "%04d" $(( RANDOM % 10000 )))"
+printf "\e[0;94;1m [*] New DATA_DIR: $DATA_DIR.\e[0m\n"
+
+npm run start:desktop
+'''

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -3,21 +3,14 @@
 Running the desktop version of Quiet should be straightforward on Mac and Linux. On Windows we recommend using git-bash or just wsl.
 Here are the steps:
 
-1. Install `patch` via your Linux package manager (you can skip this step on Mac because it is already installed)
+1. Linux users only: Install `patch` via your package manager
 
-2. Use `Node 18.20.4` and `npm 10.7.0`. We recommend [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/) for easily switching Node versions, and if this README gets out of date you can see the actual version used by CI [here](https://github.com/TryQuiet/quiet/blob/master/.github/actions/setup-env/action.yml). If you are using nvm, you can run `nvm use` in the project's root to switch to the correct version.
+2. Install `mise` via your package manager or `mise`'s install script at https://mise.jdx.dev/getting-started.html
 
-3. Install python3 and setuptools through your preferred method. (used by node-gyp)
-
-4. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies/submodules and trigger a prepublish script which builds them.
+4. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project via `mise`. It will take care of the package's dependencies/submodules and trigger a prepublish script which builds them.
 
 ```bash
-npm i lerna@6.6.2
-npm i typescript@4.9.5
-npm i -g pnpm@9.12.1 # may be needed depending on configuration
-npm install
-npm run pull:submodules
-npm run bootstrap
+mise bootstrap
 ```
 
 If you run into problems please double check if you have exact version Node and NPM as listed in point 1.

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -5,55 +5,14 @@ Quiet Mobile is a React Native app for Android and iOS that shares a Node.js [ba
 ### Prerequisites
 
 1. Set up a development environment for Quiet Desktop using [these instructions](https://github.com/TryQuiet/quiet/blob/develop/packages/desktop/README.md) and confirm you can run it
-1. If not on Mac (which comes preinstalled with `patch`), install `patch`, e.g. via your Linux package manager
-1. Install python3 and setuptools (used by node-gyp) through your preferred method. 
 
 ## Android development
 
-1. In the root directory of `quiet/`, install the monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies and trigger a prepublish script which builds them.
-1. Follow the instructions for running [Quiet Desktop](https://github.com/TryQuiet/monorepo/tree/master/packages/desktop) and confirm it runs
-1. If not on Mac, which comes preinstalled with `patch`, install `patch` (e.g. via your Linux package manager).
-1. Install python3 and setuptools (used by node-gyp) through your preferred method. 
-1. Install the [Temurin 17 JDK](https://adoptium.net/temurin) for [Mac](https://adoptium.net/temurin/releases/?package=jdk&version=17&os=mac) (.pkg) or [Linux](https://adoptium.net/installation/linux/)
-1. Set `JAVA_HOME` to the Temurin install location by adding a line to your `.bashrc` or `.zshrc`:  
-    - Mac: `export JAVA_HOME="/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home"`
-    - Linux: `export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-amd64/`
-
-    Alternatively, the easiest way to install The Temurin 17 JDK on Mac and Linux systems is to use [`SDKMAn`](https://sdkman.io/). This program is similar to `nvm` but for JDKs and allows you to easily install and switch between multiple JDKs on a single system.
-
-    ```bash
-    # downloads and installs SDKMAN
-    curl -s "https://get.sdkman.io" | bash
-
-    # downloads + installs + configures JAVA_HOME for Temurin JDK 17
-    sdk install java 17.0.0-tem
-    ``` 
-
-1. Install [Android Studio](https://developer.android.com/studio), ensuring that all of the following items in the installation wizard are checked
-    - Android SDK
-    - Android SDK Platform
-1. Point the $ANDROID_HOME environment variable in your `.bashrc` or `.zshrc` to your Android install
-    You can find it here:
-      - macOS: `~/Library/Android/sdk/`
-      - Linux: `~/Android/Sdk/`
-
-1. Ensure Android Studio's `platform-tools` directories are added to your `PATH`. 
-    
-    Your `.bashrc` or `.zshrc` should now include something like:
-    ```bash
-    export JAVA_HOME="/usr/lib/jvm/temurin-17-jdk-amd64/"
-    export ANDROID_HOME=$HOME/Android/Sdk
-    export PATH=$PATH:$ANDROID_HOME/emulator
-    export PATH=$PATH:$ANDROID_HOME/platform-tools
+1. Install the Android SDK and other needed tools via `mise`:
     ```
-
-1. Confirm that the "Android 15 (VanillaIceCream)" SDK required by React Native has been installed (confusingly, it is also called "android-35" or [API level 35](https://apilevels.com/))
-
-    ```bash
-    ls $ANDROID_HOME/platforms
+    mise bootstrap-android
     ```
-    You should see `android-35`. You may also need to select specific versions of the SDK or tools, but currently the default install is sufficient (see: [React Native setup instructions](https://reactnative.dev/docs/set-up-your-environment))
-
+  - *Note: You can also use the Android Studio SDK setup by overwriting `ANDROID_HOME` and your `PATH` as desired.*
 1. Enable [Developer options](https://developer.android.com/studio/debug/dev-options#enable) and [USB debugging](https://developer.android.com/studio/debug/dev-options#Enable-debugging) on your Android phone and restart it
 1. Connect your phone to your dev machine via USB
 1. On Linux, follow [these instructions](https://reactnative.dev/docs/running-on-device?platform=android&os=linux#2-plug-in-your-device-via-usb-2) for authorizing your phone as a USB device (skip this step on Mac)
@@ -128,9 +87,8 @@ const watchFolders = [
 ]
 ```
 
-## iOS development
+## iOS development (Mac required)
 
-1. Have a Mac (Apple requires this)
 1. Create an account at [developer.apple.com](https://developer.apple.com) 
 1. Install Xcode Command Line Tools (required for Homebrew):
     
@@ -139,30 +97,13 @@ const watchFolders = [
     ```
 1. Install [Homebrew](https://brew.sh/)
 1. Set up a development environment for Quiet Desktop using [these instructions](https://github.com/TryQuiet/quiet/blob/develop/packages/desktop/README.md) and confirm you can run it
-1. Install [Git Large File Storage (LFS)](https://git-lfs.com/)
+1. Install needed iOS dependencies via mise (expected Xcode and iOS platform versions)
 
     ```bash
-    brew install git-lfs
-    ```
-
-1. Install Xcode 16.2 and Xcode Command Line Tools (**Note:** you must use Xcode version 16.2, but you should use the iOS runtime that corresponds to the iOS version in Settings > General > About on your iPhone. Use `xcodes runtimes` to list available runtimes.) 
-
-    ```bash
-    brew install xcodesorg/made/xcodes
-    xcodes install 16.2.0 
-    xcodes select 16.2.0
-    xcodes runtimes install "iOS 18.4"
+    mise bootstrap-ios
     ```
     
-    You may need to wait for the "Verifying Runtime" modal to complete before running Quiet
-
-1. Initialize submodules in the project's root and pull files with Git LFS:
-
-    ```bash
-    git submodule update --init --recursive --remote 
-    git lfs pull 
-     # Note: it may be necessary to first run `git lfs install`
-    ```
+    The `xcodes` tool may ask for Apple Developer login credentials to download the correct versions.
 
 1. Confirm that submodules are properly initialized by checking that NodeMobile is a binary file, not text:
 
@@ -172,52 +113,6 @@ const watchFolders = [
     ```
     You should see output indicating it's a 'Mach-O binary' file with arm64 architecture, not an ASCII text file. If it shows as text, the Git LFS setup step was not successful.
 
-1. In the project's root, bootstrap the project again (must be run *after* submodule initialization)
-
-    ```bash
-    npm run bootstrap
-    ```
-
-1. Install rbenv, a Ruby version manager, and set Ruby to the suggested version.
-
-    ```bash
-    brew install rbenv
-    rbenv init
-    rbenv install 2.7.5
-    rbenv global 2.7.5
-    ```
-
-1. Restart your terminal and confirm that you are using Ruby 2.7.5
-
-    ```bash
-    ruby --version
-    ```
-
-1. Install ruby dependencies from the Gemfile in the `packages/mobile` directory.
-
-    ```bash
-    gem install bundler -v 1.17.2
-    bundle install
-    ```
-
-1. Install the pods for the iOS project.
-
-    ```bash
-    cd ios
-    bundle exec pod install 
-    ```
-
-1. In `packages/mobile`, create a `.xcode.env.local` file with your Node path:
-
-     ```bash
-     echo "export NODE_BINARY=$(which node)" > .xcode.env.local
-     ```
-
-1. Install `ios-deploy` for deploying to iOS devices from the command line
-
-     ```bash
-     brew install ios-deploy
-     ```
 1. Open the Quiet project in Xcode
 
     From the `packages/mobile` directory


### PR DESCRIPTION
I previously used `just` and `.envrc` to make it easier to set environment variables and tasks across my macOS/Linux/Windows machines, and discovered a newer tool `mise` (https://mise.jdx.dev/) along the way that works quite well with the Quiet codebase.

It can install and load/unload pretty much all the dependencies Quiet uses in a way that can also be used by CI.

It is especially helpful at drastically simplifying the Android developer setup by automatically installing the correct Temurin JDK and Android SDK and setting the environment variables as expected whenever you enter the quiet workspace.

This would replace other recommended installation methods like SDKMAN/Volta/rbenv/etc and turn developer/CI setup into a one-liner (after installing mise):

```
# (install mise via package manager or `curl https://mise.run | sh`)
mise install
```

While nix is very powerful, it's an absolutely pain to install and maintain, and this feels a lot more accessible.

I haven't updated any `README`s yet until I get feedback one way or another on if this is desirable to merge :).