### PR TITLE
feat(mobile): dev/alpha-only "Share logs" menu item

### DIFF
--- a/packages/mobile/.storybook/index.js
+++ b/packages/mobile/.storybook/index.js
@@ -41,6 +41,7 @@ configure(() => {
   require('../src/components/FileAttachmentPreview/FileAttachmentPreview.stories')
   require('../src/components/NewUsernameRequested/NewUsernameRequested.stories')
   require('../src/components/ModalBottomDrawer/drawers/ServerOffer.drawer.stories')
+  require('../src/utils/sendLogs.stories')
 }, module)
 
 const StorybookUIRoot = getStorybookUI({

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -51,9 +51,9 @@ const community_dev_items: ContextMenuItemProps[] = [
     },
   },
   {
-    title: 'Send logs to devs',
+    title: 'Share logs',
     action: () => {
-      logger.info('clicked on send logs')
+      logger.info('clicked on share logs')
       void sendLogs()
     },
   },
@@ -87,7 +87,7 @@ storiesOf('ContextMenu', module)
       />
     )
   })
-  .add('Community (dev/alpha — Send logs)', () => {
+  .add('Community (dev/alpha — Share logs)', () => {
     return (
       <ContextMenu
         title={'Rockets'}

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -6,6 +6,7 @@ import { ContextMenu } from './ContextMenu.component'
 import { ContextMenuItemProps } from './ContextMenu.types'
 
 import { createLogger } from '../../utils/logger'
+import { sendLogs } from '../../utils/sendLogs'
 
 const logger = createLogger('contextMenu:stories')
 
@@ -26,6 +27,34 @@ const community_items: ContextMenuItemProps[] = [
     title: 'Settings',
     action: () => {
       logger.info('clicked on settings')
+    },
+  },
+]
+
+const community_dev_items: ContextMenuItemProps[] = [
+  {
+    title: 'Create channel',
+    action: () => {
+      logger.info('clicked on create channel')
+    },
+  },
+  {
+    title: 'Add members',
+    action: () => {
+      logger.info('clicked on add members')
+    },
+  },
+  {
+    title: 'Leave community',
+    action: () => {
+      logger.info('clicked on leave community')
+    },
+  },
+  {
+    title: 'Send logs to devs',
+    action: () => {
+      logger.info('clicked on send logs')
+      void sendLogs()
     },
   },
 ]
@@ -51,6 +80,18 @@ storiesOf('ContextMenu', module)
       <ContextMenu
         title={'Rockets'}
         items={community_items}
+        visible={true}
+        handleClose={() => {
+          logger.info('closing menu')
+        }}
+      />
+    )
+  })
+  .add('Community (dev/alpha — Send logs)', () => {
+    return (
+      <ContextMenu
+        title={'Rockets'}
+        items={community_dev_items}
         visible={true}
         handleClose={() => {
           logger.info('closing menu')

--- a/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
@@ -52,7 +52,7 @@ export const CommunityContextMenu: FC = () => {
 
   if (Config.NODE_ENV !== NodeEnv.Production) {
     items.push({
-      title: 'Send logs to devs',
+      title: 'Share logs',
       action: () => {
         communityContextMenu.handleClose()
         void sendLogs()

--- a/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
@@ -14,6 +14,9 @@ import { navigationActions } from '../../../store/navigation/navigation.slice'
 import { ScreenNames } from '../../../const/ScreenNames.enum'
 
 import { capitalizeFirstLetter } from '@quiet/common'
+import Config from 'react-native-config'
+import { NodeEnv } from '../../../utils/const/NodeEnv.enum'
+import { sendLogs } from '../../../utils/sendLogs'
 
 export const CommunityContextMenu: FC = () => {
   const dispatch = useDispatch()
@@ -46,6 +49,16 @@ export const CommunityContextMenu: FC = () => {
     { title: 'Add members', action: () => invitationContextMenu.handleOpen() },
     { title: 'Leave community', action: () => redirect(ScreenNames.LeaveCommunityScreen) },
   ]
+
+  if (Config.NODE_ENV !== NodeEnv.Production) {
+    items.push({
+      title: 'Send logs to devs',
+      action: () => {
+        communityContextMenu.handleClose()
+        void sendLogs()
+      },
+    })
+  }
 
   useEffect(() => {
     communityContextMenu.handleClose()

--- a/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.test.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import Config from 'react-native-config'
+
+import { renderComponent } from '../../../tests/utils/renderComponent'
+import { CommunityContextMenu } from './CommunityContextMenu.container'
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+jest.mock('../../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+jest.mock('../../../hooks/useContextMenu', () => ({
+  useContextMenu: () => ({ visible: true, handleOpen: jest.fn(), handleClose: jest.fn() }),
+}))
+
+const mutableConfig = Config as { NODE_ENV?: string }
+
+describe('CommunityContextMenu (dev/alpha gate for "Share logs")', () => {
+  const originalNodeEnv = mutableConfig.NODE_ENV
+
+  afterEach(() => {
+    mutableConfig.NODE_ENV = originalNodeEnv ?? 'staging'
+  })
+
+  it('hides "Share logs" in production builds', () => {
+    mutableConfig.NODE_ENV = 'production'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share logs')).toBeNull()
+  })
+
+  it('shows "Share logs" in development builds', () => {
+    mutableConfig.NODE_ENV = 'development'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share logs')).not.toBeNull()
+  })
+
+  it('shows "Share logs" in staging/alpha builds', () => {
+    mutableConfig.NODE_ENV = 'staging'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share logs')).not.toBeNull()
+  })
+})

--- a/packages/mobile/src/utils/sendLogs.stories.tsx
+++ b/packages/mobile/src/utils/sendLogs.stories.tsx
@@ -8,7 +8,7 @@ import { sendLogs } from './sendLogs'
 storiesOf('SendLogs', module).add('Trigger share sheet', () => (
   <View style={{ flex: 1, justifyContent: 'center', padding: 24 }}>
     <Button
-      title={'Send logs to devs'}
+      title={'Share logs'}
       onPress={() => {
         void sendLogs()
       }}

--- a/packages/mobile/src/utils/sendLogs.stories.tsx
+++ b/packages/mobile/src/utils/sendLogs.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { View } from 'react-native'
+import { storiesOf } from '@storybook/react-native'
+
+import { Button } from '../components/Button/Button.component'
+import { sendLogs } from './sendLogs'
+
+storiesOf('SendLogs', module).add('Trigger share sheet', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 24 }}>
+    <Button
+      title={'Send logs to devs'}
+      onPress={() => {
+        void sendLogs()
+      }}
+    />
+  </View>
+))

--- a/packages/mobile/src/utils/sendLogs.ts
+++ b/packages/mobile/src/utils/sendLogs.ts
@@ -1,0 +1,57 @@
+import { Alert, Platform } from 'react-native'
+import RNFS from 'react-native-fs'
+import Share from 'react-native-share'
+import DeviceInfo from 'react-native-device-info'
+
+import { createLogger } from './logger'
+
+const logger = createLogger('sendLogs')
+
+const LOGS_DIR = RNFS.DocumentDirectoryPath + '/logs'
+
+export const sendLogs = async (): Promise<void> => {
+  let entries: RNFS.ReadDirItem[]
+  try {
+    entries = await RNFS.readDir(LOGS_DIR)
+  } catch (err) {
+    logger.error('Failed to read logs directory', err)
+    Alert.alert('No logs found', 'There are no log files to send yet.')
+    return
+  }
+
+  const logFiles = entries.filter(e => e.isFile()).sort((a, b) => a.name.localeCompare(b.name))
+  if (logFiles.length === 0) {
+    Alert.alert('No logs found', 'There are no log files to send yet.')
+    return
+  }
+
+  const metadata = [
+    `App version: ${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`,
+    `Platform: ${Platform.OS} ${Platform.Version}`,
+    `Device: ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}`,
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    'WARNING: Quiet logs may contain onion addresses, identity keys, invitation secrets, and message content.',
+    'Only share with people you trust.',
+    '',
+  ].join('\n')
+
+  const metadataPath = `${RNFS.CachesDirectoryPath}/quiet-log-metadata.txt`
+  await RNFS.writeFile(metadataPath, metadata, 'utf8')
+
+  const urls = [`file://${metadataPath}`, ...logFiles.map(f => `file://${f.path}`)]
+  const filenames = ['quiet-log-metadata.txt', ...logFiles.map(f => f.name)]
+
+  try {
+    await Share.open({
+      title: 'Quiet logs',
+      subject: `Quiet logs ${new Date().toISOString().slice(0, 10)}`,
+      message: metadata,
+      urls,
+      filenames,
+      failOnCancel: false,
+    })
+  } catch (err) {
+    logger.error('Failed to share logs', err)
+  }
+}

--- a/packages/mobile/src/utils/sendLogs.ts
+++ b/packages/mobile/src/utils/sendLogs.ts
@@ -33,6 +33,8 @@ export const sendLogs = async (): Promise<void> => {
   await RNFS.mkdir(SHARE_DIR)
 
   const header = [
+    `Please send to ${SUPPORT_EMAIL}`,
+    '',
     `App version: ${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`,
     `Platform: ${Platform.OS} ${Platform.Version}`,
     `Device: ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}`,

--- a/packages/mobile/src/utils/sendLogs.ts
+++ b/packages/mobile/src/utils/sendLogs.ts
@@ -8,6 +8,8 @@ import { createLogger } from './logger'
 const logger = createLogger('sendLogs')
 
 const LOGS_DIR = RNFS.DocumentDirectoryPath + '/logs'
+const SHARE_DIR = RNFS.CachesDirectoryPath + '/quiet-logs-share'
+const SUPPORT_EMAIL = 'logs@tryquiet.org'
 
 export const sendLogs = async (): Promise<void> => {
   let entries: RNFS.ReadDirItem[]
@@ -25,7 +27,12 @@ export const sendLogs = async (): Promise<void> => {
     return
   }
 
-  const metadata = [
+  if (await RNFS.exists(SHARE_DIR)) {
+    await RNFS.unlink(SHARE_DIR)
+  }
+  await RNFS.mkdir(SHARE_DIR)
+
+  const header = [
     `App version: ${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`,
     `Platform: ${Platform.OS} ${Platform.Version}`,
     `Device: ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}`,
@@ -34,21 +41,30 @@ export const sendLogs = async (): Promise<void> => {
     'WARNING: Quiet logs may contain onion addresses, identity keys, invitation secrets, and message content.',
     'Only share with people you trust.',
     '',
+    `Bundled ${logFiles.length} log file(s).`,
+    '',
   ].join('\n')
 
-  const metadataPath = `${RNFS.CachesDirectoryPath}/quiet-log-metadata.txt`
-  await RNFS.writeFile(metadataPath, metadata, 'utf8')
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const bundlePath = `${SHARE_DIR}/quiet-logs-${stamp}.txt`
 
-  const urls = [`file://${metadataPath}`, ...logFiles.map(f => `file://${f.path}`)]
-  const filenames = ['quiet-log-metadata.txt', ...logFiles.map(f => f.name)]
+  await RNFS.writeFile(bundlePath, header, 'utf8')
+  for (const f of logFiles) {
+    const sep = `\n\n===== ${f.name} =====\n\n`
+    await RNFS.appendFile(bundlePath, sep, 'utf8')
+    const contents = await RNFS.readFile(f.path, 'utf8')
+    await RNFS.appendFile(bundlePath, contents, 'utf8')
+  }
 
   try {
     await Share.open({
       title: 'Quiet logs',
       subject: `Quiet logs ${new Date().toISOString().slice(0, 10)}`,
-      message: metadata,
-      urls,
-      filenames,
+      message: header,
+      email: SUPPORT_EMAIL,
+      url: `file://${bundlePath}`,
+      filename: `quiet-logs-${stamp}.txt`,
+      type: 'text/plain',
       failOnCancel: false,
     })
   } catch (err) {


### PR DESCRIPTION
## Summary

- Adds a **Share logs** action to the community context menu on mobile, gated to non-production builds (`Config.NODE_ENV !== 'production'`). Visible in `development` and `staging`/alpha bundles, hidden in production.
- Reads the on-device log directory (`RNFS.DocumentDirectoryPath/logs`), bundles all log files plus a metadata header (app version, platform, device, sensitivity warning) into a single `quiet-logs-<timestamp>.txt` under `RNFS.CachesDirectoryPath/quiet-logs-share/`, and shares via the native share sheet with the To: field pre-filled with `logs@tryquiet.org`.
- Storybook stories added: `ContextMenu → Community (dev/alpha — Share logs)` and `SendLogs → Trigger share sheet` for on-device testing.
- Jest test added (`CommunityContextMenu.test.tsx`) verifying the gate hides the item in production and shows it in dev/staging.

Refs https://github.com/TryQuiet/quiet/issues/3196.

## Why this is dev/alpha-only

A pre-implementation audit of every `logger.*` and `console.*` call across `packages/{mobile,desktop,backend,common,state-manager,logger,identity,types}` found that current Quiet logs leak (in info-level entries, unconditionally written to the file every user would share):

- The user's **Tor onion service private key** and **libp2p peer private key** (full `Identity` object logged on every `sendMessage`).
- **Plaintext message content** (outgoing and incoming, plus mobile push-notification payloads).
- **Community PSK, root CA private key, and invitation seeds** (full `Community` and `InvitationData` payloads logged in `state-manager` and `local-db`).
- **Onion-address ↔ peerId** correlation (the deanonymization tuple in one line).

Sharing a current Quiet log would be equivalent to handing over the user's full identity, their community's secrets, and a sample of their plaintext chats. Until a redactor lands in `@quiet/logger` (`findAllByKeyAndReplace` infrastructure exists; needs wiring + a denylist) and the high-leverage call sites are scrubbed, this feature **must not** be exposed to public/production builds.

## Why a single-file bundle

First implementation used `Share.open({ urls: [...] })` to attach the log files individually. Gmail returned **"couldn't attach file"** because:

1. Logs live in `DocumentDirectoryPath` (app-private internal storage on Android), which is not exposed by `react-native-share`'s `FileProvider` (`share_download_paths.xml` only maps `cache-path` and a few external paths).
2. Even after staging into `CachesDirectoryPath`, the combination of `ACTION_SEND_MULTIPLE` + `EXTRA_EMAIL` + multiple `text/plain` URIs is fragile in Gmail — the URI grants don't always transfer through the email composer's process boundary.

Concatenating into a single `text/plain` file and using `ACTION_SEND` (single-attachment path) avoids both issues.

## Test plan

- [x] Jest unit test (`CommunityContextMenu.test.tsx`) — 3 cases covering production / development / staging.
- [x] Storybook (`com.quietmobile.storybook.debug`) on Pixel 7 — both stories render, share sheet opens, Gmail accepts the attachment.
- [x] standardDebug build with `ENVFILE=.env.development` (`com.quietmobile.debug`) on Pixel 7 — full app flow, "Share logs" appears in the community menu, share sheet opens with To: pre-filled, Gmail accepts the attachment.
- [x] standardDebug build with `ENVFILE=.env.production` (`com.quietmobile.debug`) on Pixel 7 — production env baked into the bundle; "Share logs" item is hidden in the community menu (manual confirmation).
- [ ] iOS smoke test (no simulator available in this environment).
- [ ] standardRelease (`prod` variant, Hermes + Proguard) on a CI runner — recommended as a follow-up regression layer; the runtime gate doesn't depend on minification but worth verifying once CI has a signed release build.

## Follow-ups (not in this PR)

- Log redaction in `@quiet/logger` (the actual blocker for exposing this feature publicly).
- Optional: build-time-replaced gate so production bundles dead-code-eliminate the entire `sendLogs` import, enabling a CI bundle-grep that statically proves the feature cannot ship to production. The current runtime gate is correct but leaves the strings in the bundle — fine for a sanity check, not a static guarantee.