### PR TITLE
fix(3140): Validate qss endpoint when qss is allowed to avoid registration loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fixed trace logger toggles [#3045](https://github.com/TryQuiet/quiet/issues/3045)
 * Fixed auth issues when using QSS in AWS [#3128](https://github.com/TryQuiet/quiet/issues/3128)
 * Fixed bug around killing old tor process that results in an unhandled exception [#3135](https://github.com/TryQuiet/quiet/issues/3135)
-
+* Fixed bug that caused a registration loop when QSS_ALLOWED is true but the endpoint is unset [#3140](https://github.com/TryQuiet/quiet/issues/3140)
 
 ### Chores
 

--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
@@ -20,23 +20,6 @@ import { CommunityOwnership } from '@quiet/types'
 import { communityNameField } from '../../../forms/fields/communityFields'
 
 describe('Create community', () => {
-  let qssAllowed: boolean
-  let qssEndpoint: string | undefined = undefined
-  let qssAllowedOrig: boolean
-  let qssEndpointOrig: string | undefined = undefined
-
-  beforeAll(() => {
-    qssAllowedOrig = Boolean(process.env.QSS_ALLOWED ?? 'false')
-    qssEndpointOrig = process.env.QSS_ENDPOINT ?? ''
-    qssAllowed = qssAllowedOrig
-    qssEndpoint = qssEndpointOrig
-  })
-
-  beforeEach(() => {
-    qssAllowed = qssAllowedOrig
-    qssEndpoint = qssEndpointOrig
-  })
-
   it('users switches from create to join', async () => {
     const { store } = await prepareStore({
       [StoreKeys.Socket]: {

--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.test.tsx
@@ -20,6 +20,23 @@ import { CommunityOwnership } from '@quiet/types'
 import { communityNameField } from '../../../forms/fields/communityFields'
 
 describe('Create community', () => {
+  let qssAllowed: boolean
+  let qssEndpoint: string | undefined = undefined
+  let qssAllowedOrig: boolean
+  let qssEndpointOrig: string | undefined = undefined
+
+  beforeAll(() => {
+    qssAllowedOrig = Boolean(process.env.QSS_ALLOWED ?? 'false')
+    qssEndpointOrig = process.env.QSS_ENDPOINT ?? ''
+    qssAllowed = qssAllowedOrig
+    qssEndpoint = qssEndpointOrig
+  })
+
+  beforeEach(() => {
+    qssAllowed = qssAllowedOrig
+    qssEndpoint = qssEndpointOrig
+  })
+
   it('users switches from create to join', async () => {
     const { store } = await prepareStore({
       [StoreKeys.Socket]: {
@@ -263,13 +280,54 @@ describe('Create community', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
       jest.resetModules()
-      process.env = { ...OLD_ENV, QSS_ALLOWED: 'true' }
+      process.env = { ...OLD_ENV, QSS_ALLOWED: 'true', QSS_ENDPOINT: 'ws://localhost:80/' }
     })
     afterEach(() => {
       process.env = OLD_ENV
     })
 
-    it('shows ServerOfferComponent when QSS_ALLOWED is true and user submits community name', async () => {
+    it(`doesn't ServerOfferComponent when QSS_ALLOWED is true and QSS_ENDPOINT is invalid and user submits community name`, async () => {
+      const { store } = await prepareStore({
+        [StoreKeys.Socket]: {
+          ...new SocketState(),
+          isConnected: true,
+        },
+        [StoreKeys.Modals]: {
+          ...new ModalsInitialState(),
+          [ModalName.createCommunityModal]: { open: true },
+        },
+      })
+
+      process.env.QSS_ENDPOINT = ''
+
+      renderComponent(
+        <>
+          <JoinCommunity />
+          <CreateCommunity />
+        </>,
+        store
+      )
+
+      // Confirm proper modal title is displayed
+      const createCommunityDictionary = CreateCommunityDictionary()
+      const createCommunityTitle = screen.getByText(createCommunityDictionary.header)
+      expect(createCommunityTitle).toBeVisible()
+
+      // Click redirecting link
+      const link = screen.getByTestId('CreateCommunityLink')
+      await userEvent.click(link)
+
+      // Confirm user is being redirected to join community
+      const joinCommunityDictionary = JoinCommunityDictionary()
+      const joinCommunityTitle = await screen.findByText(joinCommunityDictionary.header)
+      expect(joinCommunityTitle).toBeVisible()
+
+      // ServerOffer modal should appear
+      expect(() => screen.getByTestId('ServerOffer-UseQuietServer')).toThrow()
+      expect(() => screen.getByTestId('ServerOffer-NotNow')).toThrow()
+    })
+
+    it('shows ServerOfferComponent when QSS_ALLOWED is true and QSS_ENDPOINT is valid and user submits community name', async () => {
       const { store } = await prepareStore({
         [StoreKeys.Socket]: {
           ...new SocketState(),

--- a/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.tsx
+++ b/packages/desktop/src/renderer/components/CreateJoinCommunity/CreateCommunity/CreateCommunity.tsx
@@ -41,12 +41,24 @@ const CreateCommunity = () => {
       return
     }
     setPendingCommunityName(name)
-    logger.warn(process.env.QSS_ALLOWED)
-    if (process.env.QSS_ALLOWED === 'true') {
-      setShowServerOffer(true)
-    } else {
+    logger.warn('QSS settings', process.env.QSS_ALLOWED, process.env.QSS_ENDPOINT)
+    const createCommunityWithoutQSS = () => {
       dispatch(communities.actions.createCommunity({ name, useServer: false }))
       createUsernameModal.handleOpen()
+    }
+    if (process.env.QSS_ALLOWED === 'true') {
+      try {
+        new URL(process.env.QSS_ENDPOINT ?? '')
+        setShowServerOffer(true)
+      } catch (error) {
+        logger.error(
+          `QSS is allowed but the endpoint is invalid (endpoint provided = "${process.env.QSS_ENDPOINT}"`,
+          error
+        )
+        createCommunityWithoutQSS()
+      }
+    } else {
+      createCommunityWithoutQSS()
     }
   }
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
