### PR TITLE
fix: coalesce overlapping QSS auth connection starts per team

### DIFF
--- a/packages/backend/src/nest/qss/qss-auth-conn-manager.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss-auth-conn-manager.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { type ModuleRef } from '@nestjs/core'
 import { TestModule } from '../common/test.module'
 import { QSSAuthConnectionManager } from './qss-auth-conn-manager.service'
+import { QSSAuthConnection } from './qss-auth-conn'
 import { QSSModule } from './qss.module'
 import { QSSClient } from './qss.client'
 import MockedSocket from 'socket.io-mock'
@@ -22,6 +24,25 @@ describe('QSSAuthConnectionManager', () => {
 
   const teamName = 'foobar'
   const username = 'testuser'
+  const createDeferred = <T>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>(res => {
+      resolve = res
+    })
+    return { promise, resolve }
+  }
+
+  const createMockAuthConnection = (id: string): QSSAuthConnection =>
+    ({
+      id,
+      teamId: undefined,
+      active: true,
+      on: jest.fn(),
+      start: jest.fn(async (_teamName?: string) => {}),
+      stop: jest.fn(),
+      isForClientSocket: jest.fn(() => true),
+    }) as unknown as QSSAuthConnection
+
   const createMockSocket = (id: string): ClientSocket =>
     ({
       ...new MockedSocket(),
@@ -83,6 +104,31 @@ describe('QSSAuthConnectionManager', () => {
     expect(possiblyNewConn).toBeDefined()
     expect(possiblyNewConn!.id).toEqual(conn!.id)
     expect(possiblyNewConn?.active).toBeTruthy()
+  })
+
+  it('coalesces overlapping starts for the same team while auth connection creation is in flight', async () => {
+    const teamId = 'race-team-id'
+    const moduleRef = (qssAuthConnManager as any).moduleRef as ModuleRef
+    const createDeferredConnection = createDeferred<QSSAuthConnection>()
+    const authConnection = createMockAuthConnection('race-auth-connection')
+    const createSpy = jest.spyOn(moduleRef, 'create').mockReturnValue(createDeferredConnection.promise as any)
+
+    const firstStart = qssAuthConnManager.startNewConnection(teamId, 'race-team')
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(qssAuthConnManager.getConnection(teamId)).toBeUndefined()
+
+    const secondStart = qssAuthConnManager.startNewConnection(teamId, 'race-team')
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(qssAuthConnManager.getConnection(teamId)).toBeUndefined()
+
+    createDeferredConnection.resolve(authConnection)
+    await Promise.all([firstStart, secondStart])
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(authConnection.teamId).toBe(teamId)
+    expect(authConnection.start).toHaveBeenCalledTimes(1)
+    expect(authConnection.start).toHaveBeenCalledWith('race-team')
+    expect(qssAuthConnManager.getConnection(teamId)).toBe(authConnection)
   })
 
   it(`starts a replacement connection when the existing connection was stopped`, async () => {

--- a/packages/backend/src/nest/qss/qss-auth-conn-manager.service.ts
+++ b/packages/backend/src/nest/qss/qss-auth-conn-manager.service.ts
@@ -18,6 +18,7 @@ export class QSSAuthConnectionManager extends EventEmitter implements OnModuleDe
    * Map of team IDs to QSS auth sync connections
    */
   private readonly authConnMap: Map<string, QSSAuthConnection> = new Map()
+  private readonly startConnectionPromises: Map<string, Promise<void>> = new Map()
 
   private readonly logger = createLogger('qss:auth:conn:manager')
 
@@ -89,6 +90,24 @@ export class QSSAuthConnectionManager extends EventEmitter implements OnModuleDe
    * @param teamName Optional team name to pass in for filtering purposes
    */
   public async startNewConnection(teamId: string, teamName?: string): Promise<void> {
+    const existingStartPromise = this.startConnectionPromises.get(teamId)
+    if (existingStartPromise != null) {
+      this.logger.warn('QSS auth connection start already in progress for team ID', teamId)
+      return existingStartPromise
+    }
+
+    const startPromise = this._startNewConnection(teamId, teamName)
+    this.startConnectionPromises.set(teamId, startPromise)
+    try {
+      await startPromise
+    } finally {
+      if (this.startConnectionPromises.get(teamId) === startPromise) {
+        this.startConnectionPromises.delete(teamId)
+      }
+    }
+  }
+
+  private async _startNewConnection(teamId: string, teamName?: string): Promise<void> {
     const currentClientSocket = this.qssClient.getClientSocket()
     if (currentClientSocket == null || !currentClientSocket.connected || !currentClientSocket.active) {
       throw new Error('Must have an active QSS client socket prior to starting an auth connection!')


### PR DESCRIPTION
## Summary
- Coalesces overlapping `QSSAuthConnectionManager.startNewConnection(teamId)` calls per team.
- Adds a regression test proving 7.1.0 can create two auth connections for the same team when the first connection is still being constructed.
- Preserves the existing replacement logic once a connection is actually present in `authConnMap`.
- Realism assessment: this is a real one-client/one-team manager race, but likely low frequency. Repeated sign-in events alone are usually serialized by `_signInMutex`; the plausible production path is the fire-and-forget `QSS_START_AUTH_CONN` owner-create path overlapping with a later reconnect/sign-in/lifecycle start while provider creation or auth startup is still pending.

## What Goes Wrong
A single Quiet client can accidentally start two QSS auth sync connections for the same team. The manager is designed around one auth connection per team, but in 7.1.0 the first start is not recorded anywhere until after Nest finishes creating the `QSSAuthConnection` provider. A second start that arrives during that gap sees an empty map and creates another connection.

The result is not two active communities. It is two Local First Auth/QSS sync sessions for the same team on the same client. The later connection overwrites the earlier one in `authConnMap`, so the manager can only see, stop, and deliver inbound `AUTH_SYNC` messages to the later connection. The earlier connection may still be running on the QSS socket and can still send auth-sync messages or emit join/self-assign side effects.

User-visible symptoms would be confusing and timing-dependent: duplicate auth-sync traffic, duplicate self-assign/join-adjacent work, stale connection state, and an auth connection that is effectively orphaned from the manager until a broader QSS disconnect/teardown catches it.

## How It Happens
The vulnerable sequence is in `packages/backend/src/nest/qss/qss-auth-conn-manager.service.ts`.

1. `startNewConnection(teamId)` starts and validates that the QSS client socket is active at `qss-auth-conn-manager.service.ts:110-114`.
2. It checks `authConnMap` for an existing connection at `qss-auth-conn-manager.service.ts:116-145`.
3. In 7.1.0 there is no separate "start in progress" marker. If no connection is already in the map, the method awaits `moduleRef.create(QSSAuthConnection)` at `qss-auth-conn-manager.service.ts:148-151`.
4. The new connection is not inserted into `authConnMap` until `qss-auth-conn-manager.service.ts:152-156`.
5. If a second `startNewConnection(teamId)` call arrives while the first call is still waiting for provider creation, the second call also sees no map entry and starts another provider creation.
6. When both calls resolve, both connections get the same `teamId`, both install the `QSS_SELF_ASSIGN_MEMBER` forwarder, and both call `authConnection.start(teamName)` at `qss-auth-conn-manager.service.ts:152-157`.
7. Each `QSSAuthConnection.start()` binds to the current QSS socket, marks itself starting, initializes a Local First Auth `Connection`, and starts it at `packages/backend/src/nest/qss/qss-auth-conn.ts:148-181`.
8. That Local First Auth connection sends outbound QSS `AUTH_SYNC` messages at `qss-auth-conn.ts:192-205`, can emit `QSS_AUTH_CONNECTED`/`QSS_AUTH_JOINED` at `qss-auth-conn.ts:225-237` and `qss-auth-conn.ts:271`, and can emit `QSS_SELF_ASSIGN_MEMBER` at `qss-auth-conn.ts:255-266`.

Only the last connection written to `authConnMap` remains manager-owned. Manager delivery of inbound `AUTH_SYNC` uses the map entry at `qss-auth-conn-manager.service.ts:51-64`, and `stopConnection()` only stops the map entry at `qss-auth-conn-manager.service.ts:166-173`. That is why the first connection can become stale/orphaned while still having performed real QSS auth work.

## Realism / Honest Assessment
This does not require unsupported multiple communities or multiple users in one client. The race is within one client's QSS auth connection manager for one team.

The clearest 7.1.0 path is owner QSS community creation plus lifecycle churn:

- After QSS community creation succeeds, `_createCommunityImpl()` writes `qssSetup: true` and emits `QSS_START_AUTH_CONN` at `packages/backend/src/nest/qss/qss.service.ts:774-777`.
- The `QSS_START_AUTH_CONN` handler calls `startAuthConnection(teamId, teamName)` fire-and-forget at `qss.service.ts:165-166`.
- `startAuthConnection()` awaits `qssAuthConnManager.startNewConnection()` at `qss.service.ts:375-378`, but because the event handler does not await it, the start can remain in flight in the background.
- QSS sign-in can also call `startAuthConnection()` after a successful `SIGN_IN_COMMUNITY` ack at `qss.service.ts:951-984`.
- Sign-in work is triggered by QSS/community lifecycle events at `qss.service.ts:194-201` and then runs through `_handleQssHandleSignIn()` at `qss.service.ts:217-253`.

The common repeated sign-in path has `_signInMutex`, so repeated `QSS_HANDLE_SIGN_IN` events alone should usually serialize. The risk comes from the fire-and-forget `QSS_START_AUTH_CONN` path overlapping with a later sign-in/reconnect/lifecycle start while provider creation or auth connection startup is still pending. This is low-frequency, but plausible under slow CPU, slow dependency/provider initialization, reconnect churn, or QSS startup/join churn.

The impact is also narrower than data corruption: this is an auth-sync/session-management bug. It can duplicate QSS auth traffic and side effects and leave one connection outside the manager's normal per-team control.

## Fix
`startNewConnection()` now keeps a `startConnectionPromises` map keyed by `teamId`. If another start arrives while the first start for that team is still in progress, it returns the existing promise instead of creating a second `QSSAuthConnection`. The promise is removed in `finally`, and the existing active/inactive/stale-socket replacement behavior remains inside `_startNewConnection()` for calls that happen after no start is in flight.

## POC / Red-Green Evidence
The added regression test is `packages/backend/src/nest/qss/qss-auth-conn-manager.service.spec.ts:109-132`. It uses the real Nest test module, real `QSSAuthConnectionManager`, real `QSSClient` socket shape, and delays only `moduleRef.create(QSSAuthConnection)` to hold the first start in the pre-map insertion window.

Red on 7.1.0 before the fix:

```text
FAIL src/nest/qss/qss-auth-conn-manager.service.spec.ts
  QSSAuthConnectionManager
    ✕ coalesces overlapping starts for the same team while auth connection creation is in flight

Expected number of calls: 1
Received number of calls: 2

  120 | const secondStart = qssAuthConnManager.startNewConnection(teamId, 'race-team')
> 121 | expect(createSpy).toHaveBeenCalledTimes(1)
```

Green after this fix, focused test:

```text
PASS src/nest/qss/qss-auth-conn-manager.service.spec.ts
  QSSAuthConnectionManager
    ✓ coalesces overlapping starts for the same team while auth connection creation is in flight
Tests: 1 passed, 9 skipped, 10 total
```

Full targeted auth-connection-manager suite after this fix:

```text
PASS src/nest/qss/qss-auth-conn-manager.service.spec.ts
Tests: 10 passed, 10 total
```

Test note: local runs used `--globals '{"ts-jest":{"diagnostics":false}}'` because these temporary worktrees reuse vendored dependencies via symlinks; without that, TypeScript can see duplicate private types from the shared vendored auth package. The runtime behavior under test is the async QSS auth manager behavior described above.

## Note

Replaces holmesworcester/quiet#5, which targeted the workflow-stripped mirror at `holmesworcester/quiet:7.1.0`. This PR retargets the same patch directly at upstream `TryQuiet/quiet:7.1.0`.
