### PR TITLE
16KBAligned JavaScriptCore (libjsc.so) on Android

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -96,8 +96,12 @@ def enableProguardInReleaseBuilds = false
  * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
+ *
+ * Using this 16KB Aligned build from Maven Central
+ * https://github.com/react-native-community/jsc-android-buildscripts/pull/184
+ * https://repo1.maven.org/maven2/io/github/react-native-community/jsc-android-intl/
  */
-def jscFlavor = 'org.webkit:android-jsc-intl:+'
+def jscFlavor = "io.github.react-native-community:jsc-android-intl:2026004.0.1@aar"
 
 /**
  * Whether to enable the Hermes VM.
@@ -269,7 +273,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0")
 
-    androidTestImplementation('com.wix:detox:+')
+    androidTestImplementation("com.wix:detox:+")
     androidTestImplementation("androidx.test:core:1.7.0")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     // version set by the React Native Gradle Plugin in npm
@@ -279,7 +283,7 @@ dependencies {
     if (enableHermes) {
         //noinspection GradleDynamicVersion
         implementation("com.facebook.react:hermes-engine:+") { // From node_modules
-            exclude group: 'com.facebook.fbjni'
+            exclude group: "com.facebook.fbjni"
         }
     } else {
         implementation(jscFlavor)

--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -30,10 +30,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
         }
-        maven {
-            // Android JSC is installed from npm
-            url("$rootDir/../node_modules/jsc-android/dist")
-        }
         google()
         maven { url("$rootDir/../node_modules/detox/Detox-android") }
         maven { url("https://mvnrepository.com/artifact/commons-io/commons-io") }


### PR DESCRIPTION
This is a small change to the Android Gradle project. It replaces the unaligned native binary for javascript core (`libjsc`) that Quiet pulled from via JavaScript from an npm module to a newer 16kb aligned build based from Maven (a repository host for Android/Java dependencies). There should be no changes to iOS or Desktop with this PR since it only modifies the Android build script....

This PR should't be merged into `develop` until the [PR I just opened that lays the groundwork for all the Android alignments](https://github.com/TryQuiet/quiet/pull/3065) has been integrated into `develop`. 

For the time being, I'm comparing my PR against that branch instead of `develop` so **only** the changes to get javascript core aligned are shown as a diff on this PR... Once that PR is merged, I'll remove the DRAFT label on this PR and change the target branch to be `develop`...