### PR TITLE
IPFS Profile Photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Adds hcaptcha verification for protected QSS actions [#2908](https://github.com/TryQuiet/quiet/issues/2908)
 * Add ability to adjust image/file auto-download size threshold [#3019](https://github.com/TryQuiet/quiet/pull/3019)
 * Messages can now be relayed using QSS [#2805](https://github.com/TryQuiet/quiet/issues/2805)
+* Profile photos are now uploaded via IPFS [#3048](https://github.com/TryQuiet/quiet/issues/3048)
 
 ### Fixes
 

--- a/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
+++ b/packages/backend/src/nest/storage/userProfile/userProfile.store.ts
@@ -168,7 +168,8 @@ export class UserProfileStore extends EncryptedKeyValueIndexedValidatedStoreBase
         logger.error('Failed to add user profile, profile is invalid', userProfile.userId)
         throw new Error('Invalid user profile')
       }
-      const encEntry = await this.encryptEntry(userProfile)
+      const sanitizedProfile = UserProfileStore.sanitizeUserProfile(userProfile)
+      const encEntry = await this.encryptEntry(sanitizedProfile)
       await this.getStore().put(key, encEntry)
       this.nicknameMaps.set(userProfile.userId, userProfile.nickname)
       return encEntry
@@ -177,6 +178,30 @@ export class UserProfileStore extends EncryptedKeyValueIndexedValidatedStoreBase
       this.deferredProfiles.push(userProfile)
       throw err
     }
+  }
+
+  /**
+   * Strips sensitive local path information from user profile metadata.
+   * @param userProfile The user profile to sanitize.
+   * @returns A sanitized copy of the user profile.
+   */
+  public static sanitizeUserProfile(userProfile: UserProfile): UserProfile {
+    const sanitized = { ...userProfile }
+    if (sanitized.profilePhoto) {
+      sanitized.profilePhoto = {
+        ...sanitized.profilePhoto,
+        path: null,
+        tmpPath: undefined,
+      }
+    }
+    if (sanitized.fileMetadata) {
+      sanitized.fileMetadata = {
+        ...sanitized.fileMetadata,
+        path: null,
+        tmpPath: undefined,
+      }
+    }
+    return sanitized
   }
 
   /**

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
@@ -10,7 +10,7 @@ import { UserProfile } from '@quiet/types'
 import { useContextMenu } from '../../../../hooks/useContextMenu'
 import { ContextMenu, ContextMenuItemList } from '../ContextMenu.component'
 import { MenuName } from '../../../../const/MenuNames.enum'
-import Jdenticon from '../../Jdenticon/Jdenticon'
+import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 import { createLogger } from '../../../logger'
 
 const logger = createLogger('userProfileContextMenu:container')
@@ -211,21 +211,12 @@ export const UserProfileMenuProfileView: FC<UserProfileMenuProfileViewProps> = (
                 >
                   <Grid container direction='column'>
                     <Grid container direction='column' className={classes.profilePhotoContainer} alignItems='center'>
-                      {userProfile?.photo ? (
-                        <img className={classes.profilePhoto} src={userProfile?.photo} alt={'User profile image'} />
-                      ) : (
-                        <Jdenticon
-                          value={userId}
-                          size='96'
-                          style={{
-                            width: '96px',
-                            height: '96px',
-                            background: theme.palette.background.paper,
-                            borderRadius: '8px',
-                            marginBottom: '16px',
-                          }}
-                        />
-                      )}
+                      <ProfilePhoto
+                        userProfile={userProfile}
+                        userId={userId}
+                        className={classes.profilePhoto}
+                        size={96}
+                      />
                       <Typography variant='body2' className={classes.nickname}>
                         {username}
                       </Typography>
@@ -415,25 +406,12 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
                       </Grid>
                     )}
                     <Grid container direction='column' className={classes.profilePhotoContainer} alignItems='center'>
-                      {userProfile?.photo ? (
-                        <img
-                          className={classes.profilePhoto}
-                          src={userProfile?.photo}
-                          alt={'Your user profile image'}
-                        />
-                      ) : (
-                        <Jdenticon
-                          value={userId}
-                          size='96'
-                          style={{
-                            width: '96px',
-                            height: '96px',
-                            background: theme.palette.background.paper,
-                            borderRadius: '8px',
-                            marginBottom: '16px',
-                          }}
-                        />
-                      )}
+                      <ProfilePhoto
+                        userProfile={userProfile}
+                        userId={userId}
+                        className={classes.profilePhoto}
+                        size={96}
+                      />
                       <EditPhotoButton onChange={onChange} />
                     </Grid>
                     <label htmlFor='username' className={classes.editUsernameFieldLabel}>

--- a/packages/desktop/src/renderer/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/packages/desktop/src/renderer/components/ProfilePhoto/ProfilePhoto.tsx
@@ -12,6 +12,7 @@ interface ProfilePhotoProps {
   className?: string
   size?: number
   style?: React.CSSProperties
+  alt?: string
 }
 
 const hasProfilePhoto = (
@@ -27,7 +28,14 @@ const getProfilePhotoPath = (profile: UserProfile | undefined): string | undefin
   return undefined
 }
 
-export const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ userProfile, userId, className, size = 96, style }) => {
+export const ProfilePhoto: React.FC<ProfilePhotoProps> = ({
+  userProfile,
+  userId,
+  className,
+  size = 96,
+  style,
+  alt,
+}) => {
   const theme = useTheme()
   const profilePhotoPath = getProfilePhotoPath(userProfile)
 
@@ -39,12 +47,14 @@ export const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ userProfile, userId,
     ...style,
   }
 
+  const altText = alt || userProfile?.nickname || 'User profile'
+
   return (
     <>
       {userProfile?.photo ? (
-        <img className={className} src={userProfile.photo} alt={'User profile'} style={defaultStyle} />
+        <img className={className} src={userProfile.photo} alt={altText} style={defaultStyle} />
       ) : profilePhotoPath ? (
-        <img className={className} src={profilePhotoPath} alt={'User profile'} style={defaultStyle} />
+        <img className={className} src={profilePhotoPath} alt={altText} style={defaultStyle} />
       ) : (
         <Jdenticon
           value={userId}

--- a/packages/desktop/src/renderer/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/packages/desktop/src/renderer/components/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,62 @@
+/**
+ * `ProfilePhoto` supports both the deprecated base64-encoded photos and attachment-based photos.
+ */
+import React from 'react'
+import type { UserProfile } from '@quiet/types'
+import Jdenticon from '../Jdenticon/Jdenticon'
+import { useTheme } from '@mui/material/styles'
+
+interface ProfilePhotoProps {
+  userProfile?: UserProfile
+  userId: string
+  className?: string
+  size?: number
+  style?: React.CSSProperties
+}
+
+const hasProfilePhoto = (
+  profile: UserProfile | undefined
+): profile is UserProfile & { profilePhoto: { path: string } } => {
+  return !!profile?.profilePhoto?.path
+}
+
+const getProfilePhotoPath = (profile: UserProfile | undefined): string | undefined => {
+  if (hasProfilePhoto(profile)) {
+    return profile.profilePhoto.path
+  }
+  return undefined
+}
+
+export const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ userProfile, userId, className, size = 96, style }) => {
+  const theme = useTheme()
+  const profilePhotoPath = getProfilePhotoPath(userProfile)
+
+  const defaultStyle = {
+    width: `${size}px`,
+    height: `${size}px`,
+    borderRadius: '4px',
+    marginBottom: '16px',
+    ...style,
+  }
+
+  return (
+    <>
+      {userProfile?.photo ? (
+        <img className={className} src={userProfile.photo} alt={'User profile'} style={defaultStyle} />
+      ) : profilePhotoPath ? (
+        <img className={className} src={profilePhotoPath} alt={'User profile'} style={defaultStyle} />
+      ) : (
+        <Jdenticon
+          value={userId}
+          size={size.toString()}
+          style={{
+            background: theme.palette.background.paper,
+            ...defaultStyle,
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default ProfilePhoto

--- a/packages/desktop/src/renderer/components/Sidebar/ChannelsPanel/ChannelsPanel.test.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar/ChannelsPanel/ChannelsPanel.test.tsx
@@ -419,15 +419,15 @@ describe('Channels panel', () => {
                   <span
                     class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                   >
-                    <div
-                      class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                    <span
+                      class="UserProfileListItemavatar"
                     >
                       <img
                         alt="user_2"
-                        class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                         src="dGVzdAo="
+                        style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                       />
-                    </div>
+                    </span>
                     <span
                       class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                       data-testid="user_2-user-link-status-badge"
@@ -456,15 +456,15 @@ describe('Channels panel', () => {
                   <span
                     class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                   >
-                    <div
-                      class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                    <span
+                      class="UserProfileListItemavatar"
                     >
                       <img
                         alt="user_4"
-                        class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                         src="dGVzdAo="
+                        style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                       />
-                    </div>
+                    </span>
                     <span
                       class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                       data-testid="user_4-user-link-status-badge"
@@ -493,15 +493,15 @@ describe('Channels panel', () => {
                   <span
                     class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                   >
-                    <div
-                      class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                    <span
+                      class="UserProfileListItemavatar"
                     >
                       <img
                         alt="user_6"
-                        class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                         src="dGVzdAo="
+                        style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                       />
-                    </div>
+                    </span>
                     <span
                       class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                       data-testid="user_6-user-link-status-badge"
@@ -813,15 +813,15 @@ describe('Channels panel', () => {
                 <span
                   class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                 >
-                  <div
-                    class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                  <span
+                    class="UserProfileListItemavatar"
                   >
                     <img
                       alt="user_2"
-                      class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                       src="dGVzdAo="
+                      style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                     />
-                  </div>
+                  </span>
                   <span
                     class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                     data-testid="user_2-user-link-status-badge"
@@ -850,15 +850,15 @@ describe('Channels panel', () => {
                 <span
                   class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                 >
-                  <div
-                    class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                  <span
+                    class="UserProfileListItemavatar"
                   >
                     <img
                       alt="user_4"
-                      class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                       src="dGVzdAo="
+                      style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                     />
-                  </div>
+                  </span>
                   <span
                     class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                     data-testid="user_4-user-link-status-badge"
@@ -887,15 +887,15 @@ describe('Channels panel', () => {
                 <span
                   class="MuiBadge-root MuiBadge-root css-1vjx4ah-MuiBadge-root"
                 >
-                  <div
-                    class="MuiAvatar-root MuiAvatar-circular UserProfileListItemavatar css-1ap8qwv-MuiAvatar-root"
+                  <span
+                    class="UserProfileListItemavatar"
                   >
                     <img
                       alt="user_6"
-                      class="MuiAvatar-img css-1pqm26d-MuiAvatar-img"
                       src="dGVzdAo="
+                      style="width: 24px; height: 24px; border-radius: 4px; margin-bottom: 16px;"
                     />
-                  </div>
+                  </span>
                   <span
                     class="MuiBadge-badge MuiBadge-dot MuiBadge-anchorOriginBottomRight MuiBadge-anchorOriginBottomRightCircular MuiBadge-overlapCircular MuiBadge-badge css-mhg7zi-MuiBadge-badge"
                     data-testid="user_6-user-link-status-badge"

--- a/packages/desktop/src/renderer/components/Sidebar/DirectMessagesPanel/UserProfileListItem.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar/DirectMessagesPanel/UserProfileListItem.tsx
@@ -5,11 +5,11 @@ import { Typography, ListItemButton, Avatar } from '@mui/material'
 import Badge from '@mui/material/Badge'
 import ListItemText from '@mui/material/ListItemText'
 import { UserProfile } from '@quiet/types'
-import Jdenticon from '../../Jdenticon/Jdenticon'
 import { useContextMenu } from '../../../../hooks/useContextMenu'
 import { MenuName } from '../../../../const/MenuNames.enum'
 import { users } from '@quiet/state-manager'
 import { useSelector } from 'react-redux'
+import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 
 const PREFIX = 'UserProfileListItem'
 
@@ -30,7 +30,9 @@ const StyledBadge = styled(Badge)(({ theme }) => ({
     minWidth: theme.componentSizes.statusIndicator.size,
     minHeight: theme.componentSizes.statusIndicator.size,
     borderRadius: '50%',
-    border: `${theme.componentSizes.statusIndicator.borderWidth}px solid ${theme.palette.colors?.sidebarBackground || theme.palette.background.default}`,
+    border: `${theme.componentSizes.statusIndicator.borderWidth}px solid ${
+      theme.palette.colors?.sidebarBackground || theme.palette.background.default
+    }`,
     boxSizing: 'border-box',
     right: theme.componentSizes.statusIndicator.position.right,
     bottom: theme.componentSizes.statusIndicator.position.bottom,
@@ -106,17 +108,13 @@ export const UserProfileListItem: React.FC<UserProfileListItemProps> = ({
         variant='dot'
         invisible={!connected}
       >
-        {userProfile.photo ? (
-          <Avatar className={classes.avatar} src={userProfile.photo} alt={userProfile.nickname} />
-        ) : (
-          <span className={classes.avatar}>
-            <Jdenticon
-              value={userProfile.userId}
-              size={theme.componentSizes.avatar.small.toString()}
-              style={{ borderRadius: 4 }}
-            />
-          </span>
-        )}
+        <span className={classes.avatar}>
+          <ProfilePhoto
+            userProfile={userProfile}
+            userId={userProfile.userId}
+            size={theme.componentSizes.avatar.small}
+          />
+        </span>
       </StyledBadge>
       <ListItemText
         primary={

--- a/packages/desktop/src/renderer/components/Sidebar/UserProfilePanel/UserProfilePanel.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar/UserProfilePanel/UserProfilePanel.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography'
 import { Identity, UserProfile } from '@quiet/types'
 
 import { useContextMenu } from '../../../../hooks/useContextMenu'
-import Jdenticon from '../../Jdenticon/Jdenticon'
+import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 
 const PREFIX = 'UserProfilePanel-'
 
@@ -88,21 +88,15 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
         classes={{ root: classes.button }}
         data-testid={'user-profile-menu-button'}
       >
-        {userProfile?.photo ? (
-          <img className={classes.profilePhoto} src={userProfile?.photo} alt={'Your user profile image'} />
-        ) : (
-          <Jdenticon
-            value={userID}
-            size='24'
-            style={{
-              width: '24px',
-              height: '24px',
-              background: theme.palette.background.paper,
-              borderRadius: '4px',
-              marginRight: '8px',
-            }}
-          />
-        )}
+        <ProfilePhoto
+          userProfile={userProfile}
+          userId={userID}
+          className={classes.profilePhoto}
+          size={24}
+          style={{
+            marginRight: '8px',
+          }}
+        />
         <Typography variant='body2' className={classes.nickname} data-testid='user-profile-nickname'>
           {username}
         </Typography>

--- a/packages/desktop/src/renderer/components/widgets/channels/BasicMessage.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/BasicMessage.tsx
@@ -9,7 +9,7 @@ import ListItemText from '@mui/material/ListItemText'
 
 import red from '@mui/material/colors/red'
 
-import Jdenticon from '../../Jdenticon/Jdenticon'
+import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 
 import type { DisplayableMessage, DownloadStatus, MessageSendingStatus } from '@quiet/types'
 
@@ -145,16 +145,16 @@ const formatMessageTime = (timestamp: number | string) => {
 }
 
 const MessageProfilePhoto: React.FC<{ message: DisplayableMessage }> = ({ message }) => {
-  const imgStyle = {
-    width: '36px',
-    height: '36px',
-    borderRadius: '4px',
-    marginRight: '8px',
-  }
-  return message.photo ? (
-    <img style={imgStyle} src={message.photo} alt={"Message author's profile image"} />
-  ) : (
-    <Jdenticon value={message.userId} size='36' />
+  return (
+    <ProfilePhoto
+      userProfile={message}
+      userId={message.userId}
+      size={36}
+      style={{
+        borderRadius: '4px',
+        marginRight: '8px',
+      }}
+    />
   )
 }
 

--- a/packages/e2e-tests/src/enums.ts
+++ b/packages/e2e-tests/src/enums.ts
@@ -29,5 +29,6 @@ export enum SettingsModalTabName {
 export enum PhotoExt {
   GIF = 'gif',
   JPEG = 'jpeg',
+  JPG = 'jpg',
   PNG = 'png',
 }

--- a/packages/e2e-tests/src/selectors.ts
+++ b/packages/e2e-tests/src/selectors.ts
@@ -806,7 +806,7 @@ export class UserProfileContextMenu {
           const photoElement = await this.waitForPhoto()
           const src = await photoElement.getAttribute('src')
 
-          if (src.includes(`image/${ext}`)) {
+          if (src.endsWith(ext)) {
             return src
           }
           i++

--- a/packages/e2e-tests/src/selectors.ts
+++ b/packages/e2e-tests/src/selectors.ts
@@ -804,7 +804,11 @@ export class UserProfileContextMenu {
         let i = 0
         while (i < 5) {
           const photoElement = await this.waitForPhoto()
+
+          logger.info(`found photoElement ${photoElement}`)
           const src = await photoElement.getAttribute('src')
+
+          logger.info(`photoElement src ${src}`)
 
           if (src.endsWith(ext)) {
             return src

--- a/packages/e2e-tests/src/tests/userProfile.test.ts
+++ b/packages/e2e-tests/src/tests/userProfile.test.ts
@@ -91,67 +91,49 @@ describe('User Profile Feature', () => {
   })
 
   it('Owner updates their profile photo with JPEG', async () => {
-    try {
-      logger.info('JPEG')
-      const menu = new UserProfileContextMenu(users.owner.app.driver)
-      await menu.openMenu()
-      await menu.openEditProfileMenu()
-      await menu.uploadJPEGPhoto()
+    logger.info('JPEG')
+    const menu = new UserProfileContextMenu(users.owner.app.driver)
+    await menu.openMenu()
+    await menu.openEditProfileMenu()
+    await menu.uploadJPEGPhoto()
 
-      const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.JPEG)
-      expect(imgSrc).toEqual(EXPECTED_IMG_SRC_JPEG)
+    const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.JPG)
 
-      await menu.back(X_DATA_TESTID.EDIT_PROFILE)
-      await menu.isMenuReady()
-      await menu.back(X_DATA_TESTID.PROFILE)
-      await generalChannelOwner.isMessageInputReady()
-    } catch (e) {
-      logger.error('Failed to set JPEG profile photo', e)
-      throw e
-    }
+    await menu.back(X_DATA_TESTID.EDIT_PROFILE)
+    await menu.isMenuReady()
+    await menu.back(X_DATA_TESTID.PROFILE)
+    await generalChannelOwner.isMessageInputReady()
   })
 
   // Functionality disabled until support is added again
   it.skip('Owner updates their profile photo with GIF', async () => {
-    try {
-      logger.info('GIF')
-      const menu = new UserProfileContextMenu(users.owner.app.driver)
-      await menu.openMenu()
-      await menu.openEditProfileMenu()
-      await menu.uploadGIFPhoto()
+    logger.info('GIF')
+    const menu = new UserProfileContextMenu(users.owner.app.driver)
+    await menu.openMenu()
+    await menu.openEditProfileMenu()
+    await menu.uploadGIFPhoto()
 
-      const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.GIF)
-      expect(imgSrc).toEqual(EXPECTED_IMG_SRC_GIF)
+    const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.GIF)
 
-      await menu.back(X_DATA_TESTID.EDIT_PROFILE)
-      await menu.isMenuReady()
-      await menu.back(X_DATA_TESTID.PROFILE)
-      await generalChannelOwner.isMessageInputReady()
-    } catch (e) {
-      logger.error('Failed to set GIF profile photo', e)
-      throw e
-    }
+    await menu.back(X_DATA_TESTID.EDIT_PROFILE)
+    await menu.isMenuReady()
+    await menu.back(X_DATA_TESTID.PROFILE)
+    await generalChannelOwner.isMessageInputReady()
   })
 
   it('Owner updates their profile photo with PNG', async () => {
-    try {
-      logger.info('PNG')
-      const menu = new UserProfileContextMenu(users.owner.app.driver)
-      await menu.openMenu()
-      await menu.openEditProfileMenu()
-      await menu.uploadPNGPhoto()
+    logger.info('PNG')
+    const menu = new UserProfileContextMenu(users.owner.app.driver)
+    await menu.openMenu()
+    await menu.openEditProfileMenu()
+    await menu.uploadPNGPhoto()
 
-      const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.PNG)
-      expect(imgSrc).toEqual(EXPECTED_IMG_SRC_PNG)
+    const imgSrc = await menu.getProfilePhotoSrc(PhotoExt.PNG)
 
-      await menu.back(X_DATA_TESTID.EDIT_PROFILE)
-      await menu.isMenuReady()
-      await menu.back(X_DATA_TESTID.PROFILE)
-      await generalChannelOwner.isMessageInputReady()
-    } catch (e) {
-      logger.error('Failed to set PNG profile photo', e)
-      throw e
-    }
+    await menu.back(X_DATA_TESTID.EDIT_PROFILE)
+    await menu.isMenuReady()
+    await menu.back(X_DATA_TESTID.PROFILE)
+    await generalChannelOwner.isMessageInputReady()
   })
 
   it('Owner opens the settings tab and gets an invitation link', async () => {
@@ -206,9 +188,21 @@ describe('User Profile Feature', () => {
     expect(text).toEqual(users.owner.messages[0])
 
     const fullMessages = await generalChannelUser1.getUserMessagesFull(users.owner.username)
-    const img = await fullMessages[1].findElement(By.tagName('img'))
-    await users.user1.app.driver.wait(until.elementIsVisible(img), 60_000)
-    const imgSrc = await img.getAttribute('src')
-    expect(imgSrc).toEqual(EXPECTED_IMG_SRC_PNG)
+    const img = await users.user1.app.driver.wait(
+      async () => {
+        const images = await fullMessages[1].findElements(By.tagName('img'))
+        const image = images[0]
+        if (image && (await image.isDisplayed())) {
+          return image
+        }
+        return undefined
+      },
+      60_000,
+      'Owner profile image did not become visible'
+    )
+    if (!img) {
+      fail('Owner profile image did not become visible')
+    }
+    await users.user1.app.driver.wait(until.elementIsVisible(img), 5_000)
   })
 })

--- a/packages/mobile/src/components/Message/Message.component.tsx
+++ b/packages/mobile/src/components/Message/Message.component.tsx
@@ -24,6 +24,12 @@ const MessageProfilePhoto: React.FC<{ message: DisplayableMessage }> = ({ messag
   }
   return message.photo ? (
     <Image style={imgStyle} source={{ uri: message.photo }} alt={"Message author's profile image"} />
+  ) : message.profilePhoto?.path ? (
+    <Image
+      style={imgStyle}
+      source={{ uri: `file://${message.profilePhoto.path}` }}
+      alt={"Message author's profile image"}
+    />
   ) : (
     <Jdenticon value={message.userId} size={37} />
   )

--- a/packages/state-manager/src/sagas/files/broadcastHostedFile/broadcastHostedFile.saga.ts
+++ b/packages/state-manager/src/sagas/files/broadcastHostedFile/broadcastHostedFile.saga.ts
@@ -1,11 +1,11 @@
 import { type PayloadAction } from '@reduxjs/toolkit'
 import { applyEmitParams, type Socket } from '../../../types'
 
-import { select, apply } from 'typed-redux-saga'
+import { select, apply, put } from 'typed-redux-saga'
 import { identitySelectors } from '../../identity/identity.selectors'
 import { messagesSelectors } from '../../messages/messages.selectors'
-import { type filesActions } from '../files.slice'
-import { ChannelMessage, instanceOfChannelMessage, SocketActions } from '@quiet/types'
+import { filesActions } from '../files.slice'
+import { ChannelMessage, instanceOfChannelMessage, SocketActions, PROFILE_PHOTO_CHANNEL_ID } from '@quiet/types'
 import { createLogger } from '../../../utils/logger'
 
 const logger = createLogger('broadcastHostedFileSaga')
@@ -15,6 +15,17 @@ export function* broadcastHostedFileSaga(
   action: PayloadAction<ReturnType<typeof filesActions.broadcastHostedFile>['payload']>
 ): Generator {
   const payload = action.payload
+  if (payload.message.channelId === PROFILE_PHOTO_CHANNEL_ID) {
+    logger.info('Skipping message broadcast for profile photo attachment')
+    yield* put(
+      filesActions.setProfilePhotoMetadata({
+        messageId: payload.message.id,
+        fileMetadata: payload,
+      })
+    )
+    return
+  }
+
   logger.info('Broadcasting hosted file', payload)
   const identity = yield* select(identitySelectors.currentIdentity)
   if (!identity) return

--- a/packages/state-manager/src/sagas/files/files.selectors.ts
+++ b/packages/state-manager/src/sagas/files/files.selectors.ts
@@ -11,6 +11,9 @@ export const downloadStatuses = createSelector(filesSlice, state =>
   downloadStatusAdapter.getSelectors().selectEntities(state.downloadStatus)
 )
 
+export const profilePhotos = createSelector(filesSlice, state => state.profilePhotos)
+
 export const filesSelectors = {
   downloadStatuses,
+  profilePhotos,
 }

--- a/packages/state-manager/src/sagas/files/files.slice.ts
+++ b/packages/state-manager/src/sagas/files/files.slice.ts
@@ -13,6 +13,7 @@ import {
 
 export class FilesState {
   public downloadStatus: EntityState<DownloadStatus> = downloadStatusAdapter.getInitialState()
+  public profilePhotos: Record<string, FileMetadata> = {}
 }
 
 export const filesSlice = createSlice({
@@ -31,6 +32,12 @@ export const filesSlice = createSlice({
     broadcastHostedFile: (state, _action: PayloadAction<FileMetadata>) => state,
     downloadFile: (state, _action: PayloadAction<FileMetadata>) => state,
     updateMessageMedia: (state, _action: PayloadAction<FileMetadata>) => state,
+    setProfilePhotoMetadata: (state, action: PayloadAction<{ messageId: string; fileMetadata: FileMetadata }>) => {
+      if (!state.profilePhotos) {
+        state.profilePhotos = {}
+      }
+      state.profilePhotos[action.payload.messageId] = action.payload.fileMetadata
+    },
     checkForMissingFiles: (state, _action: PayloadAction<CommunityId>) => state,
     deleteFilesFromChannel: (state, _action: PayloadAction<DeleteFilesFromChannelPayload>) => state,
   },

--- a/packages/state-manager/src/sagas/files/updateMessageMedia/updateMessageMedia.test.ts
+++ b/packages/state-manager/src/sagas/files/updateMessageMedia/updateMessageMedia.test.ts
@@ -10,8 +10,9 @@ import { filesActions } from '../files.slice'
 import { messagesActions } from '../../messages/messages.slice'
 import { updateMessageMediaSaga } from './updateMessageMedia'
 import { publicChannelsActions } from '../../publicChannels/publicChannels.slice'
+import { usersActions } from '../../users/users.slice'
 import { DateTime } from 'luxon'
-import { type Community, type Identity, MessageType, type PublicChannel } from '@quiet/types'
+import { type Community, type Identity, MessageType, type PublicChannel, PROFILE_PHOTO_CHANNEL_ID } from '@quiet/types'
 import { publicChannelsSelectors } from '../../publicChannels/publicChannels.selectors'
 import { generateChannelId } from '@quiet/common'
 import { getReduxStoreFactory } from '../../../utils/tests/factories'
@@ -162,6 +163,51 @@ describe('downloadedFileSaga', () => {
           isVerified: true,
         })
       )
+      .run()
+  })
+
+  test('update profile photo media', async () => {
+    const id = 'profile-photo-id'
+    const cid = 'profile-photo-cid'
+
+    const metadata = {
+      cid,
+      path: 'dir/profile.png',
+      name: 'profile',
+      ext: 'png',
+      message: {
+        id,
+        channelId: PROFILE_PHOTO_CHANNEL_ID,
+      },
+    }
+
+    const userProfileWithPhoto = {
+      ...alice,
+      nickname: 'alice',
+      profilePhoto: {
+        cid,
+        path: null,
+      },
+    }
+
+    const updatedUserProfile = {
+      ...userProfileWithPhoto,
+      profilePhoto: metadata,
+    }
+
+    const reducer = combineReducers(testReducers)
+    await expectSaga(updateMessageMediaSaga, filesActions.updateMessageMedia(metadata))
+      .withReducer(reducer)
+      .withState({
+        ...store.getState(),
+        Users: {
+          ...store.getState().Users,
+          userProfiles: {
+            [alice.userId]: userProfileWithPhoto,
+          },
+        },
+      })
+      .put(usersActions.updateUserProfiles([updatedUserProfile]))
       .run()
   })
 })

--- a/packages/state-manager/src/sagas/files/updateMessageMedia/updateMessageMedia.ts
+++ b/packages/state-manager/src/sagas/files/updateMessageMedia/updateMessageMedia.ts
@@ -3,7 +3,9 @@ import { select, put } from 'typed-redux-saga'
 import { messagesSelectors } from '../../messages/messages.selectors'
 import { messagesActions } from '../../messages/messages.slice'
 import { type filesActions } from '../files.slice'
-import { instanceOfChannelMessage } from '@quiet/types'
+import { instanceOfChannelMessage, PROFILE_PHOTO_CHANNEL_ID, UserProfile } from '@quiet/types'
+import { userProfileSelectors } from '../../users/userProfile/userProfile.selectors'
+import { usersActions } from '../../users/users.slice'
 import { createLogger } from '../../../utils/logger'
 
 const logger = createLogger('updateMessageMedia')
@@ -11,6 +13,26 @@ const logger = createLogger('updateMessageMedia')
 export function* updateMessageMediaSaga(
   action: PayloadAction<ReturnType<typeof filesActions.updateMessageMedia>['payload']>
 ): Generator {
+  if (action.payload.message.channelId === PROFILE_PHOTO_CHANNEL_ID) {
+    logger.info('Updating profile photo attachment')
+    const profiles = yield* select(userProfileSelectors.userProfiles)
+    const updatedProfiles: UserProfile[] = []
+
+    for (const profile of Object.values(profiles)) {
+      if (profile.profilePhoto?.cid === action.payload.cid) {
+        updatedProfiles.push({
+          ...profile,
+          profilePhoto: action.payload,
+        })
+      }
+    }
+
+    if (updatedProfiles.length > 0) {
+      yield* put(usersActions.updateUserProfiles(updatedProfiles))
+    }
+    return
+  }
+
   const channelMessages = yield* select(
     messagesSelectors.publicChannelMessagesEntities(action.payload.message.channelId)
   )

--- a/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.test.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.test.ts
@@ -23,8 +23,7 @@ describe('downloadProfilePhotosSaga', () => {
   }
 
   it('should trigger download if path is missing', async () => {
-    await expectSaga(downloadProfilePhotosSaga)
-      .dispatch(usersActions.updateUserProfiles([mockProfile]))
+    await expectSaga(downloadProfilePhotosSaga, usersActions.updateUserProfiles([mockProfile]))
       .put(filesActions.downloadFile(mockFileMetadata))
       .silentRun()
   })
@@ -38,8 +37,7 @@ describe('downloadProfilePhotosSaga', () => {
       },
     }
 
-    await expectSaga(downloadProfilePhotosSaga)
-      .dispatch(usersActions.updateUserProfiles([profileWithPath]))
+    await expectSaga(downloadProfilePhotosSaga, usersActions.updateUserProfiles([profileWithPath]))
       .not.put(filesActions.downloadFile(profileWithPath.profilePhoto))
       .silentRun()
   })
@@ -50,8 +48,7 @@ describe('downloadProfilePhotosSaga', () => {
       profilePhoto: undefined,
     }
 
-    await expectSaga(downloadProfilePhotosSaga)
-      .dispatch(usersActions.updateUserProfiles([profileWithoutPhoto]))
+    await expectSaga(downloadProfilePhotosSaga, usersActions.updateUserProfiles([profileWithoutPhoto]))
       .not.put.actionType(filesActions.downloadFile.type)
       .silentRun()
   })

--- a/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.test.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.test.ts
@@ -1,0 +1,58 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import { downloadProfilePhotosSaga } from './downloadProfilePhotos.saga'
+import { usersActions } from '../users.slice'
+import { filesActions } from '../../files/files.slice'
+import { UserProfile, FileMetadata } from '@quiet/types'
+
+describe('downloadProfilePhotosSaga', () => {
+  const mockFileMetadata: FileMetadata = {
+    cid: 'mock-cid',
+    name: 'mock-name',
+    ext: '.png',
+    path: null,
+    message: {
+      id: 'mock-mid',
+      channelId: 'PROFILE_PHOTO_CHANNEL_ID',
+    },
+  }
+
+  const mockProfile: UserProfile = {
+    userId: 'user-1',
+    nickname: 'alice',
+    profilePhoto: mockFileMetadata,
+  }
+
+  it('should trigger download if path is missing', async () => {
+    await expectSaga(downloadProfilePhotosSaga)
+      .dispatch(usersActions.updateUserProfiles([mockProfile]))
+      .put(filesActions.downloadFile(mockFileMetadata))
+      .silentRun()
+  })
+
+  it('should not trigger download if path is present', async () => {
+    const profileWithPath = {
+      ...mockProfile,
+      profilePhoto: {
+        ...mockFileMetadata,
+        path: '/path/to/photo.png',
+      },
+    }
+
+    await expectSaga(downloadProfilePhotosSaga)
+      .dispatch(usersActions.updateUserProfiles([profileWithPath]))
+      .not.put(filesActions.downloadFile(profileWithPath.profilePhoto))
+      .silentRun()
+  })
+
+  it('should not trigger download if profilePhoto is missing', async () => {
+    const profileWithoutPhoto = {
+      ...mockProfile,
+      profilePhoto: undefined,
+    }
+
+    await expectSaga(downloadProfilePhotosSaga)
+      .dispatch(usersActions.updateUserProfiles([profileWithoutPhoto]))
+      .not.put.actionType(filesActions.downloadFile.type)
+      .silentRun()
+  })
+})

--- a/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.ts
@@ -1,31 +1,25 @@
-import { select, put, takeEvery } from 'typed-redux-saga'
+import { put } from 'typed-redux-saga'
 import { usersActions } from '../users.slice'
 import { filesActions } from '../../files/files.slice'
-import { DownloadState } from '@quiet/types'
 import { createLogger } from '../../../utils/logger'
 import { getProfilePhotoSource } from './userProfile.utils'
 import { type PayloadAction } from '@reduxjs/toolkit'
 
 const logger = createLogger('downloadProfilePhotosSaga')
 
-export function* downloadProfilePhotosSaga(): Generator {
-  logger.info('downloadProfilePhotosSaga starting')
+export function* downloadProfilePhotosSaga(
+  action: PayloadAction<ReturnType<typeof usersActions.updateUserProfiles>['payload']>
+): Generator {
+  const updatedProfiles = action.payload
 
-  yield takeEvery(
-    usersActions.updateUserProfiles.type,
-    function* (action: PayloadAction<ReturnType<typeof usersActions.updateUserProfiles>['payload']>) {
-      const updatedProfiles = action.payload
+  logger.info(`Processing profile photo updateUserProfiles for ${updatedProfiles.length} profiles`)
 
-      logger.info(`Processing profile photo updateUserProfiles for ${updatedProfiles.length} profiles`)
+  for (const profile of updatedProfiles) {
+    const profilePhoto = getProfilePhotoSource(profile)
 
-      for (const profile of updatedProfiles) {
-        const profilePhoto = getProfilePhotoSource(profile)
-
-        if (profilePhoto && typeof profilePhoto === 'object' && !profilePhoto.path) {
-          logger.info(`Triggering download for profile photo of user ${profile.userId}`)
-          yield* put(filesActions.downloadFile(profilePhoto))
-        }
-      }
+    if (profilePhoto && typeof profilePhoto === 'object' && !profilePhoto.path) {
+      logger.info(`Triggering download for profile photo of user ${profile.userId}`)
+      yield* put(filesActions.downloadFile(profilePhoto))
     }
-  )
+  }
 }

--- a/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/downloadProfilePhotos.saga.ts
@@ -1,0 +1,31 @@
+import { select, put, takeEvery } from 'typed-redux-saga'
+import { usersActions } from '../users.slice'
+import { filesActions } from '../../files/files.slice'
+import { DownloadState } from '@quiet/types'
+import { createLogger } from '../../../utils/logger'
+import { getProfilePhotoSource } from './userProfile.utils'
+import { type PayloadAction } from '@reduxjs/toolkit'
+
+const logger = createLogger('downloadProfilePhotosSaga')
+
+export function* downloadProfilePhotosSaga(): Generator {
+  logger.info('downloadProfilePhotosSaga starting')
+
+  yield takeEvery(
+    usersActions.updateUserProfiles.type,
+    function* (action: PayloadAction<ReturnType<typeof usersActions.updateUserProfiles>['payload']>) {
+      const updatedProfiles = action.payload
+
+      logger.info(`Processing profile photo updateUserProfiles for ${updatedProfiles.length} profiles`)
+
+      for (const profile of updatedProfiles) {
+        const profilePhoto = getProfilePhotoSource(profile)
+
+        if (profilePhoto && typeof profilePhoto === 'object' && !profilePhoto.path) {
+          logger.info(`Triggering download for profile photo of user ${profile.userId}`)
+          yield* put(filesActions.downloadFile(profilePhoto))
+        }
+      }
+    }
+  )
+}

--- a/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.test.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.test.ts
@@ -1,26 +1,30 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { Blob } from 'buffer'
+import { call, select } from 'redux-saga-test-plan/matchers'
 import { type FactoryGirl } from 'factory-girl'
+import { combineReducers } from 'redux'
 
 import { getReduxStoreFactory } from '../../..'
 import { type Store } from '../../store.types'
-import { saveUserProfileSaga } from './saveUserProfile.saga'
-import { usersActions } from '../users.slice'
 import { prepareStore, testReducers } from '../../../utils/tests/prepareStore'
-import { type Socket } from '../../../types'
-import { type Identity, SocketActions, UserProfile } from '@quiet/types'
 import { MockedSocket } from '../../../utils/tests/mockedSocket'
 import { getBaseTypesFactory, getSocketFactory } from '../../../utils/tests/factories'
-import { fileToBase64String } from '@quiet/common'
-import { combineReducers } from 'redux'
-import { createLogger } from '../../../utils/logger'
 
-const PHOTO_B64 = 'dGVzdAo='
+import { saveUserProfileSaga } from './saveUserProfile.saga'
+import { usersActions } from '../users.slice'
+import { filesActions } from '../../files/files.slice'
+import { filesSelectors } from '../../files/files.selectors'
+import { generateMessageId } from '../../messages/utils/message.utils'
 
-jest.mock('@quiet/common', () => ({
-  ...jest.requireActual('@quiet/common'),
-  fileToBase64String: jest.fn(() => Promise.resolve(PHOTO_B64)),
-}))
+import {
+  type Identity,
+  type UserProfile,
+  type FileMetadata,
+  DownloadState,
+  PROFILE_PHOTO_CHANNEL_ID,
+  SocketActions,
+} from '@quiet/types'
+import { type Socket } from '../../../types'
 
 describe('saveUserProfileSaga', () => {
   let store: Store
@@ -31,57 +35,281 @@ describe('saveUserProfileSaga', () => {
   let userProfile: UserProfile
 
   beforeEach(async () => {
-    const socketPayloadFactory = await getSocketFactory()
     socket = new MockedSocket()
+
+    // Make SET_USER_PROFILE succeed deterministically.
+    socket.registerExpectedResponse(SocketActions.SET_USER_PROFILE, { success: true })
+
     store = prepareStore().store
     reduxFactory = await getReduxStoreFactory(store)
     baseTypesFactory = await getBaseTypesFactory()
+
     identity = await reduxFactory.create('Identity')
-    userProfile = await reduxFactory.create('UserProfile', {
-      userId: identity.userId,
-    })
+    userProfile = await reduxFactory.create('UserProfile', { userId: identity.userId })
   })
 
-  // currently frontend doesn't supprot removing the photo
-  // from the user profile, so we are skipping this test
-  test.skip('sends user profile without photo to backend', async () => {
-    const logger = createLogger('saveUserProfileSaga-test1')
-    delete userProfile.photo
-    logger.info('userProfile', userProfile)
-    // We are testing browser-targeting code in NodeJS and this
-    // version of NodeJS doesn't have a File class, so we are using a
-    // Blob instead.
+  const makeFile = (name: string, path: string): File => {
+    return Object.assign(new Blob([]), { name, path }) as any as File
+  }
+
+  const makeUploadStatusAction = (mid: string, downloadState: DownloadState) =>
+    filesActions.updateDownloadStatus({
+      mid,
+      cid: `attaching_${mid}`,
+      downloadState,
+      downloadProgress: undefined,
+    })
+
+  test('uploads profile photo via ATTACH_FILE and saves profile with attachment-based profilePhoto', async () => {
+    const fixedId = 'fixed-upload-id'
+    const profilePhotoMessageId = `profile-photo-${identity.userId}-${fixedId}`
+
+    const uploadedMetadata: FileMetadata = {
+      name: `profile-photo-${identity.userId}`,
+      ext: '.jpg',
+      path: '/tmp/profile-photo.jpg',
+      cid: 'bafy-test-cid',
+      message: {
+        id: profilePhotoMessageId,
+        channelId: PROFILE_PHOTO_CHANNEL_ID,
+      },
+    }
+
+    let profilePhotosSelectCalls = 0
+
+    let takeCalls = 0
+    const provideTake = () => ({
+      take(effect: any, next: any) {
+        // The saga only takes updateDownloadStatus inside the upload loop.
+        // We return a Hosted status for our upload MID.
+        takeCalls += 1
+        if (takeCalls === 1) {
+          return makeUploadStatusAction(profilePhotoMessageId, DownloadState.Hosted)
+        }
+        return next()
+      },
+    })
+
+    const photo = makeFile('photo.jpg', '/tmp/photo.jpg')
+
     await expectSaga(
       saveUserProfileSaga,
       socket as unknown as Socket,
       // @ts-ignore
+      usersActions.saveUserProfile({ photo, nickname: userProfile.nickname, bio: userProfile.bio })
+    )
+      .withReducer(combineReducers(testReducers))
+      .withState(store.getState())
+      .provide([
+        // deterministic upload message id
+        [call.fn(generateMessageId), fixedId],
+        {
+          select: ({ selector }: any, next: any) => {
+            if (selector === filesSelectors.profilePhotos) {
+              profilePhotosSelectCalls += 1
+              // In the first test, we expect it to be empty initially, then contain the uploaded metadata.
+              // But wait, the saga now ALWAYS uploads, so it will always call select(profilePhotos) AFTER Hosted.
+              return { [profilePhotoMessageId]: uploadedMetadata }
+            }
+            return next()
+          },
+          take: provideTake().take,
+        },
+      ])
+      .put.like({
+        action: {
+          type: filesActions.updateDownloadStatus.type,
+          payload: {
+            mid: profilePhotoMessageId,
+            downloadState: DownloadState.Attaching,
+          },
+        },
+      })
+      .call.like({ context: socket, fn: socket.emit })
+      .call.like({
+        context: socket,
+        fn: socket.emitWithAck,
+        args: [
+          SocketActions.SET_USER_PROFILE,
+          {
+            profile: {
+              userId: identity.userId,
+              nickname: userProfile.nickname,
+              bio: userProfile.bio,
+              profilePhoto: {
+                ...uploadedMetadata,
+                path: null,
+              },
+              photo: undefined,
+            },
+          },
+        ],
+      })
+      .put.like({
+        action: {
+          type: usersActions.setUserProfile.type,
+          payload: {
+            userId: identity.userId,
+            photo: undefined,
+            profilePhoto: uploadedMetadata,
+          },
+        },
+      })
+      .put.like({
+        action: { type: usersActions.setSaveUserProfileError.type, payload: null },
+      })
+      .run()
+  })
+
+  test('handles profile photo upload failure (Canceled) by setting error and aborting save', async () => {
+    const fixedId = 'fixed-fail-id'
+    const profilePhotoMessageId = `profile-photo-${identity.userId}-${fixedId}`
+
+    let takeCalls = 0
+    const provideTake = () => ({
+      take(effect: any, next: any) {
+        takeCalls += 1
+        if (takeCalls === 1) {
+          return makeUploadStatusAction(profilePhotoMessageId, DownloadState.Canceled)
+        }
+        return next()
+      },
+    })
+
+    const photo = makeFile('photo.jpg', '/tmp/photo.jpg')
+
+    await expectSaga(
+      saveUserProfileSaga,
+      socket as unknown as Socket,
+      // @ts-ignore
+      usersActions.saveUserProfile({ photo, nickname: userProfile.nickname, bio: userProfile.bio })
+    )
+      .withReducer(combineReducers(testReducers))
+      .withState(store.getState())
+      .provide([[call.fn(generateMessageId), fixedId], { take: provideTake().take }])
+      .put.like({
+        action: {
+          type: filesActions.updateDownloadStatus.type,
+          payload: {
+            mid: profilePhotoMessageId,
+            downloadState: DownloadState.Attaching,
+          },
+        },
+      })
+      .call.like({ context: socket, fn: socket.emit })
+      .put.like({
+        action: { type: usersActions.setSaveUserProfileError.type, payload: 'Profile photo upload failed' },
+      })
+      // Must not call SET_USER_PROFILE when upload failed
+      .not.call.like({ context: socket, fn: socket.emitWithAck })
+      .not.put.like({ action: { type: usersActions.setUserProfile.type } })
+      .run()
+  })
+
+  test('when no profile photo is provided, saves profile without touching upload flow', async () => {
+    await expectSaga(
+      saveUserProfileSaga,
+      socket as unknown as Socket,
       usersActions.saveUserProfile({ photo: undefined, nickname: userProfile.nickname, bio: userProfile.bio })
     )
       .withReducer(combineReducers(testReducers))
       .withState(store.getState())
-      .not.call(fileToBase64String, expect.any(Blob))
-      .put(usersActions.setUserProfile(userProfile))
-      .apply(socket, socket.emitWithAck, [SocketActions.SET_USER_PROFILE, { profile: userProfile }])
+      // Must not generate upload message IDs or emit ATTACH_FILE
+      .not.call.fn(generateMessageId)
+      .not.call.like({ context: socket, fn: socket.emit })
+      // Should call SET_USER_PROFILE
+      .call.like({ context: socket, fn: socket.emitWithAck })
+      // Should keep existing base64 photo and set profilePhoto undefined
+      .put.like({
+        action: {
+          type: usersActions.setUserProfile.type,
+          payload: {
+            userId: identity.userId,
+            photo: userProfile.photo,
+            profilePhoto: undefined,
+          },
+        },
+      })
+      .put.like({ action: { type: usersActions.setSaveUserProfileError.type, payload: null } })
       .run()
   })
 
-  test('sends user profile with photo to backend', async () => {
-    const logger = createLogger('saveUserProfileSaga-test2')
-    logger.info('userProfile', JSON.stringify(userProfile, null, 2))
+  test('always uploads new profile photo even if metadata exists in state', async () => {
+    const existingMid = `profile-photo-${identity.userId}-existing`
+    const existingMetadata: FileMetadata = {
+      name: `profile-photo-${identity.userId}`,
+      ext: '.jpg',
+      path: '/tmp/existing-profile-photo.jpg',
+      cid: 'bafy-existing-cid',
+      message: {
+        id: existingMid,
+        channelId: PROFILE_PHOTO_CHANNEL_ID,
+      },
+    }
 
-    // We are testing browser-targeting code in NodeJS and this
-    // version of NodeJS doesn't have a File class, so we are using a
-    // Blob instead.
+    const fixedId = 'fixed-upload-id'
+    const profilePhotoMessageId = `profile-photo-${identity.userId}-${fixedId}`
+    const uploadedMetadata: FileMetadata = {
+      ...existingMetadata,
+      cid: 'bafy-new-cid',
+      message: {
+        id: profilePhotoMessageId,
+        channelId: PROFILE_PHOTO_CHANNEL_ID,
+      },
+    }
+
+    let takeCalls = 0
+    const provideTake = () => ({
+      take(effect: any, next: any) {
+        takeCalls += 1
+        if (takeCalls === 1) {
+          return makeUploadStatusAction(profilePhotoMessageId, DownloadState.Hosted)
+        }
+        return next()
+      },
+    })
+
+    const photo = makeFile('photo.jpg', '/tmp/photo.jpg')
+
     await expectSaga(
       saveUserProfileSaga,
       socket as unknown as Socket,
       // @ts-ignore
-      usersActions.saveUserProfile({ photo: new Blob([]), nickname: userProfile.nickname, bio: userProfile.bio })
+      usersActions.saveUserProfile({ photo, nickname: userProfile.nickname, bio: userProfile.bio })
     )
       .withReducer(combineReducers(testReducers))
       .withState(store.getState())
-      .put(usersActions.setUserProfile(userProfile))
-      .apply(socket, socket.emitWithAck, [SocketActions.SET_USER_PROFILE, { profile: userProfile }])
+      .provide([
+        [call.fn(generateMessageId), fixedId],
+        [
+          select(filesSelectors.profilePhotos),
+          { [existingMid]: existingMetadata, [profilePhotoMessageId]: uploadedMetadata },
+        ],
+        { take: provideTake().take },
+      ])
+      // Should upload again
+      .call.fn(generateMessageId)
+      .call.like({ context: socket, fn: socket.emit })
+      // Should save profile with NEW metadata
+      .call.like({
+        context: socket,
+        fn: socket.emitWithAck,
+        args: [
+          SocketActions.SET_USER_PROFILE,
+          {
+            profile: {
+              userId: identity.userId,
+              nickname: userProfile.nickname,
+              bio: userProfile.bio,
+              profilePhoto: {
+                ...uploadedMetadata,
+                path: null,
+              },
+              photo: undefined,
+            },
+          },
+        ],
+      })
       .run()
   })
 })

--- a/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.ts
@@ -1,19 +1,25 @@
 import { type PayloadAction } from '@reduxjs/toolkit'
-import { call, select, apply, put } from 'typed-redux-saga'
+import { call, select, apply, put, take } from 'typed-redux-saga'
 import {
   UserProfile,
   UserProfileDisplayData,
   SocketActions,
   SaveUserProfileActionPayload,
   SetUserProfilePayload,
+  FileMetadata,
+  DownloadState,
+  DownloadStatus,
+  PROFILE_PHOTO_CHANNEL_ID,
 } from '@quiet/types'
-import { fileToBase64String } from '@quiet/common'
 
 import { identitySelectors } from '../../identity/identity.selectors'
 import { type Socket, applyEmitParams } from '../../../types'
 import { createLogger } from '../../../utils/logger'
 import { usersActions } from '../users.slice'
 import { userProfileSelectors } from './userProfile.selectors'
+import { filesActions } from '../../files/files.slice'
+import { filesSelectors } from '../../files/files.selectors'
+import { generateMessageId } from '../../messages/utils/message.utils'
 
 const logger = createLogger('saveUserProfileSaga')
 
@@ -26,14 +32,79 @@ export function* saveUserProfileSaga(socket: Socket, action: PayloadAction<SaveU
     return
   }
 
-  let base64EncodedPhoto: string | undefined = undefined
+  let profilePhotoMetadata: FileMetadata | undefined = undefined
+
   if (action.payload.photo) {
-    try {
-      base64EncodedPhoto = yield* call(fileToBase64String, action.payload.photo)
-    } catch (err) {
-      logger.error('Failed to base64 encode profile photo', err)
-      yield* put(usersActions.setSaveUserProfileError('Failed to base64 encode profile photo'))
-      return
+    if (!profilePhotoMetadata) {
+      logger.info('No profile photo metadata found, starting upload process')
+      const file = action.payload.photo!
+      const id = yield* call(generateMessageId)
+
+      const profilePhotoMessageId = `profile-photo-${identity.userId}-${id}`
+      const media: FileMetadata = {
+        name: `profile-photo-${identity.userId}`,
+        ext: '.' + (file.name || '').split('.').pop(),
+        path: (file as any).path,
+        cid: `attaching_${profilePhotoMessageId}`,
+        message: {
+          id: profilePhotoMessageId,
+          channelId: PROFILE_PHOTO_CHANNEL_ID,
+        },
+      }
+
+      yield* apply(
+        socket,
+        socket.emit,
+        applyEmitParams(SocketActions.ATTACH_FILE, {
+          file: media,
+          peerId: identity.networkInfo.peerId.id,
+        })
+      )
+
+      yield* put(
+        filesActions.updateDownloadStatus({
+          mid: profilePhotoMessageId,
+          cid: `attaching_${profilePhotoMessageId}`,
+          downloadState: DownloadState.Attaching,
+          downloadProgress: undefined,
+        })
+      )
+
+      while (true) {
+        const uploadAction: ReturnType<typeof filesActions.updateDownloadStatus> = yield* take(
+          filesActions.updateDownloadStatus
+        )
+
+        if (
+          uploadAction.payload.mid === profilePhotoMessageId &&
+          uploadAction.payload.downloadState === DownloadState.Hosted
+        ) {
+          logger.info('Profile photo uploaded successfully')
+
+          const profilePhotos = yield* select(filesSelectors.profilePhotos)
+          const fileMetadata = profilePhotos[profilePhotoMessageId]
+
+          if (fileMetadata) {
+            profilePhotoMetadata = fileMetadata
+            logger.info('Profile photo metadata found in state')
+            break
+          } else {
+            logger.error('File metadata not found after upload')
+            yield* put(usersActions.setSaveUserProfileError('Failed to get profile photo metadata after upload'))
+            return
+          }
+        }
+
+        if (
+          uploadAction.payload.mid === profilePhotoMessageId &&
+          (uploadAction.payload.downloadState === DownloadState.Canceled ||
+            uploadAction.payload.downloadState === DownloadState.Malicious)
+        ) {
+          logger.error('Profile photo upload failed')
+          yield* put(usersActions.setSaveUserProfileError('Profile photo upload failed'))
+          return
+        }
+      }
     }
   }
 
@@ -51,11 +122,21 @@ export function* saveUserProfileSaga(socket: Socket, action: PayloadAction<SaveU
         ? action.payload.nickname
         : (existingUserProfile?.nickname ?? ''),
     bio: action.payload.bio && action.payload.bio.trim() !== '' ? action.payload.bio : existingUserProfile?.bio,
-    photo: base64EncodedPhoto && base64EncodedPhoto.trim() !== '' ? base64EncodedPhoto : existingUserProfile?.photo,
+    profilePhoto: profilePhotoMetadata,
+    // Clear the base64 photo when using attachment-based photo
+    photo: profilePhotoMetadata ? undefined : existingUserProfile?.photo,
   }
 
   const socketPayload: SetUserProfilePayload = {
-    profile: userProfile,
+    profile: {
+      ...userProfile,
+      profilePhoto: userProfile.profilePhoto
+        ? {
+            ...userProfile.profilePhoto,
+            path: null,
+          }
+        : undefined,
+    },
   }
 
   const response = yield* apply(

--- a/packages/state-manager/src/sagas/users/userProfile/userProfile.utils.test.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/userProfile.utils.test.ts
@@ -1,0 +1,88 @@
+import { getProfilePhotoSource, createDisplayProfile } from './userProfile.utils'
+import { UserProfile, FileMetadata } from '@quiet/types'
+
+describe('userProfile.utils', () => {
+  let mockUserProfile: UserProfile
+  let mockFileMetadata: FileMetadata
+
+  beforeEach(() => {
+    mockFileMetadata = {
+      name: 'profile-photo',
+      ext: '.jpg',
+      path: 'mock-path',
+      cid: 'test-cid',
+      size: 1024,
+      width: 200,
+      height: 200,
+      message: {
+        id: 'profile-photo-test-id',
+        channelId: 'profile-photo',
+      },
+    }
+
+    mockUserProfile = {
+      userId: 'test-user-id',
+      nickname: 'Test User',
+      bio: 'Test bio',
+    }
+  })
+
+  describe('getProfilePhotoSource', () => {
+    it('should return attachment-based photo when available', () => {
+      mockUserProfile.profilePhoto = mockFileMetadata
+      mockUserProfile.photo = 'base64-photo-data'
+
+      const result = getProfilePhotoSource(mockUserProfile)
+      expect(result).toBe(mockFileMetadata)
+    })
+
+    it('should return base64 photo when attachment-based photo is not available', () => {
+      mockUserProfile.photo = 'base64-photo-data'
+
+      const result = getProfilePhotoSource(mockUserProfile)
+      expect(result).toBe('base64-photo-data')
+    })
+
+    it('should return undefined when no photo is available', () => {
+      const result = getProfilePhotoSource(mockUserProfile)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('createDisplayProfile', () => {
+    it('should create display profile with attachment-based photo', () => {
+      mockUserProfile.profilePhoto = mockFileMetadata
+      mockUserProfile.photo = 'base64-photo-data'
+
+      const result = createDisplayProfile(mockUserProfile)
+
+      expect(result.profilePhoto).toBe(mockFileMetadata)
+      expect(result.photo).toBeUndefined() // Should be cleared for display
+      expect(result.userId).toBe(mockUserProfile.userId)
+      expect(result.nickname).toBe(mockUserProfile.nickname)
+      expect(result.bio).toBe(mockUserProfile.bio)
+    })
+
+    it('should create display profile with base64 photo', () => {
+      mockUserProfile.photo = 'base64-photo-data'
+
+      const result = createDisplayProfile(mockUserProfile)
+
+      expect(result.profilePhoto).toBeUndefined()
+      expect(result.photo).toBe('base64-photo-data')
+      expect(result.userId).toBe(mockUserProfile.userId)
+      expect(result.nickname).toBe(mockUserProfile.nickname)
+      expect(result.bio).toBe(mockUserProfile.bio)
+    })
+
+    it('should create display profile with no photo', () => {
+      const result = createDisplayProfile(mockUserProfile)
+
+      expect(result.profilePhoto).toBeUndefined()
+      expect(result.photo).toBeUndefined()
+      expect(result.userId).toBe(mockUserProfile.userId)
+      expect(result.nickname).toBe(mockUserProfile.nickname)
+      expect(result.bio).toBe(mockUserProfile.bio)
+    })
+  })
+})

--- a/packages/state-manager/src/sagas/users/userProfile/userProfile.utils.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/userProfile.utils.ts
@@ -1,0 +1,22 @@
+import { UserProfile, FileMetadata } from '@quiet/types'
+
+export function getProfilePhotoSource(userProfile: UserProfile): FileMetadata | string | undefined {
+  if (userProfile.profilePhoto) {
+    return userProfile.profilePhoto
+  }
+
+  if (userProfile.photo) {
+    return userProfile.photo
+  }
+
+  return undefined
+}
+
+export function createDisplayProfile(userProfile: UserProfile): UserProfile {
+  return {
+    ...userProfile,
+    // Ensure only one photo field is set for display
+    photo: userProfile.profilePhoto ? undefined : userProfile.photo,
+    profilePhoto: userProfile.profilePhoto,
+  }
+}

--- a/packages/state-manager/src/sagas/users/users.master.saga.ts
+++ b/packages/state-manager/src/sagas/users/users.master.saga.ts
@@ -3,6 +3,7 @@ import { all } from 'typed-redux-saga'
 import { type Socket } from '../../types'
 import { usersActions } from './users.slice'
 import { saveUserProfileSaga } from './userProfile/saveUserProfile.saga'
+import { downloadProfilePhotosSaga } from './userProfile/downloadProfilePhotos.saga'
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('usersMasterSaga')
@@ -10,7 +11,10 @@ const logger = createLogger('usersMasterSaga')
 export function* usersMasterSaga(socket: Socket): Generator {
   logger.info('usersMasterSaga starting')
   try {
-    yield all([takeEvery(usersActions.saveUserProfile.type, saveUserProfileSaga, socket)])
+    yield all([
+      takeEvery(usersActions.saveUserProfile.type, saveUserProfileSaga, socket),
+      takeEvery(usersActions.updateUserProfiles.type, downloadProfilePhotosSaga),
+    ])
   } finally {
     logger.info('usersMasterSaga stopping')
     if (yield cancelled()) {

--- a/packages/state-manager/src/sagas/users/users.slice.test.ts
+++ b/packages/state-manager/src/sagas/users/users.slice.test.ts
@@ -1,0 +1,89 @@
+import { usersSlice, UsersState } from './users.slice'
+import { UserProfile, FileMetadata } from '@quiet/types'
+
+describe('usersSlice', () => {
+  describe('updateUserProfiles', () => {
+    it('should clear profilePhoto.path if CID changes', () => {
+      const userId = 'user-1'
+      const oldCid = 'old-cid'
+      const newCid = 'new-cid'
+
+      const initialState: UsersState = {
+        userProfiles: {
+          [userId]: {
+            userId,
+            nickname: 'alice',
+            profilePhoto: {
+              cid: oldCid,
+              path: '/path/to/old/photo.png',
+              name: 'photo',
+              ext: '.png',
+              message: { id: 'mid-1', channelId: 'PROFILE_PHOTO_CHANNEL_ID' },
+            } as FileMetadata,
+          } as UserProfile,
+        },
+        users: {},
+        saveUserProfileError: null,
+      }
+
+      const updatedProfile: UserProfile = {
+        userId,
+        nickname: 'alice',
+        profilePhoto: {
+          cid: newCid,
+          path: null, // Backend sends null path
+          name: 'photo',
+          ext: '.png',
+          message: { id: 'mid-2', channelId: 'PROFILE_PHOTO_CHANNEL_ID' },
+        } as FileMetadata,
+      }
+
+      const nextState = usersSlice.reducer(initialState, usersSlice.actions.updateUserProfiles([updatedProfile]))
+
+      expect(nextState.userProfiles[userId].profilePhoto?.cid).toBe(newCid)
+      expect(nextState.userProfiles[userId].profilePhoto?.path).toBeNull()
+    })
+
+    it('should NOT clear profilePhoto.path if CID is the same', () => {
+      const userId = 'user-1'
+      const cid = 'same-cid'
+      const path = '/path/to/photo.png'
+
+      const initialState: UsersState = {
+        userProfiles: {
+          [userId]: {
+            userId,
+            nickname: 'alice',
+            profilePhoto: {
+              cid,
+              path,
+              name: 'photo',
+              ext: '.png',
+              message: { id: 'mid-1', channelId: 'PROFILE_PHOTO_CHANNEL_ID' },
+            } as FileMetadata,
+          } as UserProfile,
+        },
+        users: {},
+        saveUserProfileError: null,
+      }
+
+      const updatedProfile: UserProfile = {
+        userId,
+        nickname: 'alice-updated',
+        profilePhoto: {
+          cid,
+          path: null, // Backend might send null path even if we have it locally
+          name: 'photo',
+          ext: '.png',
+          message: { id: 'mid-1', channelId: 'PROFILE_PHOTO_CHANNEL_ID' },
+        } as FileMetadata,
+      }
+
+      const nextState = usersSlice.reducer(initialState, usersSlice.actions.updateUserProfiles([updatedProfile]))
+
+      expect(nextState.userProfiles[userId].nickname).toBe('alice-updated')
+      expect(nextState.userProfiles[userId].profilePhoto?.cid).toBe(cid)
+      expect(nextState.userProfiles[userId].profilePhoto?.path).toBe(path)
+    })
+  })
+})

--- a/packages/state-manager/src/sagas/users/users.slice.ts
+++ b/packages/state-manager/src/sagas/users/users.slice.ts
@@ -1,6 +1,12 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { StoreKeys } from '../store.keys'
-import { UserProfile, User, SaveUserProfileActionPayload, DeleteUserProfileActionPayload } from '@quiet/types'
+import {
+  UserProfile,
+  User,
+  SaveUserProfileActionPayload,
+  DeleteUserProfileActionPayload,
+  FileMetadata,
+} from '@quiet/types'
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('usersSlice')
@@ -40,10 +46,34 @@ export const usersSlice = createSlice({
       }
       for (const userProfile of action.payload) {
         if (state.userProfiles[userProfile.userId]) {
-          state.userProfiles[userProfile.userId] = {
-            ...state.userProfiles[userProfile.userId],
+          const existingProfile = state.userProfiles[userProfile.userId]
+
+          const updatedProfile = {
+            ...existingProfile,
             ...userProfile,
           }
+
+          // If CID is the same, preserve the existing path
+          if (
+            userProfile.profilePhoto?.cid &&
+            existingProfile.profilePhoto?.cid === userProfile.profilePhoto.cid &&
+            existingProfile.profilePhoto?.path
+          ) {
+            updatedProfile.profilePhoto = {
+              ...userProfile.profilePhoto,
+              path: existingProfile.profilePhoto.path,
+            }
+          }
+
+          // If CID changed, ensure path is null (it should be null from userProfile anyway, but let's be explicit)
+          if (userProfile.profilePhoto?.cid && existingProfile.profilePhoto?.cid !== userProfile.profilePhoto.cid) {
+            updatedProfile.profilePhoto = {
+              ...userProfile.profilePhoto,
+              path: null,
+            }
+          }
+
+          state.userProfiles[userProfile.userId] = updatedProfile
         } else {
           state.userProfiles[userProfile.userId] = userProfile
         }

--- a/packages/state-manager/src/utils/functions/dates/formatDisplayableMessage.ts
+++ b/packages/state-manager/src/utils/functions/dates/formatDisplayableMessage.ts
@@ -15,5 +15,6 @@ export const displayableMessage = (message: ChannelMessage, profile: UserProfile
     isDuplicated: false,
     media: message.media,
     photo: profile.photo,
+    profilePhoto: profile.profilePhoto,
   }
 }

--- a/packages/types/src/channel.ts
+++ b/packages/types/src/channel.ts
@@ -2,6 +2,8 @@ import { type EntityState } from '@reduxjs/toolkit'
 import { type FileMetadata } from './files'
 import { Base58, KeyMetadata } from '@localfirst/crdx'
 
+export const PROFILE_PHOTO_CHANNEL_ID = '__profile-photo__'
+
 export const INITIAL_CURRENT_CHANNEL_ID = 'initialcurrentChannelId'
 
 export interface PublicChannel {
@@ -67,7 +69,8 @@ export interface DisplayableMessage {
   media?: FileMetadata
   isRegistered: boolean
   isDuplicated: boolean
-  photo?: string // base64 encoded image
+  photo?: string // base64 encoded image, deprecated
+  profilePhoto?: FileMetadata
   pubkey?: string // deprecated
   signature?: string // deprecated
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './errors'
+export * from './channel'
 export * from './process'
 export * from './socket'
 export * from './identity'

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -13,7 +13,8 @@ export interface User {
 }
 
 export interface UserProfileDisplayData {
-  photo?: string // base64 encoded image
+  photo?: string // base64 encoded image (legacy)
+  profilePhoto?: FileMetadata
   nickname: string
   bio?: string
 }
@@ -21,10 +22,11 @@ export interface UserProfileDisplayData {
 export interface UserProfile {
   userId: string
   nickname: string
-  photo?: string // base64 encoded image
+  photo?: string // base64 encoded image (legacy)
   fileMetadata?: FileMetadata
   bio?: string
   userData?: UserData
+  profilePhoto?: FileMetadata
 }
 
 // ----


### PR DESCRIPTION
### Migration

This update deprecates the previous profile photo method of setting a base64-encoded image URI within the profile metadata, in favor of using the IPFS attachment upload pipeline.

Old profile photos are still displayed as expected, but when a new profile photo is set, it will *only* use the new IPFS flow, so older clients will not see a photo. I can change this to do both at the same time, but that feels like it defeats the purpose a bit, and we're at the turn of a new major version here as well.

### Approach

This creates a new "virtual channel" for attachment photos so that we can reuse as much of the same image attachment processing pipeline as possible.

Some things obviously couldn't be handled the same, though, so you'll notice some conditional handling of profile photo attachments that stray from the typical assumption that an attachment is associated with a message in a viewable chat room.

Fixes #2926.
