### PR TITLE
fix: register QSS_FULLY_JOINED listener before qssService.connect() in launch

### DIFF
--- a/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
@@ -220,6 +220,45 @@ describe('ConnectionsManagerService', () => {
     expect(launchResolved).toBe(true)
   })
 
+  it('handles QSS_FULLY_JOINED emitted synchronously while connecting', async () => {
+    const teamId = 'team-id'
+
+    jest.spyOn(connectionsManagerService['storageService'], 'getIdentity').mockResolvedValue(userIdentity)
+    jest.spyOn(connectionsManagerService, 'spawnTorHiddenService').mockResolvedValue('localhost.onion')
+    jest.spyOn(connectionsManagerService.libp2pService, 'createInstance').mockResolvedValue(undefined as any)
+    jest.spyOn(qssService, 'connect').mockImplementation(() => {
+      qssService.emit(QSSEvents.QSS_FULLY_JOINED, teamId)
+      return Promise.resolve(QSSOperationResult.SUCCESS)
+    })
+    jest.spyOn(connectionsManagerService['tor'], 'isBootstrappingFinished').mockResolvedValue(false)
+    connectionsManagerService['ports'] = {
+      socksPort: 9001,
+      libp2pHiddenService: 9002,
+      controlPort: 9003,
+      dataServer: 9004,
+      httpTunnelPort: 9005,
+    }
+    jest.spyOn(sigChainService, 'getActiveChain').mockReturnValue({
+      team: {
+        id: teamId,
+      },
+      roles: {
+        amIMemberOfRole: () => false,
+      },
+    } as any)
+
+    const storageInitSpy = jest.spyOn(connectionsManagerService['storageService'], 'init').mockResolvedValue()
+    const markTeamStorageReadySpy = jest.spyOn(qssService, 'markTeamStorageReady').mockImplementation(() => {})
+
+    await connectionsManagerService.launch(community)
+
+    expect(qssService.connect).toHaveBeenCalledTimes(1)
+    expect(storageInitSpy).toHaveBeenCalledTimes(1)
+    expect(storageInitSpy).toHaveBeenCalledWith(teamId)
+    expect(markTeamStorageReadySpy).toHaveBeenCalledTimes(1)
+    expect(markTeamStorageReadySpy).toHaveBeenCalledWith(teamId)
+  })
+
   it('attempts notification token tombstoning before closing services and still leaves if it is not acked', async () => {
     const tombstoneSpy = jest.spyOn(qpsService, 'tombstoneCurrentUserNotificationTokens').mockResolvedValue(false)
     const captchaResetSpy = jest.spyOn(captchaService, 'reset')

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -693,7 +693,6 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       torBootstrap: this.tor,
     }
     await this.libp2pService.createInstance(params)
-    this.qssService.connect(community.qssEndpoint)
 
     let storageTeamId: string | undefined
     let setupStorageWithTeamMetaPromise: Promise<void> | undefined
@@ -722,6 +721,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
     if (hasStorageReadyChain) {
       this.logger.debug('Active chain already has team and user is a member, setting up storage immediately')
       await setupStorageWithTeamMeta(activeChain.team!.id)
+      this.qssService.connect(community.qssEndpoint)
     } else {
       this.logger.debug(
         'Active chain does not have team or user is not a member, waiting for team metadata before setting up storage'
@@ -750,6 +750,8 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
           void handleStorageReady(teamId)
         })
       })
