### PR TITLE
fix(qss): serialize data-sync DLQ processing to avoid duplicate sends

### DIFF
--- a/packages/backend/src/nest/qss/qss.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss.service.spec.ts
@@ -1581,7 +1581,8 @@ describe('QSSService', () => {
       expect(qssService.connected).toBeTruthy()
 
       const teamId = sigchainService.activeChain.team!.id
-      qssService.markTeamStorageReady(teamId)
+      // @ts-ignore Mark storage ready without triggering processDeadLetterQueue before the spy is installed.
+      qssService._storageReadyTeams.add(teamId)
 
       const getPendingSpy = jest.spyOn(localDbService, 'getPendingQssLogSyncMessages').mockResolvedValue({})
 
@@ -1590,6 +1591,102 @@ describe('QSSService', () => {
 
       expect(getPendingSpy).toHaveBeenCalled()
       getPendingSpy.mockRestore()
+    })
+
+    it('coalesces overlapping DLQ processing to avoid duplicate QSS sends and push triggers', async () => {
+      await initCommunity({ qssEnabled: true, qssSetup: true })
+      mockedAllowed = jest.spyOn(qssService, 'qssAllowed', 'get').mockReturnValue(true)
+      await qssService.connect('ws://localhost:3000')
+
+      const teamId = sigchainService.activeChain.team!.id
+      const address = 'channels.dlq-race'
+      const hash = 'dlq-race-hash'
+      const entry = {
+        hash,
+        id: 'dlq-race-db-id',
+        payload: {
+          value: {
+            teamId,
+          },
+        },
+      } as any
+
+      // @ts-ignore Exercise the private DLQ processor directly without triggering markTeamStorageReady side effects.
+      qssService._storageReadyTeams.add(teamId)
+
+      let pendingHashes = [hash]
+      const getPendingSpy = jest
+        .spyOn(localDbService, 'getPendingQssLogSyncMessages')
+        .mockImplementation(async () => {
+          const result: Record<string, string[]> = pendingHashes.length > 0 ? { [address]: [...pendingHashes] } : {}
+          return result
+        })
+      const removeSpy = jest
+        .spyOn(localDbService, 'removePendingQssLogSyncMessages')
+        .mockImplementation(async (sentMessageHashes: Record<string, string[]>) => {
+          pendingHashes = pendingHashes.filter(pendingHash => !sentMessageHashes[address]?.includes(pendingHash))
+        })
+      const getLogEntriesSpy = jest.spyOn(orbitDbService, 'getLogEntriesByHashes').mockResolvedValue([entry])
+      const pushTriggerSpy = jest.fn()
+      qssClient.on(QSSEvents.QSS_LOG_SYNCED, pushTriggerSpy)
+
+      const successResponse: LogEntrySyncResponseMessage = {
+        ts: DateTime.utc().toMillis(),
+        status: CommunityOperationStatus.SUCCESS,
+        payload: {
+          teamId,
+          hash,
+          hashedDbId: entry.id,
+        },
+      }
+      let logSyncSendCount = 0
+      let resolveFirstSend!: (response: LogEntrySyncResponseMessage) => void
+      mockedSendMessage = jest
+        .spyOn(qssClient, 'sendMessage')
+        .mockImplementation(async <T>(event: WebsocketEvents, payload: unknown, withAck = false): Promise<T | undefined> => {
+          logger.debug('Sending event to QSS', event, payload, withAck)
+          if (event !== WebsocketEvents.LOG_ENTRY_SYNC || !withAck) {
+            return undefined
+          }
+
+          logSyncSendCount += 1
+          if (logSyncSendCount > 1) {
+            return successResponse as T
+          }
+
+          return new Promise<T>(resolve => {
+            resolveFirstSend = response => resolve(response as T)
+          })
+        })
+
+      // @ts-ignore
+      const firstRun = qssService.processDeadLetterQueue(teamId)
+      await waitForExpect(() => {
+        expect(logSyncSendCount).toBe(1)
+        expect(resolveFirstSend).toBeDefined()
+      })
+
+      // @ts-ignore Simulates a second lifecycle trigger while the first QSS ack is still pending.
+      const secondRun = qssService.processDeadLetterQueue(teamId)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      resolveFirstSend(successResponse)
+
+      await Promise.all([firstRun, secondRun])
+
+      expect(getPendingSpy).toHaveBeenCalled()
+      expect(getLogEntriesSpy).toHaveBeenCalledWith(address, [hash])
+      expect(mockedSendMessage).toHaveBeenCalledTimes(1)
+      expect(pushTriggerSpy).toHaveBeenCalledTimes(1)
+      expect(removeSpy).toHaveBeenCalledTimes(1)
+      expect(await localDbService.getPendingQssLogSyncMessages()).toEqual({})
+
+      qssClient.off(QSSEvents.QSS_LOG_SYNCED, pushTriggerSpy)
+      getPendingSpy.mockRestore()
+      removeSpy.mockRestore()
+      getLogEntriesSpy.mockRestore()
     })
 
     it('triggers DLQ processing when markTeamStorageReady is called', async () => {

--- a/packages/backend/src/nest/qss/qss.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss.service.spec.ts
@@ -1615,12 +1615,10 @@ describe('QSSService', () => {
       qssService._storageReadyTeams.add(teamId)
 
       let pendingHashes = [hash]
-      const getPendingSpy = jest
-        .spyOn(localDbService, 'getPendingQssLogSyncMessages')
-        .mockImplementation(async () => {
-          const result: Record<string, string[]> = pendingHashes.length > 0 ? { [address]: [...pendingHashes] } : {}
-          return result
-        })
+      const getPendingSpy = jest.spyOn(localDbService, 'getPendingQssLogSyncMessages').mockImplementation(async () => {
+        const result: Record<string, string[]> = pendingHashes.length > 0 ? { [address]: [...pendingHashes] } : {}
+        return result
+      })
       const removeSpy = jest
         .spyOn(localDbService, 'removePendingQssLogSyncMessages')
         .mockImplementation(async (sentMessageHashes: Record<string, string[]>) => {
@@ -1643,21 +1641,23 @@ describe('QSSService', () => {
       let resolveFirstSend!: (response: LogEntrySyncResponseMessage) => void
       mockedSendMessage = jest
         .spyOn(qssClient, 'sendMessage')
-        .mockImplementation(async <T>(event: WebsocketEvents, payload: unknown, withAck = false): Promise<T | undefined> => {
-          logger.debug('Sending event to QSS', event, payload, withAck)
-          if (event !== WebsocketEvents.LOG_ENTRY_SYNC || !withAck) {
-            return undefined
-          }
+        .mockImplementation(
+          async <T>(event: WebsocketEvents, payload: unknown, withAck = false): Promise<T | undefined> => {
+            logger.debug('Sending event to QSS', event, payload, withAck)
+            if (event !== WebsocketEvents.LOG_ENTRY_SYNC || !withAck) {
+              return undefined
+            }
 
-          logSyncSendCount += 1
-          if (logSyncSendCount > 1) {
-            return successResponse as T
-          }
+            logSyncSendCount += 1
+            if (logSyncSendCount > 1) {
+              return successResponse as T
+            }
 
-          return new Promise<T>(resolve => {
-            resolveFirstSend = response => resolve(response as T)
-          })
-        })
+            return new Promise<T>(resolve => {
+              resolveFirstSend = response => resolve(response as T)
+            })
+          }
+        )
 
       // @ts-ignore
       const firstRun = qssService.processDeadLetterQueue(teamId)

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -104,6 +104,9 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
    */
   private _dlqDecryptRetryRequested = false
 
+  private _deadLetterQueueInFlight = false
+  private readonly _deadLetterQueueRetryTeamIds: Set<string> = new Set()
+
   /**
    * Mutexes for createCommunity per teamId
    */
@@ -277,6 +280,28 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
    * Check for pending data sync messages and, if connected, attempt to send to QSS
    */
   private async processDeadLetterQueue(teamId: string): Promise<void> {
+    this._deadLetterQueueRetryTeamIds.add(teamId)
+    if (this._deadLetterQueueInFlight) {
+      this.logger.debug('QSS data sync dead letter queue already processing, requesting retry', teamId)
+      return
+    }
+
+    this._deadLetterQueueInFlight = true
+    try {
+      while (this._deadLetterQueueRetryTeamIds.size > 0) {
+        const nextTeamId = this._deadLetterQueueRetryTeamIds.values().next().value
+        if (nextTeamId == null) {
+          break
+        }
+        this._deadLetterQueueRetryTeamIds.delete(nextTeamId)
+        await this._processDeadLetterQueueOnce(nextTeamId)
+      }
+    } finally {
+      this._deadLetterQueueInFlight = false
+    }
+  }
+
+  private async _processDeadLetterQueueOnce(teamId: string): Promise<void> {
     if (!this.connected) {
       return
     }
@@ -1427,6 +1452,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
     this._logPullSuccessTimeouts.clear()
     this._logPullInFlight.clear()
     this._storageReadyTeams.clear()
+    this._deadLetterQueueRetryTeamIds.clear()
     this._teardownEventHandlers()
     this.qssClient.off(QSSEvents.QSS_CONNECTED, this._requestCaptchaVerificationAfterConnect)
     this._captchaVerificationQueued = false


### PR DESCRIPTION
## Summary
- Serializes QSS data-sync DLQ processing so overlapping lifecycle events coalesce instead of sending the same pending log entry twice.
- Adds a regression test that reproduces the duplicate-send window and asserts it only sends once and only fires one `QSS_LOG_SYNCED` push trigger.
- Keeps retry behavior: a trigger that arrives while a DLQ pass is active queues another pass for that team after the current pass finishes.

## Bug Narrative
This is a 7.1.0 race in `packages/backend/src/nest/qss/qss.service.ts`. DLQ processing is triggered from normal QSS lifecycle paths without awaiting it:

- `_handleQssAuthJoined` calls `void this.processDeadLetterQueue(teamId)` at `qss.service.ts:162-165`.
- `_handleSelfAssignMember` emits `QSS_FULLY_JOINED` and calls `void this.processDeadLetterQueue(teamId)` at `qss.service.ts:259-272`.
- The auth-connected handler calls it after starting log pulls at `qss.service.ts:934-937`.
- `markTeamStorageReady` also calls it at `qss.service.ts:862-866`.

Before this PR, `processDeadLetterQueue` had no in-flight guard. It read all pending QSS log sync hashes from local DB, sent each recovered OrbitDB entry to QSS, and removed successful hashes only after the sends completed. The critical sequence is still visible in the extracted `_processDeadLetterQueueOnce`: read pending hashes at `qss.service.ts:316-318`, send the entry at `qss.service.ts:337-340`, then remove the successful hash at `qss.service.ts:352-355`.

That means two lifecycle triggers can both snapshot the same local pending hash if the first `LOG_ENTRY_SYNC` ack is still in flight. This does not require multiple communities in one client. It is a realistic join/reconnect/startup window because the triggers above naturally happen close together while QSS auth, storage readiness, and log sync are being established, and the ack is network-bound.

## Why OrbitDB/QSS Storage Dedupe Does Not Make This Harmless
QSS storage does dedupe by CID: `3rd-party/qss/app/src/nest/communities/storage/log-entry-sync.storage.service.ts:89-102` returns the existing row when the CID is already present. So the expected data-integrity risk is not duplicate rows in QSS storage.

The side effect is still real. QSS handles a duplicate successful `LOG_ENTRY_SYNC` by building a fanout message and returning a success ack every time: `3rd-party/qss/app/src/nest/websocket/handlers/log-entry-sync.handler.ts:60-88`. On the Quiet client side, every successful ack causes `_sendLogEntrySyncMessage` to emit `QSS_LOG_SYNCED` at `qss.service.ts:1111-1117`.

QPS listens for that event and triggers batch push work in `packages/backend/src/nest/qps/qps.service.ts:60-62`. `sendBatchPush` then sends `SEND_BATCH_PUSH` to QSS for every registered UCAN batch at `qps.service.ts:222-250`. On the QSS side, `3rd-party/qss/app/src/nest/qps/qps.service.ts:154-238` validates UCANs and calls `pushService.sendMulticast`, which reaches Firebase multicast send in `3rd-party/qss/app/src/nest/qps/push/push.service.ts:86-151`. I did not find message-CID dedupe in that QPS path.

So the honest impact is: QSS/OrbitDB storage dedupe reduces data corruption risk, but duplicate DLQ sends can still produce duplicate fanout traffic and duplicate push notification requests/wakeups for a single recovered log entry. The bug is timing-sensitive, but the timing window is directly in normal 7.1.0 lifecycle code and becomes more likely with slow QSS ack, degraded network, CPU throttling, or reconnect/join churn.

## Fix
`processDeadLetterQueue` now uses a single in-flight guard plus a team retry set. If a second trigger arrives while a DLQ pass is active, it records the team for another pass and returns. The active pass drains queued teams in order, so we avoid overlapping snapshots of the same local pending hashes while preserving the ability to retry work requested during the current pass.

## POC / Red-Green Evidence
The added regression test is `packages/backend/src/nest/qss/qss.service.spec.ts:1596-1690`. It creates one pending DLQ hash, makes the first `LOG_ENTRY_SYNC` send wait for its ack, then calls `processDeadLetterQueue(teamId)` a second time while the first send is still pending. It asserts one QSS send, one `QSS_LOG_SYNCED` push trigger, one local removal, and an empty pending queue.

Red on 7.1.0 before the fix, using the same test in a test-only branch:

```text
FAIL src/nest/qss/qss.service.spec.ts
  QSSService
    processDeadLetterQueue
      ✕ coalesces overlapping DLQ processing to avoid duplicate QSS sends and push triggers

Expected number of calls: 1
Received number of calls: 2
```

The red run logs showed two `Processing QSS data sync dead letter queue` / `Sending log sync message to QSS dlq-race-hash` sequences before local removal, which is the duplicate send window.

Green after this fix:

```text
PASS src/nest/qss/qss.service.spec.ts
  processDeadLetterQueue
    ✓ coalesces overlapping DLQ processing to avoid duplicate QSS sends and push triggers
Tests: 1 passed, 45 skipped, 46 total
```

Full targeted QSS service suite after the fix:

```text
PASS src/nest/qss/qss.service.spec.ts
Tests: 46 passed, 46 total
```

Existing QPS listener check also confirms that `QSS_LOG_SYNCED` drives push batching:

```text
PASS src/nest/qps/qps.service.spec.ts
  sendBatchPush
    ✓ QSS_LOG_SYNCED event fires sendBatchPush
```

Test note: these local runs used `--globals '{"ts-jest":{"diagnostics":false}}'` because the temporary worktrees reused vendored dependencies through symlinks, which otherwise produced duplicate private TypeScript type identities from `3rd-party/auth`. The runtime behavior under test is the QSS/QPS async behavior described above.

## Note

Replaces holmesworcester/quiet#4, which targeted the workflow-stripped mirror at `holmesworcester/quiet:7.1.0`. This PR retargets the same patch directly at upstream `TryQuiet/quiet:7.1.0`.
