### PR TITLE
Fix dotenv flavor key matching so npm run android works first time

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -318,11 +318,17 @@ tasks.register("copyDownloadableDepsToLibs", Copy) {
 }
 
 // Additional configuration
+// Keys are matched by dotenv.gradle's getCurrentFlavor(), which captures the
+// trailing CamelCase segment of the gradle task name and lowercases it (e.g.
+// installStandardDebug -> "standarddebug"). With product flavors in play the
+// bare buildType keys ("debug", "release") never match, so keys must include
+// the flavor prefix.
 project.ext.envConfigFiles = [
-        debug    : ".env.development",
-        storybook: ".env.storybook",
-        release  : ".env.staging",
-        prod     : ".env.production",
+        standarddebug   : ".env.development",
+        standardrelease : ".env.staging",
+        standardprod    : ".env.production",
+        storybookdebug  : ".env.storybook",
+        storybookrelease: ".env.storybook",
 ]
 
 apply from: project(":react-native-config").projectDir.getPath() + "/dotenv.gradle"


### PR DESCRIPTION
## Summary
- `react-native-config`'s `dotenv.gradle` selects an env file by capturing the trailing CamelCase segment of the gradle task name (e.g. `installStandardDebug` → `standarddebug`) and prefix-matching it against `project.ext.envConfigFiles`. With product flavors (`standard`, `storybook`) in play, the existing keys (`debug`, `release`, `storybook`, `prod`) never matched, so dotenv silently fell back to a non-existent `.env` and printed `*** Missing .env file ****`.
- That meant `BuildConfig.SHOULD_RUN_BACKEND_WORKER` (and the other env-derived fields) were never injected, and `MainActivity.kt:48` failed to compile with `Unresolved reference 'SHOULD_RUN_BACKEND_WORKER'`.
- This change rewrites the keys to include the flavor prefix, so each variant maps to the right `.env`.

## Why this matters
This was a first-run gotcha in `packages/mobile/README.md` step "Run Quiet → `npm run android`". On a fresh checkout the build would fail with a Kotlin compile error that points at user code, not at the underlying missing env file (which scrolls past in the noise of unrelated deprecation warnings). After this fix, `npm run android` works the first time without an `ENVFILE=` workaround.

## Test plan
- [x] `npm run android` from `packages/mobile` builds and installs `standardDebug` on a connected device, with `Reading env from: .env.development` logged by dotenv.gradle.
- [ ] `npm run android-storybook` (or equivalent storybook variant) still picks `.env.storybook`.
- [ ] Release builds (`--mode=standardRelease`) pick `.env.staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)