### PR TITLE
bump react on desktop 18.1.0 -> 18.3.1, matching mobile

### DIFF
--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -110,7 +110,7 @@
         "node-polyfill-webpack-plugin": "^2.0.1",
         "ramda": "^0.26.1",
         "rc-scrollbars": "^1.1.5",
-        "react": "18.1.0",
+        "react": "18.3.1",
         "react-alice-carousel": "^1.15.3",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dnd": "^16.0.1",
@@ -39395,9 +39395,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -76922,9 +76922,9 @@
       }
     },
     "react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -237,7 +237,7 @@
     "node-polyfill-webpack-plugin": "^2.0.1",
     "ramda": "^0.26.1",
     "rc-scrollbars": "^1.1.5",
-    "react": "18.1.0",
+    "react": "18.3.1",
     "react-alice-carousel": "^1.15.3",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dnd": "^16.0.1",


### PR DESCRIPTION
react 18.2.0 contains bug fixes, 18.3 is identical to 18.2 except it prints warnings for things that'll break in react 19.