### PR TITLE
Closes #3123 Removes Superflous @peculiar/webcrypto dependency

### DIFF
--- a/packages/backend/jestSetup.ts
+++ b/packages/backend/jestSetup.ts
@@ -1,14 +1,10 @@
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
-
-const crypto = new Crypto()
-global.crypto = crypto
 
 setEngine(
   'newEngine',
   new CryptoEngine({
     name: 'newEngine',
     // @ts-ignore
-    crypto: crypto,
+    crypto: global.crypto,
   })
 )

--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -43,7 +43,6 @@
         "@nestjs/platform-express": "^10.2.10",
         "@orbitdb/core": "file:../../3rd-party/orbitdb",
         "@paralleldrive/cuid2": "^2.2.2",
-        "@peculiar/webcrypto": "1.5.0",
         "abortable-iterator": "^3.0.0",
         "async-mutex": "^0.5.0",
         "base-x": "^5.0.0",
@@ -24534,75 +24533,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.15",
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/asn1js": {
-      "version": "3.0.5",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/@types/cors": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -133,7 +133,6 @@
     "@nestjs/platform-express": "^10.2.10",
     "@orbitdb/core": "file:../../3rd-party/orbitdb",
     "@paralleldrive/cuid2": "^2.2.2",
-    "@peculiar/webcrypto": "1.5.0",
     "@quiet/common": "^2.0.2-alpha.1",
     "@quiet/identity": "^2.0.2-alpha.2",
     "@quiet/logger": "^2.0.2-alpha.0",

--- a/packages/backend/src/backendManager.ts
+++ b/packages/backend/src/backendManager.ts
@@ -1,4 +1,3 @@
-import { Crypto } from '@peculiar/webcrypto'
 import { Command } from 'commander'
 import { NestFactory } from '@nestjs/core'
 import path from 'path'
@@ -178,14 +177,6 @@ export const runBackendDesktop = async (secret: string) => {
   logger.info('Running backend manager desktop')
 
   const isDev = process.env.NODE_ENV === 'development'
-  const webcrypto = new Crypto()
-
-  // https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-  // TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-  Object.defineProperty(global, 'crypto', {
-    value: webcrypto,
-    writable: true,
-  })
 
   validateOptions(options)
   const resourcesPath = options.resourcesPath.trim()

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -1,6 +1,5 @@
 import * as uint8arrays from 'uint8arrays'
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common'
-import { Crypto } from '@peculiar/webcrypto'
 import { EventEmitter } from 'events'
 import getPort from 'get-port'
 import { Agent } from 'https'
@@ -106,21 +105,13 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
   }
 
   async onModuleInit() {
-    const webcrypto = new Crypto()
-    // https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-    // TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-    Object.defineProperty(global, 'crypto', {
-      value: webcrypto,
-      writable: true,
-    })
-
     setEngine(
       'newEngine',
       // @ts-ignore
       new CryptoEngine({
         name: 'newEngine',
         // @ts-ignore
-        crypto: webcrypto,
+        crypto: global.crypto,
       })
     )
 

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@dotenvx/dotenvx": "1.39.0",
         "@electron/remote": "^2.1.3",
-        "@peculiar/webcrypto": "~1.5.0",
         "electron-context-menu": "^3.6.1",
         "electron-debug": "^3.2.0",
         "electron-localshortcut": "^3.2.1",