+
+      this.qssService.connect(community.qssEndpoint)
 
       if (await this.tor.isBootstrappingFinished()) {
         this.serverIoProvider.io.emit(SocketEvents.TOR_INITIALIZED)


### PR DESCRIPTION
## Summary

This fixes an event-ordering race in the QSS launch path by installing the storage-ready listeners before starting the QSS connection/auth flow.

Changes:

- Move `qssService.connect()` so it runs after the `QSS_FULLY_JOINED` / `AUTH_JOINED` listeners are registered in the join-waiting branch.
- Keep the already-member branch simple: initialize storage and mark it ready, then connect to QSS.
- Add a regression test that forces `QSS_FULLY_JOINED` to fire during `qssService.connect()` and verifies launch still initializes storage.

## Code Path

The vulnerable ordering in the 7.1.0 base branch is in `ConnectionsManagerService.launch()`:

- `packages/backend/src/nest/connections-manager/connections-manager.service.ts:695-696` creates the libp2p instance and immediately calls `this.qssService.connect(community.qssEndpoint)`.
- `packages/backend/src/nest/connections-manager/connections-manager.service.ts:729-752` only later creates `storageReadyPromise` and registers the one-shot listeners for `QSSEvents.QSS_FULLY_JOINED` and `Libp2pEvents.AUTH_JOINED`.
- `packages/backend/src/nest/connections-manager/connections-manager.service.ts:759` then awaits `storageReadyPromise`.

That means launch depends on an unbuffered `EventEmitter.once(...)` listener for the event that makes storage initialization happen, but the code starts the QSS side effect before installing that listener.

The production event chain exists in QSS code:

- QSS socket connection emits `QSSEvents.QSS_CONNECTED` in `packages/backend/src/nest/qss/qss.client.ts:187-190`.
- `QSSService` listens for that event and enters sign-in handling in `packages/backend/src/nest/qss/qss.service.ts:347-350`.
- Sign-in starts the QSS auth connection in `packages/backend/src/nest/qss/qss.service.ts:951-978`.
- When auth join completes for an invitee without a local team yet, `QSSAuthConnection` emits `QSSEvents.QSS_SELF_ASSIGN_MEMBER` in `packages/backend/src/nest/qss/qss-auth-conn.ts:247-266`.
- `QSSService._handleSelfAssignMember()` then emits `QSSEvents.QSS_FULLY_JOINED` in `packages/backend/src/nest/qss/qss.service.ts:256-269`.

This PR changes the launch ordering so the listener is installed before `qssService.connect()` can start that event chain:

- The storage setup helper is defined in `packages/backend/src/nest/connections-manager/connections-manager.service.ts:697-717`.
- The join-waiting branch registers `QSS_FULLY_JOINED` and `AUTH_JOINED` at `packages/backend/src/nest/connections-manager/connections-manager.service.ts:729-752`.
- Only after those listeners are in place does it call `this.qssService.connect(...)` at `packages/backend/src/nest/connections-manager/connections-manager.service.ts:754`.

## Why This Is A Real Bug Class

The bug is not that QSS always emits `QSS_FULLY_JOINED` synchronously. The deterministic test deliberately compresses the timing so the failure is reliable. The real bug is that the old code made launch correctness depend on an ordering assumption that was not enforced: "QSS join completion cannot happen until after launch registers its one-shot listener."

That assumption is fragile because `QSS_FULLY_JOINED` is not a stored state transition. It is an EventEmitter event. If it fires before the `once(...)` listener exists, nothing replays it. The launch path then waits on `storageReadyPromise`, storage is not initialized, `markTeamStorageReady()` is not called, and `launch()` does not complete normally.

The likely user-facing symptom, if this ordering window is hit, is a client stuck during QSS-backed join/launch: QSS auth may have succeeded, but the backend launch path is still waiting for the event that it already missed. That aligns with the class of bugs we are looking for: startup/join races where one subsystem reaches a state before another subsystem has registered the callback that observes that state.

## How Likely Is This In Real Use?

Honest assessment: this is a credible race-hardening fix, not proof that every normal QSS join on 7.1.0 is broken.

Reasons it is credible:

- It affects a normal single-client, single-community QSS join path; it does not require multiple communities or two users sharing one process.
- The production event chain that emits `QSS_FULLY_JOINED` is real and is part of QSS auth completion.
- The old code starts QSS before registering the listener that is required to finish launch.
- The listener is one-shot and unbuffered, so a missed event is terminal unless another later event happens to arrive.
- A fast local QSS, an already-warm socket, reconnect behavior, CPU scheduling, or future refactoring inside `connect()`/auth handling can make this order observable. This is exactly the sort of condition a stateful network/CPU fuzzer is designed to find.

Reasons not to overstate it:

- The current `QSSService.connect()` implementation usually crosses async boundaries before QSS auth can emit `QSS_FULLY_JOINED`, such as local DB checks and the socket handshake. In many ordinary runs, those async boundaries probably give `launch()` enough time to register the listener.
- The regression test uses a synchronous mock emission to make the ordering bug deterministic. It proves the old launch code was not robust to fast QSS completion; it does not prove the production server emits synchronously today.

So the best claim is: this is a real ordering bug in the launch contract, with plausible production triggers and a severe failure mode when hit, but it is probably timing-sensitive rather than guaranteed or frequent.

## Regression Test

The new test is in `packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts:223-260`.

It configures the launch path so the active chain is not yet storage-ready (`amIMemberOfRole()` returns false), then mocks `qssService.connect()` to emit `QSSEvents.QSS_FULLY_JOINED` immediately. The expected behavior after the fix is:

- `launch()` resolves.
- `storageService.init(teamId)` is called once.
- `qssService.markTeamStorageReady(teamId)` is called once.

On raw 7.1.0, after adding only this test, it hangs because the event fires before the listener is registered:

```text
FAIL src/nest/connections-manager/connections-manager.service.spec.ts
ConnectionsManagerService
  ✕ handles QSS_FULLY_JOINED emitted synchronously while connecting (40166 ms)

thrown: "Exceeded timeout of 40000 ms for a test."
```

After this fix:

```text
PASS src/nest/connections-manager/connections-manager.service.spec.ts
ConnectionsManagerService
  ✓ handles QSS_FULLY_JOINED emitted synchronously while connecting (157 ms)
  ✓ 12 tests passed
```

## Validation

```bash
PATH=/home/holmes/.nvm/versions/node/v20.20.1/bin:$PATH npm run test -- --runInBand --verbose --detectOpenHandles --forceExit --globals '{"ts-jest":{"diagnostics":false}}' src/nest/connections-manager/connections-manager.service.spec.ts
```

Result:

```text
PASS src/nest/connections-manager/connections-manager.service.spec.ts
Tests: 12 passed, 12 total
```

## Note

Replaces holmesworcester/quiet#1, which targeted the workflow-stripped mirror at `holmesworcester/quiet:7.1.0`. This PR retargets the same patch directly at upstream `TryQuiet/quiet:7.1.0`.
