### PR TITLE
ci(mobile): use .env.staging for Android prerelease deploys

### DIFF
--- a/.github/workflows/mobile-build-apk.yml
+++ b/.github/workflows/mobile-build-apk.yml
@@ -87,7 +87,9 @@ jobs:
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
       - name: "Build .apk"
-        run: cd ./packages/mobile/android && ENVFILE=../.env.production ./gradlew assembleStandardRelease
+        env:
+          ENVFILE: ${{ github.event.release.prerelease && '../.env.staging' || '../.env.production' }}
+        run: cd ./packages/mobile/android && ./gradlew assembleStandardRelease
 
       - name: "Upload .apk to artifacts"
         continue-on-error: true
@@ -97,7 +99,9 @@ jobs:
           path: ./packages/mobile/android/app/build/outputs/apk/standard/release/app-standard-release.apk
 
       - name: "Build debug .apk"
-        run: cd ./packages/mobile/android && ENVFILE=../.env.production ./gradlew assembleStandardDebug
+        env:
+          ENVFILE: ${{ github.event.release.prerelease && '../.env.staging' || '../.env.production' }}
+        run: cd ./packages/mobile/android && ./gradlew assembleStandardDebug
 
       - name: "Upload debug .apk to artifacts"
         continue-on-error: true

--- a/.github/workflows/mobile-deploy-android.yml
+++ b/.github/workflows/mobile-deploy-android.yml
@@ -74,7 +74,9 @@ jobs:
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
       - name: "Build .aab"
-        run: cd ./packages/mobile/android && ENVFILE=../.env.production ./gradlew bundleStandardRelease
+        env:
+          ENVFILE: ${{ github.event.release.prerelease && '../.env.staging' || '../.env.production' }}
+        run: cd ./packages/mobile/android && ./gradlew bundleStandardRelease
 
       - name: "Upload .abb to artifacts"
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Android deploy workflow hard-coded `ENVFILE=../.env.production`, so prerelease (alpha) builds shipped with `NODE_ENV=production` — same env as a production release.
- That hides the dev/alpha-only "Share logs" menu item (#3198) and any other non-prod gated UI in alpha bundles on the Play track.
- Mirror the iOS workflow's logic (`mobile-deploy-ios.yml:90`): switch `ENVFILE` based on `github.event.release.prerelease` so alpha releases get `.env.staging` and production releases get `.env.production`.

## Test plan
- [ ] Cut a prerelease GitHub release on a test branch and confirm the Android build step reads `.env.staging` (NODE_ENV=staging).
- [ ] Confirm a non-prerelease release still reads `.env.production`.
- [ ] Install the resulting alpha .aab/.apk and verify the "Share logs" item appears in the community context menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)