### PR TITLE
Add mise package manager config and documentation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,157 @@
+min_version = "2025.11.0"
+
+[env]
+
+[hooks]
+
+[tools]
+# general dev/sdk tools & dependencies
+usage = "latest" # needed by mise for shell completions
+git-lfs = "latest"
+tmux = "latest"
+
+# project-wide dependencies
+node = "18.20.4"
+npm = "10.7.0"
+pnpm = "10.25.0"
+"npm:lerna" = "6.6.2"
+"npm:typescript" = "4.9.5"
+
+# android dependencies
+java = "temurin-17.0.17+10"
+android-sdk = "19"
+
+# ios dependencies
+xcodes = { version = "latest", os = ["macos"]}
+ruby = { version = "2.7.5", os = ["macos"]}
+
+[tasks.bootstrap]
+description = "Install base project dependencies (only needs to be run once per environment)"
+quiet = true
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+
+# using the newly install yq, we can now install the rest of the tools
+mise exec -- mise install
+
+printf "\e[0;94;1m [*] Pulling submodules and Git LFS blobs.\e[0m\n"
+git submodule update --init --recursive --remote
+git lfs pull
+
+printf "\e[0;94;1m [*] Installing NPM dependencies.\e[0m\n"
+npm install
+npm run pull:submodules
+npm run bootstrap
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.bootstrap-android]
+confirm = "Have you read and accepted the Android SDK licenses?"
+description = "Install Android-specific dependencies (only needs to be run once per environment)"
+quiet = true
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+mise install
+
+printf "\e[0;94;1m [*] Installing correct Android platform version.\e[0m\n"
+yes | sdkmanager --licenses
+sdkmanager "platforms;android-35" "build-tools;35.0.1"
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.bootstrap-ios]
+description = "Install iOS-specific dependencies (only needs to be run once per environment)"
+quiet = true
+run = '''
+printf "\e[0;94;1m [*] Ensuring all mise tools are installed.\e[0m\n"
+mise install
+
+printf "\e[0;94;1m [*] Installing Xcode and iOS runtime.\e[0m\n"
+xcodes install 16.2.0
+xcodes select 16.2.0
+xcodes runtimes install 'iOS 18.4'
+
+printf "\e[0;94;1m [*] Installing Ruby and Cocoapods dependencies.\e[0m\n"
+pushd packages/mobile/ios
+gem install bundler -v 1.17.2
+bundle install
+bundle exec pod install
+echo "export NODE_BINARY=$(which node)" > .xcode.env.local
+
+printf "\e[0;94;1m [*] Installing ios-deploy CLI deployment tool from Homebrew.\e[0m\n"
+brew install -q ios-deploy
+
+printf "\e[0;92;1m [*] Success!\e[0m\n"
+'''
+
+[tasks.desktop]
+description = "Run a command from within the desktop project"
+dir = "{{cwd}}/packages/desktop"
+run = "npm run"
+
+[tasks.mobile]
+description = "Run a command from within the mobile project"
+dir = "{{cwd}}/packages/mobile"
+run = "npm run"
+
+[tasks.backend]
+description = "Run a command from within the backend project"
+dir = "{{cwd}}/packages/backend"
+run = "npm run"
+
+[tasks.clean-data-dirs]
+confirm = "Delete all Quiet data directories (both production and development)?"
+description = "Clean all data directories left over from quiet installs"
+quiet = true
+run = '''
+CONFIG_DIR="${XDG_CONFIG_HOME:-"$HOME/Library/Application Support"}"
+find "$CONFIG_DIR" -maxdepth 1 -type d \( -name "Quiet*" -o -name "e2e_*" \) -exec rm -rf {} +
+printf "\e[0;92;1m [*] Deleted all Quiet data directories.\e[0m\n"
+'''
+
+[tasks.build-backend-deps]
+description = "Build all backend dependencies"
+run = '''
+lerna run build --scope @quiet/backend --include-dependencies
+'''
+
+[tasks.start]
+description = "Start Quiet Desktop with the Quietdev data directory"
+depends = ['build-backend-deps']
+run = '''
+npm run start:desktop 2>&1 | less
+'''
+
+[tasks.start-temp]
+description = "Start Quiet Desktop with a fresh random data directory"
+depends = ['build-backend-deps']
+run = '''
+export DATA_DIR="Quiet$(printf "%04d" $(( RANDOM % 10000 )))"
+CONFIG_DIR="${XDG_CONFIG_HOME:-"$HOME/Library/Application Support"}"
+printf "\e[0;94;1m [*] Generated data directory: $CONFIG_DIR/$DATA_DIR.\e[0m\n"
+
+npm run start:desktop 2>&1 | less
+'''
+
+[tasks.start-pair]
+description = "Start Quiet Desktop with a fresh random data directory"
+depends = ['build-backend-deps']
+run = '''
+CONFIG_DIR="${XDG_CONFIG_HOME:-"$HOME/Library/Application Support"}"
+export DATA_DIR1="Quiet$(printf "%04d" $(( RANDOM % 10000 )))"
+export DATA_DIR2="Quiet$(printf "%04d" $(( RANDOM % 10000 )))"
+printf "\e[0;94;1m [*] Generated data directory 1: $CONFIG_DIR/$DATA_DIR1.\e[0m\n"
+printf "\e[0;94;1m [*] Generated data directory 2: $CONFIG_DIR/$DATA_DIR2.\e[0m\n"
+
+tmux \
+    new-session 'env DATA_DIR=$DATA_DIR1 npm run start:desktop' \; \
+    split-window 'sleep 1 && env DATA_DIR=$DATA_DIR2 npm run start:desktop'
+'''
+
+[tasks.build-backend]
+sources = ["packages/backend/**", "packages/state-manager/**", "packages/common/**"]
+run = '''
+lerna run build --scope @quiet/backend --include-dependencies
+'''

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -3,30 +3,44 @@
 Running the desktop version of Quiet should be straightforward on Mac and Linux. On Windows we recommend using git-bash or just wsl.
 Here are the steps:
 
