### PR TITLE
fix: await setCurrentCommunityId before launching community services

### DIFF
--- a/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
@@ -144,6 +144,32 @@ describe('ConnectionsManagerService', () => {
     expect(launchSpy).toBeCalledTimes(1)
   })
 
+  it('waits for current community id to be persisted before launching community services', async () => {
+    await localDbService.setCommunity(community)
+
+    let resolveSetCurrentCommunityId!: () => void
+    const setCurrentCommunityIdPromise = new Promise<void>(resolve => {
+      resolveSetCurrentCommunityId = resolve
+    })
+    const setCurrentCommunityIdSpy = jest
+      .spyOn(localDbService, 'setCurrentCommunityId')
+      .mockReturnValue(setCurrentCommunityIdPromise)
+    const loadChainSpy = jest.spyOn(sigChainService, 'loadChain').mockResolvedValue({} as any)
+    const launchSpy = jest.spyOn(connectionsManagerService, 'launch').mockResolvedValue()
+
+    const launchCommunityPromise = connectionsManagerService.launchCommunity(community.id)
+
+    await waitForExpect(() => expect(setCurrentCommunityIdSpy).toHaveBeenCalledWith(community.id))
+    expect(loadChainSpy).not.toHaveBeenCalled()
+    expect(launchSpy).not.toHaveBeenCalled()
+
+    resolveSetCurrentCommunityId()
+    await launchCommunityPromise
+
+    expect(loadChainSpy).toHaveBeenCalledWith(community.name, true)
+    expect(launchSpy).toHaveBeenCalledWith(community)
+  })
+
   it('pauses and resumes qss alongside the mobile lifecycle', async () => {
     const closeSocketSpy = jest.spyOn(connectionsManagerService, 'closeSocket').mockResolvedValue()
     const openSocketSpy = jest.spyOn(connectionsManagerService, 'openSocket').mockResolvedValue()

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -599,7 +599,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
       })
       return
     }
-    this.localDbService.setCurrentCommunityId(id)
+    await this.localDbService.setCurrentCommunityId(id)
     if ([ServiceState.LAUNCHING, ServiceState.LAUNCHED].includes(this.communityState)) {
       this.logger.error(
         'Cannot launch community more than once.' +


### PR DESCRIPTION
## Summary
- Awaits `LocalDbService.setCurrentCommunityId(id)` before `launchCommunity()` loads sigchain or starts backend services.
- Adds a regression test that holds the current-community write open and proves launch work waits for it.

## Bug Narrative
In 7.1.0, `packages/backend/src/nest/connections-manager/connections-manager.service.ts:591-602` started `this.localDbService.setCurrentCommunityId(id)` but did not await it. `launchCommunity()` then immediately continued into launch-state checks, sigchain loading, and `launch(community)` at `connections-manager.service.ts:603-635`.

`setCurrentCommunityId()` is not just an in-memory assignment. It writes `CURRENT_COMMUNITY_ID` to LevelDB and only then emits `LocalDbEvents.COMMUNITY_ADDED` at `packages/backend/src/nest/local-db/local-db.service.ts:235-238`. `getCurrentCommunity()` later reads that key and uses it to select the community object at `local-db.service.ts:250-255`. If the write is still in progress, readers can observe no current community or a stale previous current-community pointer even though `launchCommunity(id)` is already launching the new requested community.

The QSS path is the important downstream consumer. `launch(community)` starts libp2p and then calls `this.qssService.connect(community.qssEndpoint)` without awaiting it at `connections-manager.service.ts:670-696`. Inside QSS, `_connectImpl()` checks `getQssInitStatus()` before opening the socket when `enabledOverride` is false: `packages/backend/src/nest/qss/qss.service.ts:571-580`. `getQssInitStatus()` reads the current community from LocalDB at `qss.service.ts:418-427`. QSS sign-in handling does the same through `_handleQssHandleSignIn()` at `qss.service.ts:217-223`, which is triggered by both community-added and QSS-connected events at `qss.service.ts:194-201`.

So the race is: `launchCommunity(id)` has a concrete community object, starts the async current-community write, then continues far enough to start QSS. QSS can check whether the current community is initialized/enabled before `CURRENT_COMMUNITY_ID` actually points at `id`. In that case QSS may skip or delay connection/sign-in for the community that is being launched, or make the decision from stale current-community state.

## Realism / Honest Assessment
This does not require multiple communities or users in one running client. It is relevant to normal one-community flows where the community record already exists and `launchCommunity(id)` is asked to repair or start runtime services. The clearest paths are:

- The frontend/socket launch path calls `this.launchCommunity(args.id)` from `SocketActions.LAUNCH_COMMUNITY` at `connections-manager.service.ts:790-795`.
- A partial leave/recreate, migration, or startup repair can leave the community object present while the current-community pointer is missing or stale.
- Slow LevelDB writes or CPU/network churn make the ordering easier to hit because QSS launch is asynchronous and not awaited by `launch()`.

There is one important limit: `createCommunity()` and `joinCommunity()` already await `setCurrentCommunityId()` before their next steps at `connections-manager.service.ts:462-465` and `connections-manager.service.ts:570-571`. So this PR is not claiming the initial create path itself skips the write. The bug is specifically the reusable `launchCommunity(id)` path, which previously violated the same ordering guarantee.

The likely impact is not data corruption. It is an intermittent launch/QSS initialization failure mode: QSS can decide the community is not initialized or not enabled and return early, relying on later retries/events to recover. That makes it the sort of bug that shows up under leave/recreate residue, startup repair, slow disk, or lifecycle churn rather than on every launch.

## Fix
`launchCommunity()` now awaits `setCurrentCommunityId(id)` before checking launch state, loading sigchain, or starting services. This aligns `launchCommunity()` with the existing create/join ordering and makes current-community state durable before QSS reads it.

## POC / Red-Green Evidence
The regression test is `packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts:147-171`. It stores a community, mocks `setCurrentCommunityId()` with a deferred promise, calls `launchCommunity(community.id)`, and asserts that neither `sigChainService.loadChain()` nor `launch()` is called until the current-community write resolves.

Red on 7.1.0 before the fix:

```text
FAIL src/nest/connections-manager/connections-manager.service.spec.ts
  ConnectionsManagerService
    ✕ waits for current community id to be persisted before launching community services

expect(jest.fn()).not.toHaveBeenCalled()
Expected number of calls: 0
Received number of calls: 1
```

Green after this fix, focused test:

```text
PASS src/nest/connections-manager/connections-manager.service.spec.ts
  ConnectionsManagerService
    ✓ waits for current community id to be persisted before launching community services
Tests: 1 passed, 11 skipped, 12 total
```

Full targeted connections-manager suite after this fix:

```text
PASS src/nest/connections-manager/connections-manager.service.spec.ts
Tests: 12 passed, 12 total
```

Test note: local runs used `--globals '{"ts-jest":{"diagnostics":false}}'` because the temporary worktrees reuse vendored dependencies through symlinks, which otherwise can produce duplicate private TypeScript type identities from vendored auth packages. The runtime behavior under test is the launch ordering described above.

## Note

Replaces holmesworcester/quiet#6, which targeted the workflow-stripped mirror at `holmesworcester/quiet:7.1.0`. This PR retargets the same patch directly at upstream `TryQuiet/quiet:7.1.0`.
