### PR TITLE
fix: Backend fails to start on GrapheneOS in 6.5.1

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -216,9 +216,10 @@ android {
         }
     }
     buildTypes.each {
-        it.buildConfigField("String", "SHOULD_RUN_BACKEND_WORKER", "\"true\"")
-        it.buildConfigField("String", "QSS_ALLOWED", "\"false\"")
+        it.buildConfigField("Boolean", "SHOULD_RUN_BACKEND_WORKER", "true")
+        it.buildConfigField("Boolean", "QSS_ALLOWED", "false")
         it.buildConfigField("String", "QSS_ENDPOINT", "\"\"")
+        it.buildConfigField("Boolean", "DEBUG", "false")
     }
     buildTypes {
         debug {

--- a/packages/mobile/android/app/src/main/cpp/own-native-lib.cpp
+++ b/packages/mobile/android/app/src/main/cpp/own-native-lib.cpp
@@ -203,7 +203,8 @@ Java_com_quietmobile_Backend_BackendWorker_startNodeWithArguments(
     current_args_position += strlen(current_args_position) + 1;
   }
 
-  free(args_buffer);
+  // NOTE: this works on android but breaks on GrapheneOS which uses its own hardened version of calloc/malloc/free
+  // free(args_buffer);
 
   rn_register_bridge_cb(&rcv_message);
 

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/MainActivity.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : ReactActivity() {
         val intent = intent
         checkAgainstIntentUpdate(intent)
 
-        if (BuildConfig.SHOULD_RUN_BACKEND_WORKER === "true") {
+        if (BuildConfig.SHOULD_RUN_BACKEND_WORKER) {
             val context = applicationContext
             BackendWorkManager(context).enqueueRequests()
         }


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