-1. Install `patch` via your Linux package manager (you can skip this step on Mac because it is already installed)
+1. Linux users only: ensure `patch` is installed on your system
 
-2. Use `Node 18.20.4` and `npm 10.7.0`. We recommend [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/) for easily switching Node versions, and if this README gets out of date you can see the actual version used by CI [here](https://github.com/TryQuiet/quiet/blob/master/.github/actions/setup-env/action.yml). If you are using nvm, you can run `nvm use` in the project's root to switch to the correct version.
+## Manual Setup
+1. Use `Node 18.20.4` and `npm 10.7.0`. We recommend [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/) for easily switching Node versions, and if this README gets out of date you can see the actual version used by CI [here](https://github.com/TryQuiet/quiet/blob/master/.github/actions/setup-env/action.yml). If you are using nvm, you can run `nvm use` in the project's root to switch to the correct version.
 
-3. Install python3 and setuptools through your preferred method. (used by node-gyp)
+1. Install python3 and setuptools through your preferred method. (used by node-gyp)
 
-4. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies/submodules and trigger a prepublish script which builds them.
+1. In `quiet/` (project's root) install monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies/submodules and trigger a prepublish script which builds them.
 
-```bash
-npm i lerna@6.6.2
-npm i typescript@4.9.5
-npm i -g pnpm@9.12.1 # may be needed depending on configuration
-npm install
-npm run pull:submodules
-npm run bootstrap
-```
-
-If you run into problems please double check if you have exact version Node and NPM as listed in point 1.
-
-5. In project root run,
+    ```bash
+    npm i lerna@6.6.2
+    npm i typescript@4.9.5
+    npm i -g pnpm@9.12.1 # may be needed depending on configuration
+    npm install
+    npm run pull:submodules
+    npm run bootstrap
+    ```
+  
+    If you run into problems please double check if you have exact version Node and NPM as listed in point 1.
+  
+1. In project root run:
 
 ```
 npm run start:desktop
 ```
+
+## Setup with `mise`
+
+1. Install `mise` via your package manager or `mise`'s install script at https://mise.jdx.dev/getting-started.html
+
+1. Bootstrap the project with `mise`:
+
+    ```
+    mise bootstrap
+    ```
+
+    > [!NOTE]  
+    > If this command fails, please make sure you have the latest version of `mise` installed, and try re-running the command.
 
 ----
 

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -5,11 +5,25 @@ Quiet Mobile is a React Native app for Android and iOS that shares a Node.js [ba
 ### Prerequisites
 
 1. Set up a development environment for Quiet Desktop using [these instructions](https://github.com/TryQuiet/quiet/blob/develop/packages/desktop/README.md) and confirm you can run it
-1. If not on Mac (which comes preinstalled with `patch`), install `patch`, e.g. via your Linux package manager
-1. Install python3 and setuptools (used by node-gyp) through your preferred method. 
+
+Similar to the Desktop setup, you have a choice of using our `mise` bootstrap scripts or manually setting up each dependency.
 
 ## Android development
 
+### Setup with `mise`
+
+1. Install the Android SDK and other needed tools via `mise`:
+
+    ```bash
+    mise bootstrap-android
+    ```
+    
+    > [!NOTE]
+    > You can also use the Android Studio SDK setup by overwriting `ANDROID_HOME` and your `PATH` as desired.*
+
+### Setup manually
+
+1. Install python3 and setuptools (used by node-gyp) through your preferred method.
 1. In the root directory of `quiet/`, install the monorepo's dependencies and bootstrap the project with lerna. It will take care of the package's dependencies and trigger a prepublish script which builds them.
 1. Follow the instructions for running [Quiet Desktop](https://github.com/TryQuiet/monorepo/tree/master/packages/desktop) and confirm it runs
 1. If not on Mac, which comes preinstalled with `patch`, install `patch` (e.g. via your Linux package manager).
@@ -130,6 +144,27 @@ const watchFolders = [
 
 ## iOS development
 
+### Setup with `mise`
+
+1. Have a Mac (Apple requires this)
+1. Create an account at [developer.apple.com](https://developer.apple.com) 
+1. Install Xcode Command Line Tools (required for Homebrew):
+    
+    ```bash
+    xcode-select --install
+    ```
+1. Install [Homebrew](https://brew.sh/)
+1. Set up a development environment for Quiet Desktop using [these instructions](https://github.com/TryQuiet/quiet/blob/develop/packages/desktop/README.md) and confirm you can run it
+1. Install the needed iOS dependencies via `mise`:
+    
+    ```bash
+    mise bootstrap-ios
+    ```
+    
+    > [!NOTE]
+    > The `xcodes` tool may ask for Apple Developer login credentials to download the correct versions.
+
+### Setup manually
 1. Have a Mac (Apple requires this)
 1. Create an account at [developer.apple.com](https://developer.apple.com) 
 1. Install Xcode Command Line Tools (required for Homebrew):


### PR DESCRIPTION
See https://mise.jdx.dev/ for details on `mise`.

This is a followup to #3031 that no longer aims to replace the existing developer setups/documentation, and just adds the option and tools to use mise with quiet. The other good news is that they have fixed the Android SDK issue!