### PR TITLE
fix: Ensure we connect after app resume on mobile

### DIFF
--- a/packages/backend/src/nest/qss/qss.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss.service.spec.ts
@@ -4,7 +4,7 @@ import { QSSModule } from './qss.module'
 import { QSSClient } from './qss.client'
 import MockedSocket from 'socket.io-mock'
 import { jest } from '@jest/globals'
-import { type Socket as ClientSocket } from 'socket.io-client'
+import { Socket, type Socket as ClientSocket } from 'socket.io-client'
 import { SigChainModule } from '../auth/sigchain.service.module'
 import { SigChainService } from '../auth/sigchain.service'
 import { QSSService } from './qss.service'
@@ -78,6 +78,9 @@ describe('QSSService', () => {
   let community: Community
   let userIdentity: Identity
   let mockedCaptchaVerified: jest.SpiedGetter<any> | undefined
+  let mockedCanConnect: jest.SpiedGetter<any> | undefined
+  let mockedClientClose: jest.SpiedFunction<any> | undefined
+  let socket: Socket | undefined
 
   const teamName = 'foobar'
   const username = 'testuser'
@@ -119,14 +122,6 @@ describe('QSSService', () => {
     orbitDbService = await module.resolve(OrbitDbService)
     await orbitDbService.create(ipfsService.ipfsInstance!)
 
-    let socket = {
-      ...new MockedSocket(),
-      close: () => {},
-      on: (event: string, callback: (...args: any[]) => void) => {},
-      emit: (event: string, payload: any) => {},
-      connected: false,
-      active: false,
-    } as any as ClientSocket
     mockedCreateSocket = jest
       .spyOn(qssClient, 'createSocketAndConnect')
       .mockImplementation(async (_qssEndpoint: string | undefined): Promise<ClientSocket> => {
@@ -142,6 +137,9 @@ describe('QSSService', () => {
       })
     mockedGetSocket = jest.spyOn(qssClient, 'getClientSocket').mockImplementation((): ClientSocket | undefined => {
       return socket
+    })
+    mockedClientClose = jest.spyOn(qssClient, 'close').mockImplementation((): void => {
+      socket = undefined
     })
   })
 
@@ -172,6 +170,10 @@ describe('QSSService', () => {
     if (mockedGetAuthConnection != null) {
       mockedGetAuthConnection.mockRestore()
       mockedGetAuthConnection = undefined
+    }
+    if (mockedCanConnect != null) {
+      mockedCanConnect.mockRestore()
+      mockedCanConnect = undefined
     }
   })
 
@@ -314,6 +316,9 @@ describe('QSSService', () => {
     })
 
     it('re-arms lifecycle handlers after close/resume without duplicates', async () => {
+      await initCommunity()
+      mockedAllowed = jest.spyOn(qssService, 'qssAllowed', 'get').mockReturnValue(true)
+      mockedCanConnect = jest.spyOn(qssService, 'canConnect', 'get').mockReturnValue(true)
       const countHandler = (emitter: any, event: string, handler: (...args: any[]) => void): number => {
         return emitter.listeners(event).filter((listener: (...args: any[]) => void) => listener === handler).length
       }
@@ -353,7 +358,7 @@ describe('QSSService', () => {
 
       expectLifecycleHandlers(1)
 
-      qssService.close()
+      qssService.pause()
 
       expectLifecycleHandlers(0)
 
@@ -364,6 +369,20 @@ describe('QSSService', () => {
       await qssService.resume()
 
       expectLifecycleHandlers(1)
+    })
+
+    it('disconnects and reconnects on pause/resume', async () => {
+      await initCommunity()
+      mockedAllowed = jest.spyOn(qssService, 'qssAllowed', 'get').mockReturnValue(true)
+
+      await qssService.connect('ws://localhost:3000')
+      expect(qssService.connected).toBe(true)
+
+      qssService.pause()
+      expect(qssService.connected).toBe(false)
+
+      await qssService.resume()
+      expect(qssService.connected).toBe(true)
     })
 
     it('serializes concurrent connect requests without overlapping attempts', async () => {

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -555,9 +555,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
   private async _connectImpl(qssEndpoint: string | undefined, enabledOverride: boolean): Promise<QSSOperationResult> {
     const requestedEndpoint = qssEndpoint ?? this._qssEndpoint
     const endpointChanged = qssEndpoint != null && qssEndpoint !== this._qssEndpoint
-    if (endpointChanged) {
-      this._qssEndpoint = requestedEndpoint
-    }
+    this._qssEndpoint = requestedEndpoint
     this._enabledOverride = enabledOverride
 
     // if we are already connected return true and move on

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -72,8 +72,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
    */
   private _reconnectQueueProcessor: NodeJS.Timeout | undefined
   private _reconnectDelayMs = QSS_RECONNECT_DELAY_MS
-  private _reconnectQssEndpoint: string | undefined
-  private _reconnectEnabledOverride = false
+  private _enabledOverride = false
 
   /**
    * Map of team IDs to intervals pulling log entries
@@ -459,8 +458,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
         return QSSOperationResult.DISABLED
       }
 
-      this._reconnectQssEndpoint = qssEndpoint ?? this.qssEndpoint
-      this._reconnectEnabledOverride = enabledOverride
+      this._enabledOverride = enabledOverride
 
       let connStatus: QSSOperationResult
       try {
@@ -509,13 +507,19 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
     this.logger.debug('Scheduling QSS reconnect in', reconnectDelayMs, 'ms')
     this._reconnectQueueProcessor = setTimeout(() => {
       this._reconnectQueueProcessor = undefined
-      void this.connect(this._reconnectQssEndpoint ?? this.qssEndpoint, this._reconnectEnabledOverride)
+      void this.connect(this.qssEndpoint, this._enabledOverride)
     }, reconnectDelayMs)
   }
 
   public pause(): void {
+    if (!this.canConnect) {
+      this.logger.trace(`Skipping QSS pause because QSS isn't enabled`)
+      return
+    }
+
     this.logger.info('Pausing QSS service')
     this._paused = true
+    this._teardownEventHandlers()
     this._clearReconnectTimer(true)
     for (const interval of this._logPullIntervals.values()) {
       clearInterval(interval)
@@ -525,16 +529,21 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
       clearTimeout(timeout)
     }
     this._logPullSuccessTimeouts.clear()
-    this.qssClient.off(QSSEvents.QSS_CONNECTED, this._requestCaptchaVerificationAfterConnect)
     this._captchaVerificationQueued = false
     this.qssAuthConnManager.close()
     this.qssClient.close()
   }
 
   public async resume(): Promise<void> {
+    if (!this.canConnect) {
+      this.logger.trace(`Skipping QSS resume because QSS isn't enabled`)
+      return
+    }
+
     this.logger.info(`Resuming QSS service`)
     this._paused = false
     this._configureEventHandlers()
+    await this.connect(this.qssEndpoint, this._enabledOverride)
   }
 
   /**
@@ -546,7 +555,10 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
   private async _connectImpl(qssEndpoint: string | undefined, enabledOverride: boolean): Promise<QSSOperationResult> {
     const requestedEndpoint = qssEndpoint ?? this._qssEndpoint
     const endpointChanged = qssEndpoint != null && qssEndpoint !== this._qssEndpoint
-    this._qssEndpoint = requestedEndpoint
+    if (endpointChanged) {
+      this._qssEndpoint = requestedEndpoint
+    }
+    this._enabledOverride = enabledOverride
 
     // if we are already connected return true and move on
     if (this.connected && !endpointChanged) {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
