### PR TITLE
fix(qss): track endpoint identity in QSSClient connection coalescing

### DIFF
--- a/packages/backend/src/nest/qss/qss.client.spec.ts
+++ b/packages/backend/src/nest/qss/qss.client.spec.ts
@@ -1,0 +1,161 @@
+import { jest } from '@jest/globals'
+import EventEmitter from 'node:events'
+import { type Socket as ClientSocket } from 'socket.io-client'
+import { type QSSClient as QSSClientType } from './qss.client'
+
+const connectMock = jest.fn()
+
+jest.unstable_mockModule('socket.io-client', () => ({
+  connect: connectMock,
+}))
+
+jest.unstable_mockModule('../captcha/captcha.service', () => ({
+  CaptchaService: class {},
+}))
+
+jest.unstable_mockModule('../common/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    trace: jest.fn(),
+    warn: jest.fn(),
+  }),
+}))
+
+class MockCompoundError extends Error {
+  public original?: Error
+
+  constructor(message: string, original?: Error) {
+    super(message)
+    this.original = original
+  }
+}
+
+jest.unstable_mockModule('@quiet/types', () => ({
+  CaptchaErrorMessages: {
+    CATCHA_VERIFICATION_REQUIRED: 'captcha verification required',
+  },
+  CompoundError: MockCompoundError,
+  SocketEvents: {
+    HCAPTCHA_SITE_KEY: 'hcaptchaSiteKey',
+    HCAPTCHA_VERIFICATION_UPDATE: 'hcaptchaVerificationUpdate',
+  },
+}))
+
+class MockQSSConnectionError extends Error {}
+class MockQSSNotInitializedError extends Error {}
+
+jest.unstable_mockModule('./qss.types', () => ({
+  CommunityOperationStatus: {
+    SENDING: 'sending',
+    SUCCESS: 'success',
+  },
+  QSSConnectionError: MockQSSConnectionError,
+  QSSEvents: {
+    QSS_CONNECTED: 'qssConnected',
+    QSS_DISCONNECTED: 'qssDisconnected',
+    QSS_CAPTCHA_REQUIRED: 'qssCaptchaRequired',
+  },
+  QSSNotInitializedError: MockQSSNotInitializedError,
+  WebsocketEvents: {},
+}))
+
+let QSSClient: typeof QSSClientType
+
+class PendingClientSocket extends EventEmitter {
+  public active = false
+  public connected = false
+  public id: string
+  public connect = jest.fn()
+  public close = jest.fn(() => {
+    this.active = false
+    this.connected = false
+  })
+  public onAny = jest.fn()
+  public offAny = jest.fn()
+
+  constructor(id: string) {
+    super()
+    this.id = id
+  }
+
+  public emitConnect(): void {
+    this.active = true
+    this.connected = true
+    this.emit('connect')
+  }
+}
+
+const connectOptions = {
+  autoConnect: false,
+  forceNew: false,
+  transports: ['websocket'],
+}
+
+describe('QSSClient', () => {
+  beforeAll(async () => {
+    const qssClientModule = await import('./qss.client')
+    QSSClient = qssClientModule.QSSClient
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('coalesces concurrent connection requests for the same endpoint', async () => {
+    const socketA = new PendingClientSocket('socket-a')
+    connectMock.mockReturnValue(socketA as any as ClientSocket)
+    const client = new QSSClient(
+      true,
+      'ws://default-qss',
+      { io: { emit: jest.fn() } } as any,
+      { getToken: jest.fn() } as any
+    )
+
+    const firstConnect = client.createSocketAndConnect('ws://qss-a')
+    const secondConnect = client.createSocketAndConnect('ws://qss-a')
+
+    expect(connectMock).toHaveBeenCalledTimes(1)
+    expect(connectMock).toHaveBeenCalledWith('ws://qss-a', connectOptions)
+    expect(socketA.connect).toHaveBeenCalledTimes(1)
+
+    socketA.emitConnect()
+
+    await expect(firstConnect).resolves.toBe(socketA)
+    await expect(secondConnect).resolves.toBe(socketA)
+    expect(socketA.close).not.toHaveBeenCalled()
+  })
+
+  it('does not satisfy a newer endpoint request with an abandoned endpoint connection', async () => {
+    const socketA = new PendingClientSocket('socket-a')
+    const socketB = new PendingClientSocket('socket-b')
+    connectMock.mockImplementation((endpoint: unknown) => {
+      if (endpoint === 'ws://old-qss') {
+        return socketA as any as ClientSocket
+      }
+      return socketB as any as ClientSocket
+    })
+    const client = new QSSClient(
+      true,
+      'ws://default-qss',
+      { io: { emit: jest.fn() } } as any,
+      { getToken: jest.fn() } as any
+    )
+
+    const abandonedConnect = client.createSocketAndConnect('ws://old-qss')
+    const abandonedError = abandonedConnect.catch(error => error)
+    const replacementConnect = client.createSocketAndConnect('ws://new-qss')
+
+    expect(connectMock).toHaveBeenCalledTimes(2)
+    expect(connectMock).toHaveBeenNthCalledWith(1, 'ws://old-qss', connectOptions)
+    expect(connectMock).toHaveBeenNthCalledWith(2, 'ws://new-qss', connectOptions)
+    expect(socketA.close).toHaveBeenCalledTimes(1)
+    expect(socketB.connect).toHaveBeenCalledTimes(1)
+
+    socketB.emitConnect()
+
+    await expect(abandonedError).resolves.toBeInstanceOf(MockCompoundError)
+    await expect(replacementConnect).resolves.toBe(socketB)
+  })
+})

--- a/packages/backend/src/nest/qss/qss.client.ts
+++ b/packages/backend/src/nest/qss/qss.client.ts
@@ -32,6 +32,8 @@ export class QSSClient extends EventEmitter {
   private _clientSocket: ClientSocket | undefined = undefined
   private _clientSocketEndpoint: string | undefined = undefined
   private _connectPromise: Promise<ClientSocket> | undefined = undefined
+  private _connectPromiseEndpoint: string | undefined = undefined
+  private _connectAbortController: AbortController | undefined = undefined
   private _captchaVerified = false
   private _captchaVerificationPromise: Promise<boolean> | null = null
   private _socketEventHandlers:
@@ -80,24 +82,46 @@ export class QSSClient extends EventEmitter {
    * @returns Connected socket.io socket instance
    */
   public async createSocketAndConnect(qssEndpoint: string | undefined): Promise<ClientSocket> {
+    const requestedEndpoint = qssEndpoint ?? this.qssEndpoint
+
     if (this._connectPromise != null) {
-      this.logger.debug('QSS connection already in flight, returning existing connection promise')
-      return this._connectPromise
+      if (this._connectPromiseEndpoint !== requestedEndpoint) {
+        this.logger.warn(
+          'QSS connection already in flight for a different endpoint, aborting stale connection',
+          this._connectPromiseEndpoint,
+          requestedEndpoint
+        )
+        this._connectAbortController?.abort()
+        this._connectPromise = undefined
+        this._connectPromiseEndpoint = undefined
+        this._connectAbortController = undefined
+      } else {
+        this.logger.debug('QSS connection already in flight, returning existing connection promise')
+        return this._connectPromise
+      }
     }
 
-    const connectPromise = this._createSocketAndConnect(qssEndpoint)
+    const abortController = new AbortController()
+    const connectPromise = this._createSocketAndConnect(requestedEndpoint, abortController.signal)
     this._connectPromise = connectPromise
+    this._connectPromiseEndpoint = requestedEndpoint
+    this._connectAbortController = abortController
 
     try {
       return await connectPromise
     } finally {
       if (this._connectPromise === connectPromise) {
         this._connectPromise = undefined
+        this._connectPromiseEndpoint = undefined
+        this._connectAbortController = undefined
       }
     }
   }
 
-  private async _createSocketAndConnect(qssEndpoint: string | undefined): Promise<ClientSocket> {
+  private async _createSocketAndConnect(
+    qssEndpoint: string | undefined,
+    abortSignal?: AbortSignal
+  ): Promise<ClientSocket> {
     try {
       const requestedEndpoint = qssEndpoint ?? this.qssEndpoint
       this.qssEndpoint = requestedEndpoint
@@ -126,7 +150,7 @@ export class QSSClient extends EventEmitter {
       this._clientSocket = socket
       this._clientSocketEndpoint = this.qssEndpoint
       // wait for socket to connect with QSS instance
-      await this._waitForConnect()
+      await this._waitForConnect(socket, abortSignal)
 
       return socket
     } catch (e) {
@@ -139,12 +163,7 @@ export class QSSClient extends EventEmitter {
   /**
    * Wait for QSS socket connection to finish connecting
    */
-  private async _waitForConnect(): Promise<void> {
-    const socket = this._clientSocket
-    if (socket == null) {
-      throw new QSSNotInitializedError(`Must run createSocket first!`)
-    }
-
+  private async _waitForConnect(socket: ClientSocket, abortSignal?: AbortSignal): Promise<void> {
     if (this.connected) {
       this.logger.debug('QSS already connected')
       return
@@ -154,29 +173,59 @@ export class QSSClient extends EventEmitter {
 
     this.logger.debug('Waiting for QSS socket to connect...')
     await new Promise<void>((resolve, reject) => {
+      let settled = false
       const timer = setTimeout(() => {
-        socket.off('connect', onConnect)
-        socket.off('connect_error', onError)
         this.logger.error('QSS client failed to connect within timeout, closing socket')
-        this._closeSocket(socket)
-        reject(new QSSConnectionError(`Client didn't connect in time!`))
+        fail(new QSSConnectionError(`Client didn't connect in time!`))
       }, 10_000)
 
-      const onConnect = (): void => {
+      const cleanup = (): void => {
         clearTimeout(timer)
+        socket.off('connect', onConnect)
         socket.off('connect_error', onError)
+        abortSignal?.removeEventListener('abort', onAbort)
+      }
+
+      const succeed = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
         resolve()
       }
 
-      const onError = (err: Error): void => {
-        clearTimeout(timer)
-        socket.off('connect', onConnect)
+      const fail = (error: Error): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
         this._closeSocket(socket)
-        reject(new QSSConnectionError(`Client failed to connect: ${err.message}`, err as any))
+        reject(error)
+      }
+
+      const onConnect = (): void => {
+        succeed()
+      }
+
+      const onError = (err: Error): void => {
+        fail(new QSSConnectionError(`Client failed to connect: ${err.message}`, err as any))
+      }
+
+      const onAbort = (): void => {
+        fail(new QSSConnectionError(`Client connection was replaced by a request for another QSS endpoint`))
       }
 
       socket.once('connect', onConnect)
       socket.once('connect_error', onError)
+      abortSignal?.addEventListener('abort', onAbort, { once: true })
+
+      if (abortSignal?.aborted) {
+        onAbort()
+        return
+      }
+
       socket.connect()
     })
   }


### PR DESCRIPTION
## Summary

This fixes a QSS client connection race where one in-flight endpoint connection can incorrectly satisfy a later request for a different endpoint.

Changes:

- Preserve same-endpoint coalescing: concurrent requests for `ws://qss-a` still share the same in-flight promise.
- Track the endpoint associated with the in-flight connect promise.
- If a new request targets a different endpoint, abort the stale socket connect and start a fresh socket for the requested endpoint.
- Add QSSClient regression coverage for both same-endpoint coalescing and endpoint replacement.

## Code Path

The vulnerable primitive in 7.1.0 is `QSSClient.createSocketAndConnect()`.

In the base branch:

- `packages/backend/src/nest/qss/qss.client.ts:82-89` stores one global `_connectPromise`.
- If `_connectPromise` exists, the method returns it without checking what endpoint it belongs to.
- `packages/backend/src/nest/qss/qss.client.ts:100-129` then creates a socket for the first requested endpoint and waits for that socket to connect.

That means this sequence is possible inside one client process:

1. A QSS connect starts for endpoint A.
2. Before A connects, the user abandons that flow or the app starts a replacement flow, such as leave/recreate, aborted join/retry, or a new invite/server endpoint.
3. The app asks to connect to endpoint B.
4. The old code returns endpoint A's pending promise to the endpoint B caller.
5. If A eventually connects, B's caller receives A's socket and the client believes the replacement flow connected even though it is on the stale server.

This does not require multiple active communities or users in one Quiet client. It only requires one client to replace an in-flight QSS connection attempt before the first attempt settles.

## Fix

The fix adds endpoint identity to the in-flight connection state:

- `packages/backend/src/nest/qss/qss.client.ts:34-36` now tracks `_connectPromiseEndpoint` and an abort controller for the in-flight connect.
- `packages/backend/src/nest/qss/qss.client.ts:84-101` still returns the existing promise when the requested endpoint matches.
- `packages/backend/src/nest/qss/qss.client.ts:87-98` aborts the stale in-flight connect when the requested endpoint differs.
- `packages/backend/src/nest/qss/qss.client.ts:104-118` records and clears the promise/endpoint/abort state together.
- `packages/backend/src/nest/qss/qss.client.ts:166-229` makes `_waitForConnect()` operate on the specific socket it was given and reject promptly when that connect is aborted.

The key invariant is now: coalesce only when the endpoint is the same; replace when the endpoint changes.

## Why This Is A Real Bug Class

This is not a "multiple communities active at once" bug. The realistic version is stale state during transition:

- A user starts a QSS-backed create/join flow.
- The endpoint connect is still pending.
- The user leaves, aborts, retries, or recreates with a different invite/server endpoint.
- The backend starts a new QSS connection request while the old one has not settled.

The previous implementation had no way to distinguish those requests. That is a real correctness issue because QSS endpoint identity is part of the community/join context. Returning a socket for endpoint A to a caller that requested endpoint B can make subsequent auth/sign-in/log-sync traffic go to the wrong QSS server.

Honest likelihood assessment:

- This is timing-sensitive. If the first connection settles before the replacement flow starts, the bug does not appear.
- It is most plausible under slow or flaky network, CPU throttling, QSS startup delay, aborted join/create flows, or leave/recreate flows where cleanup and retry overlap.
- The failure mode is high impact when hit because the client can proceed using a stale QSS connection for the replacement flow.
- The POC does not require unsupported multiple active communities. It models one active client replacing an abandoned pending endpoint with a new endpoint.

## Regression Test

The new test file is `packages/backend/src/nest/qss/qss.client.spec.ts`.

It covers two cases:

- `packages/backend/src/nest/qss/qss.client.spec.ts:106-128`: concurrent requests for the same endpoint still coalesce onto one socket.
- `packages/backend/src/nest/qss/qss.client.spec.ts:130-160`: a newer request for `ws://new-qss` must not be satisfied by an abandoned pending connection to `ws://old-qss`.

Red on raw 7.1.0 after adding the test only:

```text
FAIL src/nest/qss/qss.client.spec.ts
QSSClient
  ✓ coalesces concurrent connection requests for the same endpoint (4 ms)
  ✕ does not satisfy a newer endpoint request with an abandoned endpoint connection (1 ms)

expect(jest.fn()).toHaveBeenCalledTimes(expected)
Expected number of calls: 2
Received number of calls: 1
```

Green after this fix:

```text
PASS src/nest/qss/qss.client.spec.ts
QSSClient
  ✓ coalesces concurrent connection requests for the same endpoint (5 ms)
  ✓ does not satisfy a newer endpoint request with an abandoned endpoint connection (2 ms)
```

## Validation

```bash
PATH=/home/holmes/.nvm/versions/node/v20.20.1/bin:$PATH npm run test -- --runInBand --verbose --detectOpenHandles --forceExit src/nest/qss/qss.client.spec.ts
```

Result:

```text
PASS src/nest/qss/qss.client.spec.ts
Tests: 2 passed, 2 total
```

## Note

Replaces holmesworcester/quiet#2, which targeted the workflow-stripped mirror at `holmesworcester/quiet:7.1.0`. This PR retargets the same patch directly at upstream `TryQuiet/quiet:7.1.0`.
