### PR TITLE
Trigger auto-download recheck on settings change

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.test.tsx
@@ -203,7 +203,7 @@ describe('NestedMessageContent', () => {
     `)
   })
 
-  it('renders large image as file', () => {
+  it('renders downloaded large image as image', () => {
     const messages = generateMessages({ type: 2 })
 
     const message = {
@@ -255,100 +255,25 @@ describe('NestedMessageContent', () => {
               data-testid="messagesGroupContent-0"
             >
               <div
-                class="css-bnw0xg"
-                data-testid="abcd1234-fileComponent"
+                class="css-2iuva0"
               >
-                <span>
-                  <div
-                    class=""
-                    data-mui-internal-clone-element="true"
-                    style="display: flex;"
-                  >
-                    <div
-                      class="FileComponenticon"
-                    >
-                      <span
-                        aria-valuenow="100"
-                        class="MuiCircularProgress-root MuiCircularProgress-determinate MuiCircularProgress-colorPrimary css-1036n7b-MuiCircularProgress-root"
-                        role="progressbar"
-                        style="width: 18px; height: 18px; transform: rotate(-90deg); position: absolute; color: rgb(178, 178, 178);"
-                      >
-                        <svg
-                          class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
-                          viewBox="22 22 44 44"
-                        >
-                          <circle
-                            class="MuiCircularProgress-circle MuiCircularProgress-circleDeterminate css-oxts8u-MuiCircularProgress-circle"
-                            cx="44"
-                            cy="44"
-                            fill="none"
-                            r="20"
-                            stroke-width="4"
-                            style="stroke-dasharray: 125.664; stroke-dashoffset: 0.000px;"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        aria-valuenow="50"
-                        class="MuiCircularProgress-root MuiCircularProgress-determinate MuiCircularProgress-colorPrimary css-1036n7b-MuiCircularProgress-root"
-                        role="progressbar"
-                        style="width: 18px; height: 18px; transform: rotate(-90deg); color: rgb(82, 28, 116);"
-                      >
-                        <svg
-                          class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
-                          viewBox="22 22 44 44"
-                        >
-                          <circle
-                            class="MuiCircularProgress-circle MuiCircularProgress-circleDeterminate css-oxts8u-MuiCircularProgress-circle"
-                            cx="44"
-                            cy="44"
-                            fill="none"
-                            r="20"
-                            stroke-width="4"
-                            style="stroke-dasharray: 125.664; stroke-dashoffset: 62.838px;"
-                          />
-                        </svg>
-                      </span>
-                    </div>
-                    <div
-                      class="FileComponentfilename"
-                    >
-                      <h5
-                        class="MuiTypography-root MuiTypography-h5 css-11l3dv4-MuiTypography-root"
-                        style="line-height: 20px; color: rgb(0, 0, 0);"
-                      >
-                        test
-                        .png
-                      </h5>
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-16d47hw-MuiTypography-root"
-                        style="line-height: 20px; color: rgb(127, 127, 127);"
-                      >
-                        20 MB
-                      </p>
-                    </div>
-                  </div>
-                </span>
                 <div
-                  style="padding-top: 16px; display: block;"
+                  class="ImageAttachmentcontainer"
                 >
                   <div
-                    style="cursor: pointer;"
+                    class="ImageAttachmentimage"
+                    data-testid="abcd1234-imageVisual"
                   >
-                    <div
-                      class="css-1vnortn"
+                    <p
+                      class="css-h94c3"
                     >
-                      <img
-                        class="FileComponentactionIcon"
-                        src="test-file-stub"
-                      />
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-16d47hw-MuiTypography-root"
-                        style="color: rgb(127, 127, 127); margin-left: 8px;"
-                      >
-                        Downloading...
-                      </p>
-                    </div>
+                      test.png
+                    </p>
+                    <img
+                      class="ImageAttachmentimage"
+                      src="path/to/file/test.png"
+                      style="width: 400px;"
+                    />
                   </div>
                 </div>
               </div>

--- a/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.tsx
@@ -69,7 +69,8 @@ export const NestedMessageContent: React.FC<NestedMessageContentProps & FileActi
       case 2: {
         // MessageType.Image (cypress tests incompatibility with enums)
         const size = message?.media?.size
-        const fileDisplay = !isMalicious && (!size || size < maxAutodownloadSizeBytes)
+        const isDownloaded = Boolean(message?.media?.path)
+        const fileDisplay = !isMalicious && (isDownloaded || !size || size < maxAutodownloadSizeBytes)
         return (
           <div
             className={classNames({

--- a/packages/state-manager/src/sagas/files/files.master.saga.ts
+++ b/packages/state-manager/src/sagas/files/files.master.saga.ts
@@ -12,6 +12,8 @@ import { deleteFilesFromChannelSaga } from './deleteFilesFromChannel/deleteFiles
 import { uploadFileSaga } from './sendFileMessage/attachFile.saga'
 import { messagesActions } from '../messages/messages.slice'
 import { sendFileMessageSaga } from './attachFile/sendFileMessage.saga'
+import { settingsActions } from '../settings/settings.slice'
+import { recheckAutoDownloadThresholdSaga } from './recheckAutoDownloadThreshold/recheckAutoDownloadThreshold.saga'
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('filesMasterSaga')
@@ -29,6 +31,7 @@ export function* filesMasterSaga(socket: Socket): Generator {
       takeEvery(filesActions.downloadFile.type, downloadFileSaga, socket),
       takeEvery(filesActions.broadcastHostedFile.type, broadcastHostedFileSaga, socket),
       takeEvery(filesActions.deleteFilesFromChannel.type, deleteFilesFromChannelSaga, socket),
+      takeEvery(settingsActions.setMaxAutodownloadBytes.type, recheckAutoDownloadThresholdSaga, socket),
     ])
   } finally {
     logger.info('filesMasterSaga stopping')

--- a/packages/state-manager/src/sagas/files/recheckAutoDownloadThreshold/recheckAutoDownloadThreshold.saga.ts
+++ b/packages/state-manager/src/sagas/files/recheckAutoDownloadThreshold/recheckAutoDownloadThreshold.saga.ts
@@ -1,0 +1,63 @@
+import { apply, put, select } from 'typed-redux-saga'
+import { identitySelectors } from '../../identity/identity.selectors'
+import { messagesSelectors } from '../../messages/messages.selectors'
+import { settingsSelectors } from '../../settings/settings.selectors'
+import { filesActions } from '../files.slice'
+import { filesSelectors } from '../files.selectors'
+import { applyEmitParams, type Socket } from '../../../types'
+import { DownloadState, MessageType, SocketActions } from '@quiet/types'
+import { createLogger } from '../../../utils/logger'
+
+const logger = createLogger('recheckAutoDownloadThresholdSaga')
+
+export function* recheckAutoDownloadThresholdSaga(socket: Socket): Generator {
+  const identity = yield* select(identitySelectors.currentIdentity)
+  if (!identity) {
+    logger.error('Could not recheck auto-download threshold, no identity')
+    return
+  }
+
+  const downloadStatuses = yield* select(filesSelectors.downloadStatuses)
+  const maxAutodownloadSizeBytes = yield* select(settingsSelectors.maxAutodownloadBytes)
+
+  const readyMessageIds = Object.keys(downloadStatuses).filter(
+    mid => downloadStatuses[mid]?.downloadState === DownloadState.Ready
+  )
+
+  if (readyMessageIds.length === 0) {
+    return
+  }
+
+  const messages = yield* select(messagesSelectors.messagesByIds(readyMessageIds))
+  for (const message of messages) {
+    if (!message.media || (message.type !== MessageType.Image && message.type !== MessageType.File)) {
+      continue
+    }
+
+    if (message.media.path) continue
+
+    const messageMediaSize = message.media.size || 0
+    if (messageMediaSize > maxAutodownloadSizeBytes) {
+      continue
+    }
+
+    logger.info(`Re-queuing download for file ${message.media.cid} in message ${message.id} due to threshold change`)
+
+    yield* put(
+      filesActions.updateDownloadStatus({
+        mid: message.id,
+        cid: message.media.cid,
+        downloadState: DownloadState.Queued,
+      })
+    )
+
+    yield* apply(
+      socket,
+      socket.emit,
+      applyEmitParams(SocketActions.DOWNLOAD_FILE, {
+        peerId: identity.networkInfo.peerId.id,
+        metadata: message.media,
+      })
+    )
+  }
+}


### PR DESCRIPTION
This fixes a bug where settings changes in auto-download would not correctly apply retroactively - a follow-up to #571, a fix for #3038.