### PR TITLE
fix soon to be broken github actions that need the node24 runner

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -21,7 +21,7 @@ runs:
         node-version-file: ".nvmrc"
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       if: runner.os == 'macOS'
       with:
         python-version: 3.12
@@ -63,7 +63,7 @@ runs:
 
     - name: "Cache NPM dependencies"
       id: cache-nodemodules
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: |
           node_modules

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -29,7 +29,7 @@ jobs:
         if: steps.filter.outputs.backend == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.backend == 'true'
         with:
           submodules: 'recursive'
@@ -52,7 +52,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -68,7 +68,7 @@ jobs:
         if: steps.filter.outputs.backend == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.backend == 'true'
         with:
           submodules: 'recursive'
@@ -91,7 +91,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -107,7 +107,7 @@ jobs:
         if: steps.filter.outputs.backend == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.backend == 'true'
         with:
           submodules: 'recursive'

--- a/.github/workflows/check-desktop-visual-regression.yml
+++ b/.github/workflows/check-desktop-visual-regression.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -28,7 +28,7 @@ jobs:
         if: steps.filter.outputs.desktop == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.desktop == 'true'
         with:
           fetch-depth: 0 # Required to retrieve git history

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/depencency-review.yml
+++ b/.github/workflows/depencency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -35,7 +35,7 @@ jobs:
       TEST_MODE: true
       IS_LOCAL: true
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -99,7 +99,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/@quiet/desktop')
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5 # v4.1.1
         with:
           submodules: 'recursive'
 
@@ -145,7 +145,7 @@ jobs:
       CHECKSUM_PATH: ${{ github.event.action == 'released' && 'packages/desktop/dist/latest-linux.yml' || 'packages/desktop/dist/alpha-linux.yml' }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5 # v4.1.1
         with:
           submodules: 'recursive'
 
@@ -227,7 +227,7 @@ jobs:
       S3_BUCKET: ${{ github.event.action == 'released' && 'quiet.7.x' || 'test.quiet' }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5 # v4.1.1
         with:
           submodules: 'recursive'
 
@@ -308,7 +308,7 @@ jobs:
       S3_BUCKET: ${{ github.event.action == 'released' && 'quiet.7.x' || 'test.quiet' }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5 # v4.1.1
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -99,7 +99,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/@quiet/desktop')
 
     steps:
-      - uses: actions/checkout@v5 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -145,7 +145,7 @@ jobs:
       CHECKSUM_PATH: ${{ github.event.action == 'released' && 'packages/desktop/dist/latest-linux.yml' || 'packages/desktop/dist/alpha-linux.yml' }}
 
     steps:
-      - uses: actions/checkout@v5 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -227,7 +227,7 @@ jobs:
       S3_BUCKET: ${{ github.event.action == 'released' && 'quiet.7.x' || 'test.quiet' }}
 
     steps:
-      - uses: actions/checkout@v5 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -308,7 +308,7 @@ jobs:
       S3_BUCKET: ${{ github.event.action == 'released' && 'quiet.7.x' || 'test.quiet' }}
 
     steps:
-      - uses: actions/checkout@v5 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/desktop-rtl-tests.yml
+++ b/.github/workflows/desktop-rtl-tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, macos-latest]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/desktop-test-scroll.yml
+++ b/.github/workflows/desktop-test-scroll.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -29,7 +29,7 @@ jobs:
         if: steps.filter.outputs.desktop == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.desktop == 'true'
         with:
           submodules: 'recursive'

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, macos-latest]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -29,7 +29,7 @@ jobs:
         if: steps.filter.outputs.desktop == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.desktop == 'true'
         with:
           submodules: 'recursive'

--- a/.github/workflows/e2e-android-self.yml
+++ b/.github/workflows/e2e-android-self.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, android]
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [macos-latest-xlarge]
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           lfs: true

--- a/.github/workflows/e2e-back-compat-linux.yml
+++ b/.github/workflows/e2e-back-compat-linux.yml
@@ -19,7 +19,7 @@ jobs:
       SKIP_BACK_COMPAT_TEST_BRANCHES: '["update-orbitdb", "chore/upgrade-orbitdb-2_4_3", "fix/2679-2680-2682-3_0-fixes"]'
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [macos-14-xlarge]
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           lfs: true

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -19,7 +19,7 @@ jobs:
       SKIP_BACK_COMPAT_TEST_BRANCHES: '["update-orbitdb", "chore/upgrade-orbitdb-2_4_3", "fix/2679-2680-2682-3_0-fixes"]'
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/e2e-mac.yml
+++ b/.github/workflows/e2e-mac.yml
@@ -11,7 +11,7 @@ jobs:
       IS_CI: true
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/e2e-qss-linux.yml
+++ b/.github/workflows/e2e-qss-linux.yml
@@ -18,7 +18,7 @@ jobs:
       IS_CI: true
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -13,7 +13,7 @@ jobs:
       IS_CI: true
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/identity-tests.yml
+++ b/.github/workflows/identity-tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -29,7 +29,7 @@ jobs:
         if: steps.filter.outputs.identity == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.identity == 'true'
         with:
           submodules: 'recursive'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Print OS'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/mobile-build-apk.yml
+++ b/.github/workflows/mobile-build-apk.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: false
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: false
 

--- a/.github/workflows/mobile-deploy-android.yml
+++ b/.github/workflows/mobile-deploy-android.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/mobile-deploy-common.yml
+++ b/.github/workflows/mobile-deploy-common.yml
@@ -12,7 +12,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/@quiet/mobile')
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/mobile-deploy-ios.yml
+++ b/.github/workflows/mobile-deploy-ios.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           lfs: true

--- a/.github/workflows/mobile-tests.yml
+++ b/.github/workflows/mobile-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/state-manager-tests.yml
+++ b/.github/workflows/state-manager-tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, macos-latest]
 
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -29,7 +29,7 @@ jobs:
         if: steps.filter.outputs.stateManager == 'true'
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         if: steps.filter.outputs.stateManager == 'true'
         with:
           submodules: 'recursive'

--- a/.github/workflows/utils-tests.yml
+++ b/.github/workflows/utils-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Print OS"
         run: echo ${{ matrix.os }}
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5 
         with:
           submodules: 'recursive'
 


### PR DESCRIPTION
Recently if you start using the GitHub CI you see the following warning message after completing a workflow:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11, actions/setup-python@v5, dorny/paths-filter@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I think this will break workflows in early June. The solution seems to be updating to the node24 releases of the github actions we use. 