### PR TITLE
Allow quitting app before renderer sets up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ### Fixes
 
 * DisableWebDrag added to links listed in an issue [#481] (https://github.com/TryQuiet/quiet/issues/481)
- 
+* Fixed being unable to quit application during initial load [#3046](https://github.com/TryQuiet/quiet/issues/3046)
+
 ### Chores
 
 * Change autoupdater text [#2971](https://github.com/TryQuiet/quiet/issues/2971)

--- a/packages/desktop/src/main/main.test.ts
+++ b/packages/desktop/src/main/main.test.ts
@@ -24,6 +24,7 @@ const mockWindowHide = jest.fn()
 const mockWindowClose = jest.fn()
 const mockSetMovable = jest.fn()
 const mockSetAlwaysOnTop = jest.fn()
+const mockIsDestroyed = jest.fn()
 
 const spyCreateWindow = jest.spyOn(main, 'createWindow')
 const spyGetPorts = jest.spyOn(backendHelpers, 'getPorts')
@@ -104,6 +105,7 @@ jest.mock('electron', () => {
           on: mockwebContentsOn,
           once: mockwebContentsOnce,
           send: mockWindowWebContentsSend,
+          isDestroyed: mockIsDestroyed,
         },
       }
     }),

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -23,6 +23,8 @@ const logger = createLogger('main')
 let resetting = false
 let SOCKET_IO_SECRET: string | undefined = undefined
 let updating = false
+let rendererReady = false
+let quitting = false
 
 const updaterInterval = 15 * 60_000
 
@@ -154,6 +156,16 @@ export const applyDevTools = async () => {
   )
 }
 
+const requestStateSaveOrQuit = () => {
+  if (rendererReady && isBrowserWindow(mainWindow) && !mainWindow.webContents.isDestroyed()) {
+    mainWindow.webContents.send('force-save-state')
+    return
+  }
+
+  logger.info('Renderer not ready for state save, quitting immediately')
+  app.quit()
+}
+
 app.on('open-url', (event, url) => {
   // MacOS only
   logger.info('Event app.open-url', url)
@@ -232,6 +244,7 @@ export const createWindow = async () => {
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {
     logger.info('Event mainWindow.closed')
+    rendererReady = false
     mainWindow = null
   })
   mainWindow.on('resize', () => {
@@ -512,10 +525,16 @@ app.on('ready', async () => {
     showSaveImageAs: true,
   })
 
+  if (quitting) {
+    logger.info('Quit requested before backend setup, skipping startup')
+    return
+  }
+
   ports = await getPorts()
   await createWindow()
 
   mainWindow?.webContents.on('did-finish-load', () => {
+    rendererReady = true
     // Only send the secret to the renderer via IPC, not via URL
     if (splash && !splash.isDestroyed()) {
       const [width, height] = splash.getSize()
@@ -650,7 +669,7 @@ app.on('ready', async () => {
     logger.warn('Backend process close event', code, signal)
     backendProcess = null
     if (updating) return
-    mainWindow?.webContents.send('force-save-state')
+    requestStateSaveOrQuit()
   })
 
   backendProcess.on('error', e => {
@@ -853,6 +872,7 @@ app.on('activate', async () => {
 })
 
 app.on('before-quit', e => {
+  quitting = true
   if (backendProcess !== null) {
     logger.info('App before-quit intercepted waiting for backend to exit')
     if (!updating) {


### PR DESCRIPTION
Fixes an issue where requests to quit the app would get swallowed if the main window was not setup yet. This fixes some inconsistency with the oneClient e2e test
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
