### PR TITLE
rm order expectation from test

### DIFF
--- a/packages/backend/src/nest/local-db/local-db.service.spec.ts
+++ b/packages/backend/src/nest/local-db/local-db.service.spec.ts
@@ -616,10 +616,12 @@ describe('LocalDbService', () => {
       await service.addDLQDecryptEntry(TEAM_ID, payload1, serializer)
       await service.addDLQDecryptEntry(TEAM_ID, payload2, serializer)
 
-      // Get entries
+      // Get entries (order not guaranteed when timestamps collide)
       const entries = await service.getDLQDecryptEntries(TEAM_ID, serializer)
       expect(entries.length).toBe(2)
-      expect(entries[0].entry.payload.signature.signature).toBe(payload1.signature.signature)
+      const sigs = entries.map(e => e.entry.payload.signature.signature)
+      expect(sigs).toContain(payload1.signature.signature)
+      expect(sigs).toContain(payload2.signature.signature)
 
       // Remove first entry
       await service.removeDLQDecryptEntries(TEAM_ID, [entries[0]])


### PR DESCRIPTION
Fixes intermittent test failures on local-db.service.spec.ts 'add / get / remove DLQ decrypt entries' test by removing expectation of strict ordering. I validated that we don't actually need strict ordering because they get dumped into the IPFS blockstore in `OrbitDbService:ingestEntries` before `OrbitDbService:joinHeads` is called, so the graph traversal handles out of order entries.

### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