@@ -7591,87 +7590,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -53373,73 +53291,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        }
-      }
-    },
-    "@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "requires": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "dependencies": {
-        "@peculiar/asn1-schema": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-          "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-          "requires": {
-            "asn1js": "^3.0.6",
-            "pvtsutils": "^1.3.6",
-            "tslib": "^2.8.1"
-          }
-        },
-        "@peculiar/json-schema": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-          "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-          "requires": {
-            "tslib": "^2.0.0"
-          }
-        },
-        "asn1js": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-          "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
-          "requires": {
-            "pvtsutils": "^1.3.6",
-            "pvutils": "^1.1.3",
-            "tslib": "^2.8.1"
-          }
-        },
-        "pvtsutils": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-          "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-          "requires": {
-            "tslib": "^2.8.1"
-          }
-        },
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-        },
-        "webcrypto-core": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-          "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-          "requires": {
-            "@peculiar/asn1-schema": "^2.3.13",
-            "@peculiar/json-schema": "^1.1.12",
-            "asn1js": "^3.0.5",
-            "pvtsutils": "^1.3.5",
-            "tslib": "^2.7.0"
           }
         }
       }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -129,7 +129,6 @@
   "dependencies": {
     "@dotenvx/dotenvx": "1.39.0",
     "@electron/remote": "^2.1.3",
-    "@peculiar/webcrypto": "~1.5.0",
     "@quiet/common": "^2.0.2-alpha.1",
     "@quiet/logger": "^2.0.2-alpha.0",
     "@quiet/node-common": "^4.0.3",

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -7,7 +7,6 @@ import electronLocalshortcut from 'electron-localshortcut'
 import url from 'url'
 import { getPorts, ApplicationPorts, closeHangingBackendProcess } from './backendHelpers'
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 import { createLogger } from './logger'
 import { fork, ChildProcess } from 'child_process'
 import { getFilesData } from '@quiet/common'
@@ -34,15 +33,6 @@ export const isE2Etest = process.env.IS_E2E === 'true'
 if (isE2Etest) {
   autoUpdater.autoInstallOnAppQuit = false
 }
-
-const webcrypto = new Crypto()
-
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})
 
 let mainWindow: BrowserWindow | null
 let splash: BrowserWindow | null
@@ -106,11 +96,11 @@ const windowSize: IWindowSize = {
 
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
 

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -94,13 +94,14 @@ const windowSize: IWindowSize = {
   height: 540,
 }
 
+const crypto = require('crypto').webcrypto
 setEngine(
   'newEngine',
-  global.crypto,
+  crypto,
   new CryptoEngine({
     name: '',
-    crypto: global.crypto,
-    subtle: global.crypto.subtle,
+    crypto: crypto,
+    subtle: crypto.subtle,
   })
 )
 

--- a/packages/desktop/src/shared/setupTests.ts
+++ b/packages/desktop/src/shared/setupTests.ts
@@ -1,25 +1,16 @@
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 
 import { io } from 'socket.io-client'
 
-const webcrypto = new Crypto()
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
-
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})
 
 // @ts-ignore
 process._linkedBinding = name => name

--- a/packages/desktop/src/shared/setupTests.ts
+++ b/packages/desktop/src/shared/setupTests.ts
@@ -2,13 +2,14 @@ import { setEngine, CryptoEngine } from 'pkijs'
 
 import { io } from 'socket.io-client'
 
+const crypto = require('crypto').webcrypto
 setEngine(
   'newEngine',
-  global.crypto,
+  crypto,
   new CryptoEngine({
     name: '',
-    crypto: global.crypto,
-    subtle: global.crypto.subtle,
+    crypto: crypto,
+    subtle: crypto.subtle,
   })
 )
 

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -51,7 +51,6 @@
     ]
   },
   "dependencies": {
-    "@peculiar/webcrypto": "1.4.3",
     "@quiet/eslint-config": "^2.0.2-alpha.0",
     "@quiet/logger": "^2.0.2-alpha.0",
     "@quiet/types": "^2.0.2-alpha.1",

--- a/packages/identity/src/test/helpers.ts
+++ b/packages/identity/src/test/helpers.ts
@@ -1,5 +1,4 @@
 import { Time, setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 import { createRootCA, type RootCA } from '../createRootCA'
 import { createUserCert, type UserCert } from '../createUserCert'
 import { createUserCsr, type UserCsr } from '../createUserCsr'
@@ -35,22 +34,15 @@ export async function createTestUserCert(rootCert?: RootCA, userCsr?: UserCsr): 
 }
 
 export function setupCrypto() {
-  const webcrypto = new Crypto()
   setEngine(
     'newEngine',
-    webcrypto,
+    global.crypto,
     new CryptoEngine({
       name: '',
-      crypto: webcrypto,
-      subtle: webcrypto.subtle,
+      crypto: global.crypto,
+      subtle: global.crypto.subtle,
     })
   )
-  // https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-  // TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-  Object.defineProperty(global, 'crypto', {
-    value: webcrypto,
-    writable: true,
-  })
 }
 
 export const createRootCertificateTestHelper = async (commonName: string): Promise<RootCA> => {

--- a/packages/identity/src/test/helpers.ts
+++ b/packages/identity/src/test/helpers.ts
@@ -34,13 +34,15 @@ export async function createTestUserCert(rootCert?: RootCA, userCsr?: UserCsr): 
 }
 
 export function setupCrypto() {
+  // prettier-ignore
+  const crypto = require('crypto').webcrypto;
   setEngine(
     'newEngine',
-    global.crypto,
+    crypto,
     new CryptoEngine({
       name: '',
-      crypto: global.crypto,
-      subtle: global.crypto.subtle,
+      crypto: crypto,
+      subtle: crypto.subtle,
     })
   )
 }

