### PR TITLE
remove massive console.error in logs when running mobile tests

### DIFF
--- a/packages/mobile/src/components/ChannelList/ChannelList.test.tsx
+++ b/packages/mobile/src/components/ChannelList/ChannelList.test.tsx
@@ -40,7 +40,7 @@ describe('ChannelList component', () => {
           },
           {
             name: 'qa',
-            id: 'design',
+            id: 'qa',
             message:
               'Text from latest chat message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Id massa venenatis id eget massa commodo posuere faucibus aliquam. At scelerisque nisi mauris facilisis.',
             date: 'Yesterday',
@@ -231,7 +231,7 @@ describe('ChannelList component', () => {
               },
               {
                 "date": "Yesterday",
-                "id": "design",
+                "id": "qa",
                 "message": "Text from latest chat message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Id massa venenatis id eget massa commodo posuere faucibus aliquam. At scelerisque nisi mauris facilisis.",
                 "name": "qa",
                 "redirect": [MockFunction],


### PR DESCRIPTION
Noticed this when working on getting CI jobs to be happy with #3011 (_this problem exists on `develop` though_)

<img width="1057" height="779" alt="Screenshot 2025-12-01 at 3 26 47 PM" src="https://github.com/user-attachments/assets/eba4dd57-49d5-4c7e-a06b-9b9835a32f33" />

The test where this would happen would still pass, but you get this error message. This just cleans that up. 