### PR TITLE
fix: ensure emoji picker scales responsively on small window sizes (#…

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelInput/ChannelInput.tsx
@@ -169,9 +169,16 @@ const StyledChannelInput = styled(Grid)(({ theme }) => ({
     padding: '5px',
   },
   [`& .${classes.picker}`]: {
-    position: 'fixed',
     bottom: 60,
     right: 15,
+    left: 'auto',
+    maxWidth: '100%',
+    width: 'min(350px, calc(100vw - 40px))',
+    maxHeight: 'min(450px, calc(100vh - 120px))',
+    overflowY: 'auto',
+    boxSizing: 'border-box',
+    zIndex: 999999,
+    position: 'fixed',
   },
   [`& .${classes.errorIcon}`]: {
     display: 'flex',


### PR DESCRIPTION
…2939)

This patch adjusts the emoji picker container to prevent content from disappearing when the desktop window becomes narrow. The component now uses responsive width constraints and proper z-index handling to ensure the picker remains fully visible within the application window.

Refs: #2939