--- a/packages/identity/src/test/index.test.ts
+++ b/packages/identity/src/test/index.test.ts
@@ -13,7 +13,7 @@ describe('Message signature verification', () => {
       'newEngine',
       new CryptoEngine({
         name: 'newEngine',
-        crypto: global.crypto,
+        crypto: require('crypto').webcrypto,
       })
     )
     crypto = getCrypto()

--- a/packages/identity/src/test/index.test.ts
+++ b/packages/identity/src/test/index.test.ts
@@ -1,4 +1,3 @@
-import { Crypto } from '@peculiar/webcrypto'
 import { sign } from '../sign'
 import { extractPubKey, parseCertificate, parseCertificationRequest } from '../extractPubKey'
 import { verifySignature } from '../verifySignature'
@@ -10,12 +9,11 @@ import { getCrypto, setEngine, CryptoEngine } from 'pkijs'
 describe('Message signature verification', () => {
   let crypto: SubtleCrypto | null
   beforeAll(() => {
-    const webcrypto = new Crypto()
     setEngine(
       'newEngine',
       new CryptoEngine({
         name: 'newEngine',
-        crypto: webcrypto,
+        crypto: global.crypto,
       })
     )
     crypto = getCrypto()

--- a/packages/identity/src/test/setupTests.ts
+++ b/packages/identity/src/test/setupTests.ts
@@ -1,11 +1,12 @@
 import { setEngine, CryptoEngine } from 'pkijs'
 
+const crypto = require('crypto').webcrypto
 setEngine(
   'newEngine',
-  global.crypto,
+  crypto,
   new CryptoEngine({
     name: '',
-    crypto: global.crypto,
-    subtle: global.crypto.subtle,
+    crypto: crypto,
+    subtle: crypto.subtle,
   })
 )

--- a/packages/identity/src/test/setupTests.ts
+++ b/packages/identity/src/test/setupTests.ts
@@ -1,20 +1,11 @@
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 
-const webcrypto = new Crypto()
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
-
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -38,7 +38,6 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@peculiar/webcrypto": "1.4.3",
     "@quiet/identity": "^2.0.2-alpha.2",
     "@quiet/logger": "^2.0.2-alpha.0",
     "@quiet/node-common": "^4.0.3",

--- a/packages/integration-tests/src/bot/bot.ts
+++ b/packages/integration-tests/src/bot/bot.ts
@@ -11,21 +11,15 @@ import { CryptoEngine, setEngine } from 'pkijs'
 import { createLogger } from '../logger'
 const logger = createLogger('bot')
 // eslint-disable-next-line
-const { Crypto } = require('@peculiar/webcrypto')
-
-const crypto = new Crypto()
-global.crypto = crypto
-
-const webcrypto = new Crypto()
 setEngine(
   'newEngine',
   // @ts-ignore
-  webcrypto,
+  global.crypto,
   // @ts-ignore
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
 

--- a/packages/integration-tests/src/integrationTests/createJoinCommunity.test.ts
+++ b/packages/integration-tests/src/integrationTests/createJoinCommunity.test.ts
@@ -1,12 +1,7 @@
-import { Crypto } from '@peculiar/webcrypto'
 import { AsyncReturnType } from '../types/AsyncReturnType.interface'
 import { createApp, sleep } from '../utils'
 import { createCommunity, getCommunityOwnerData, joinCommunity } from './appActions'
 import { assertConnectedToPeers, assertReceivedCertificates } from './assertions'
-
-const crypto = new Crypto()
-
-global.crypto = crypto
 
 describe('owner creates community', () => {
   let owner: AsyncReturnType<typeof createApp>

--- a/packages/integration-tests/src/integrationTests/restartApp.test.ts
+++ b/packages/integration-tests/src/integrationTests/restartApp.test.ts
@@ -1,4 +1,3 @@
-import { Crypto } from '@peculiar/webcrypto'
 import { createCommunity, clearInitializedCommunitiesAndRegistrars } from './appActions'
 import { createApp, sleep, storePersistor } from '../utils'
 import { AsyncReturnType } from '../types/AsyncReturnType.interface'
@@ -7,10 +6,6 @@ import {
   assertStoreStatesAreEqual,
   assertInitializedCommunity,
 } from './assertions'
-
-const crypto = new Crypto()
-
-global.crypto = crypto
 
 describe('restart app without doing anything', () => {
   let owner: AsyncReturnType<typeof createApp>

--- a/packages/integration-tests/src/integrationTests/sendFiles.test.ts
+++ b/packages/integration-tests/src/integrationTests/sendFiles.test.ts
@@ -1,4 +1,3 @@
-import { Crypto } from '@peculiar/webcrypto'
 import {
   assertDownloadedImage,
   assertReceivedCertificates,
@@ -12,10 +11,6 @@ import { FileContent } from '@quiet/types'
 import { createLogger } from '../logger'
 
 const logger = createLogger('files')
-
-const crypto = new Crypto()
-
-global.crypto = crypto
 
 describe('send message - users are online', () => {
   let owner: AsyncReturnType<typeof createApp>

--- a/packages/integration-tests/src/integrationTests/sendMessages.test.ts
+++ b/packages/integration-tests/src/integrationTests/sendMessages.test.ts
@@ -1,4 +1,3 @@
-import { Crypto } from '@peculiar/webcrypto'
 import {
   assertReceivedCertificates,
   assertReceivedChannelsAndSubscribe,
@@ -8,10 +7,6 @@ import {
 import { createCommunity, joinCommunity, getCommunityOwnerData, sendMessage } from './appActions'
 import { createApp, createAppWithoutTor, sleep, storePersistor } from '../utils'
 import { AsyncReturnType } from '../types/AsyncReturnType.interface'
-
-const crypto = new Crypto()
-
-global.crypto = crypto
 
 describe('send message - users go offline and online', () => {
   let owner: AsyncReturnType<typeof createApp>

--- a/packages/integration-tests/src/setupTests.ts
+++ b/packages/integration-tests/src/setupTests.ts
@@ -1,20 +1,11 @@
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 
-const webcrypto = new Crypto()
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
-
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Backend/BackendWorker.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Backend/BackendWorker.kt
@@ -228,6 +228,7 @@ class BackendWorker(private val context: Context, workerParams: WorkerParameters
 
         val command: MutableList<String> = ArrayList()
         command.add("node")
+        command.add("--experimental-global-webcrypto")
         command.add("--experimental-global-customevent")
         command.add(scriptPath)
         command.addAll(args)

--- a/packages/mobile/ios/NodeJsMobile/RNNodeJsMobile.m
+++ b/packages/mobile/ios/NodeJsMobile/RNNodeJsMobile.m
@@ -63,6 +63,7 @@ RCT_EXPORT_MODULE()
   {
     nodeArguments = [NSMutableArray arrayWithObjects:
                               @"node",
+                              @"--experimental-global-webcrypto",
                               @"--experimental-global-customevent",
                               srcPath,
                               nil
@@ -72,6 +73,7 @@ RCT_EXPORT_MODULE()
   } else {
     nodeArguments = [NSMutableArray arrayWithObjects:
                               @"node",
+                              @"--experimental-global-webcrypto",
                               @"--experimental-global-customevent",
                               @"-r",
                               dlopenoverridePath,

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@d11/react-native-fast-image": "8.11.1",
         "@hcaptcha/react-native-hcaptcha": "^2.1.0",
-        "@peculiar/webcrypto": "~1.5.0",
         "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-navigation/core": "^6.4.17",
         "@react-navigation/native": "^6.1.18",
@@ -5819,87 +5818,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@d11/react-native-fast-image": "8.11.1",
     "@hcaptcha/react-native-hcaptcha": "^2.1.0",
-    "@peculiar/webcrypto": "~1.5.0",
     "@quiet/backend": "^2.0.3-alpha.5",
     "@quiet/common": "^2.0.2-alpha.1",
     "@quiet/identity": "^2.0.2-alpha.2",

--- a/packages/mobile/src/setupTests.tsx
+++ b/packages/mobile/src/setupTests.tsx
@@ -1,36 +1,27 @@
 /* eslint-disable */
 import { setEngine, CryptoEngine } from 'pkijs'
 import { setEngine as setIdentityEngine } from '../../identity/node_modules/pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 import React from 'react'
 
 import { io } from 'socket.io-client'
 
-const webcrypto = new Crypto()
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})
-
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
 
 setIdentityEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
 

--- a/packages/state-manager/package-lock.json
+++ b/packages/state-manager/package-lock.json
@@ -28,7 +28,6 @@
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
-        "@peculiar/webcrypto": "1.4.3",
         "@types/factory-girl": "^5.0.12",
         "@types/jest": "^26.0.24",
         "@types/luxon": "^2.0.0",
@@ -4695,45 +4694,6 @@
     "node_modules/@localfirst/auth": {
       "resolved": "../../3rd-party/auth/packages/auth/dist",
       "link": true
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
-      "dev": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
     },
     "node_modules/@redux-saga/core": {
       "version": "1.1.3",
@@ -12752,19 +12712,6 @@
         "makeerror": "1.0.x"
       }
     },
-    "node_modules/webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
-      "dev": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -16373,39 +16320,6 @@
     },
     "@localfirst/auth": {
       "version": "file:../../3rd-party/auth/packages/auth/dist"
-    },
-    "@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
-      "dev": true,
-      "requires": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
-      "dev": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
-      }
     },
     "@redux-saga/core": {
       "version": "1.1.3",
@@ -22594,19 +22508,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
-      "dev": true,
-      "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
       }
     },
     "whatwg-encoding": {

--- a/packages/state-manager/package.json
+++ b/packages/state-manager/package.json
@@ -48,7 +48,6 @@
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
-    "@peculiar/webcrypto": "1.4.3",
     "@quiet/eslint-config": "^2.0.2-alpha.0",
     "@quiet/identity": "^2.0.2-alpha.2",
     "@types/factory-girl": "^5.0.12",

--- a/packages/state-manager/src/setupTests.ts
+++ b/packages/state-manager/src/setupTests.ts
@@ -1,11 +1,13 @@
 import { setEngine, CryptoEngine } from 'pkijs'
 
+const crypto = require('crypto').webcrypto
+
 setEngine(
   'newEngine',
-  global.crypto,
+  crypto,
   new CryptoEngine({
     name: '',
-    crypto: global.crypto,
-    subtle: global.crypto.subtle,
+    crypto: crypto,
+    subtle: crypto.subtle,
   })
 )

--- a/packages/state-manager/src/setupTests.ts
+++ b/packages/state-manager/src/setupTests.ts
@@ -1,20 +1,11 @@
 import { setEngine, CryptoEngine } from 'pkijs'
-import { Crypto } from '@peculiar/webcrypto'
 
-const webcrypto = new Crypto()
 setEngine(
   'newEngine',
-  webcrypto,
+  global.crypto,
   new CryptoEngine({
     name: '',
-    crypto: webcrypto,
-    subtle: webcrypto.subtle,
+    crypto: global.crypto,
+    subtle: global.crypto.subtle,
   })
 )
-
-// https://github.com/lobehub/lobehub/issues/5315#issuecomment-2572703223
-// TODO https://github.com/TryQuiet/quiet/issues/3123 replace if not needed
-Object.defineProperty(global, 'crypto', {
-  value: webcrypto,
-  writable: true,
-})


### PR DESCRIPTION
 Closes #3123 Removes Superflous @peculiar/webcrypto dependency. Removes hacky JavaScript that was needed to override global.crypto

    - this was probably needed for along time because iOS was using nodejs12 until some recent work, hence
    having no global.crypto flag.
    - iOS and Android need the --experimental-global-webcrypto flag until nodejs mobile is rebuilt