### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -110,7 +110,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -156,7 +156,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -318,7 +318,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -399,7 +399,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 
@@ -409,7 +409,7 @@ jobs:
 
       - name: "Add Windows certificate"
         id: write_file
-        uses: TryQuiet/base64-to-file@64eeb40ad3514f57de3a7dee92aee10fd42452c1 # main
+        uses: timheur/base64-to-file@1.2.4
         with:
           fileName: 'win-certificate.pfx'
           encodedString: ${{ secrets.WIN_CSC_LINK }}

--- a/.github/workflows/e2e-back-compat-linux.yml
+++ b/.github/workflows/e2e-back-compat-linux.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 

--- a/.github/workflows/e2e-qss-linux.yml
+++ b/.github/workflows/e2e-qss-linux.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 

--- a/.github/workflows/mobile-build-apk.yml
+++ b/.github/workflows/mobile-build-apk.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 

--- a/.github/workflows/mobile-deploy-android.yml
+++ b/.github/workflows/mobile-deploy-android.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 

--- a/.github/workflows/mobile-deploy-common.yml
+++ b/.github/workflows/mobile-deploy-common.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/desktop
 

--- a/.github/workflows/mobile-deploy-ios.yml
+++ b/.github/workflows/mobile-deploy-ios.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract version
         id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
+        uses: Saionaro/extract-package-version@v1.4.0
         with:
           path: packages/mobile
 


### PR DESCRIPTION
Recently Holmes shared this screenshot from a GitHub actions run:
<img width="749" height="407" alt="image" src="https://github.com/user-attachments/assets/1485051c-a257-4ba7-9770-35e726d53f85" />

In it, it shows that 3 actions have still not been updated to do their CI things in node 24 and that GitHub will soon force actions to run with nodejs24. The actions are:

- `Saionaro/extract-package-version` this can be trivialy updated to their new 1.4.0 release which explicitly uses node 24
- `TryQuiet/base64-to-file` This is [Quiet's unmodified fork ](https://github.com/tryquiet/base64-to-file) of https://github.com/timheuer/base64-to-file. Quiet's fork had no new commits, and there have been other fixes by the original maintainer. [In the near future, there will be a release supporting node24 that Quiet can update to.](https://github.com/timheuer/base64-to-file/issues/60). [Quiet's fork of this repo should be closed](https://github.com/tryquiet/base64-to-file)
- https://github.com/actions-ecosystem/action-slack-notifier the slack action has not seen any activity in years. I could fork it to run under node 24, however it seems pretty unlikely that if it were forced to run in node24 anything will break. We can test this. 