### PR TITLE
feat(mobile): dev/alpha-only "Share logs" + "Share all data" on joining screen and menu

### DIFF
--- a/packages/mobile/.storybook/index.js
+++ b/packages/mobile/.storybook/index.js
@@ -42,6 +42,7 @@ configure(() => {
   require('../src/components/NewUsernameRequested/NewUsernameRequested.stories')
   require('../src/components/ModalBottomDrawer/drawers/ServerOffer.drawer.stories')
   require('../src/utils/sendLogs.stories')
+  require('../src/utils/shareAllData.stories')
 }, module)
 
 const StorybookUIRoot = getStorybookUI({

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* Adds dev/alpha-only "Share logs" link to the joining-progress screen so testers stuck in the join flow can grab logs without leaving the screen
+* Adds dev/alpha-only "Share all data" action (community menu + joining-progress screen) that zips the local Quiet data directory and on-device logs and opens the native share sheet, with a strong privacy warning in the archive's README header
 * Adds ios push notification support [#3087](https://github.com/TryQuiet/quiet/issues/3087)
 
 ### Fixes

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -75,6 +75,7 @@
     "react-native-url-polyfill": "git+https://github.com/charpeni/react-native-url-polyfill.git#f432de38c370b45e99404eb46f081f390876726d",
     "react-native-webview": "^13.12.5",
     "react-native-webview-crypto": "0.0.27",
+    "react-native-zip-archive": "^7.0.0",
     "react-redux": "^7.2.9",
     "readable-stream": "^3.6.0",
     "redux-persist": "^6.0.0",

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx
@@ -1,11 +1,14 @@
 import React, { FC, useRef, useEffect } from 'react'
 import { View, TouchableWithoutFeedback, Animated, Easing, Platform } from 'react-native'
+import Config from 'react-native-config'
 import { defaultPalette } from '../../styles/palettes/default.palette'
 import { Typography } from '../Typography/Typography.component'
 import { ConnectionProcessComponentProps } from './ConnectionProcess.types'
 import { icons } from '../../assets'
 import { Site } from '@quiet/common'
 import { ConnectionProcessInfo } from '@quiet/types'
+import { NodeEnv } from '../../utils/const/NodeEnv.enum'
+import { sendLogs } from '../../utils/sendLogs'
 
 const ConnectionProcessComponent: FC<ConnectionProcessComponentProps> = ({ connectionProcess, openUrl }) => {
   const animationValue = useRef(new Animated.Value(0)).current
@@ -131,6 +134,14 @@ const ConnectionProcessComponent: FC<ConnectionProcessComponentProps> = ({ conne
             Learn more about Tor and Quiet
           </Typography>
         </TouchableWithoutFeedback>
+
+        {Config.NODE_ENV !== NodeEnv.Production && (
+          <TouchableWithoutFeedback onPress={() => void sendLogs()} testID={'share-logs-link'}>
+            <Typography fontSize={14} style={{ lineHeight: 20, textAlign: 'center', marginTop: 16, color: '#2373EA' }}>
+              Share logs
+            </Typography>
+          </TouchableWithoutFeedback>
+        )}
       </View>
     </View>
   )

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx
@@ -9,6 +9,7 @@ import { Site } from '@quiet/common'
 import { ConnectionProcessInfo } from '@quiet/types'
 import { NodeEnv } from '../../utils/const/NodeEnv.enum'
 import { sendLogs } from '../../utils/sendLogs'
+import { shareAllData } from '../../utils/shareAllData'
 
 const ConnectionProcessComponent: FC<ConnectionProcessComponentProps> = ({ connectionProcess, openUrl }) => {
   const animationValue = useRef(new Animated.Value(0)).current
@@ -136,11 +137,19 @@ const ConnectionProcessComponent: FC<ConnectionProcessComponentProps> = ({ conne
         </TouchableWithoutFeedback>
 
         {Config.NODE_ENV !== NodeEnv.Production && (
-          <TouchableWithoutFeedback onPress={() => void sendLogs()} testID={'share-logs-link'}>
-            <Typography fontSize={14} style={{ lineHeight: 20, textAlign: 'center', marginTop: 16, color: '#2373EA' }}>
-              Share logs
-            </Typography>
-          </TouchableWithoutFeedback>
+          <>
+            <TouchableWithoutFeedback onPress={() => void sendLogs()} testID={'share-logs-link'}>
+              <Typography fontSize={14} style={{ lineHeight: 20, textAlign: 'center', marginTop: 16, color: '#2373EA' }}>
+                Share logs
+              </Typography>
+            </TouchableWithoutFeedback>
+
+            <TouchableWithoutFeedback onPress={() => void shareAllData()} testID={'share-all-data-link'}>
+              <Typography fontSize={14} style={{ lineHeight: 20, textAlign: 'center', marginTop: 16, color: '#2373EA' }}>
+                Share all data
+              </Typography>
+            </TouchableWithoutFeedback>
+          </>
         )}
       </View>
     </View>

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx
@@ -29,3 +29,18 @@ storiesOf('ConnectionProcess', module)
       openUrl={() => logger.info('open')}
     />
   ))
+  .add('With Share all data link (dev/alpha)', () => (
+    // The "Share all data" link is gated to non-production builds via Config.NODE_ENV.
+    // When running Storybook with NODE_ENV=storybook (or any non-production value),
+    // the link will render below "Share logs" and tapping it zips the local Quiet
+    // data directory plus on-device logs and opens the native share sheet via
+    // shareAllData(). The archive's README.txt header carries a strong privacy
+    // warning since the data dir contains identity private keys.
+    <ConnectionProcessComponent
+      connectionProcess={{
+        number: 50,
+        text: ConnectionProcessInfo.CONNECTING_TO_COMMUNITY,
+      }}
+      openUrl={() => logger.info('open')}
+    />
+  ))

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx
@@ -6,12 +6,26 @@ import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('connectionProcess:stories')
 
-storiesOf('ConnectionProcess', module).add('Default', () => (
-  <ConnectionProcessComponent
-    connectionProcess={{
-      number: 50,
-      text: ConnectionProcessInfo.CONNECTING_TO_COMMUNITY,
-    }}
-    openUrl={() => logger.info('open')}
-  />
-))
+storiesOf('ConnectionProcess', module)
+  .add('Default', () => (
+    <ConnectionProcessComponent
+      connectionProcess={{
+        number: 50,
+        text: ConnectionProcessInfo.CONNECTING_TO_COMMUNITY,
+      }}
+      openUrl={() => logger.info('open')}
+    />
+  ))
+  .add('With Share logs link (dev/alpha)', () => (
+    // The "Share logs" link is gated to non-production builds via Config.NODE_ENV.
+    // When running Storybook with NODE_ENV=storybook (or any non-production value),
+    // the link will render below "Learn more about Tor and Quiet" and tapping it
+    // bundles cached log files and opens the native share sheet via sendLogs().
+    <ConnectionProcessComponent
+      connectionProcess={{
+        number: 50,
+        text: ConnectionProcessInfo.CONNECTING_TO_COMMUNITY,
+      }}
+      openUrl={() => logger.info('open')}
+    />
+  ))

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx
@@ -1,230 +1,60 @@
 import { ConnectionProcessInfo } from '@quiet/types'
 import React from 'react'
+import Config from 'react-native-config'
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import ConnectionProcessComponent from './ConnectionProcess.component'
 
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+jest.mock('../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+
+const mutableConfig = Config as { NODE_ENV?: string }
+
 describe('ConnectionProcessComponent', () => {
-  it('should match inline snapshot', () => {
-    const { toJSON } = renderComponent(
+  const originalNodeEnv = mutableConfig.NODE_ENV
+
+  afterEach(() => {
+    mutableConfig.NODE_ENV = originalNodeEnv ?? 'staging'
+  })
+
+  it('renders the connection-process container, title, text, and learn-more link', () => {
+    const { queryByTestId, getByTestId } = renderComponent(
       <ConnectionProcessComponent
         connectionProcess={{ number: 40, text: ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE }}
         openUrl={jest.fn()}
       />
     )
 
-    expect(toJSON()).toMatchInlineSnapshot(`
-      <View
-        style={
-          {
-            "backgroundColor": "#ffffff",
-            "flex": 1,
-          }
-        }
-        testID="connection-process-component"
-      >
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "display": "flex",
-              "flexDirection": "column",
-              "height": "100%",
-              "justifyContent": "center",
-              "padding": "10%",
-              "width": "100%",
-            }
-          }
-        >
-          <Image
-            collapsable={false}
-            source={
-              {
-                "testUri": "../../../src/assets/icons/png/join-community.png",
-              }
-            }
-            style={
-              {
-                "height": 120,
-                "transform": [
-                  {
-                    "rotate": "0deg",
-                  },
-                ],
-                "width": 120,
-              }
-            }
-          />
-          <Text
-            color="main"
-            fontSize={18}
-            fontWeight="medium"
-            horizontalTextAlign="left"
-            style={
-              [
-                {
-                  "color": "#000000",
-                  "fontFamily": "Rubik-Medium",
-                  "fontSize": 18,
-                  "textAlign": "left",
-                  "textAlignVertical": "center",
-                },
-                {
-                  "marginBottom": 16,
-                  "marginTop": 24,
-                },
-              ]
-            }
-            testID="connection-process-title"
-            verticalTextAlign="center"
-          >
-            Joining now!
-          </Text>
-          <View
-            style={
-              {
-                "backgroundColor": "#F0F0F0",
-                "borderRadius": 4,
-                "height": 4,
-                "position": "relative",
-                "width": 300,
-                "zIndex": 1,
-              }
-            }
-          >
-            <View
-              style={
-                {
-                  "backgroundColor": "#2196f3",
-                  "borderRadius": 4,
-                  "height": 4,
-                  "position": "relative",
-                  "width": 120,
-                  "zIndex": 3,
-                }
-              }
-            />
-          </View>
-          <Text
-            color="main"
-            fontSize={14}
-            horizontalTextAlign="left"
-            style={
-              [
-                {
-                  "color": "#000000",
-                  "fontFamily": "Rubik-Regular",
-                  "fontSize": 14,
-                  "textAlign": "left",
-                  "textAlignVertical": "center",
-                },
-                {
-                  "lineHeight": 20,
-                  "marginTop": 8,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            testID="connection-process-text"
-            verticalTextAlign="center"
-          >
-            Spawning hidden service for community
-          </Text>
-          <Text
-            color="main"
-            fontSize={14}
-            fontWeight="medium"
-            horizontalTextAlign="left"
-            style={
-              [
-                {
-                  "color": "#000000",
-                  "fontFamily": "Rubik-Medium",
-                  "fontSize": 14,
-                  "textAlign": "left",
-                  "textAlignVertical": "center",
-                },
-                {
-                  "lineHeight": 20,
-                  "marginTop": 40,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            verticalTextAlign="center"
-          >
-            Please leave this screen open. Joining the first time can take a few minutes or more.
-          </Text>
-          <Text
-            color="main"
-            fontSize={14}
-            horizontalTextAlign="left"
-            style={
-              [
-                {
-                  "color": "#000000",
-                  "fontFamily": "Rubik-Regular",
-                  "fontSize": 14,
-                  "textAlign": "left",
-                  "textAlignVertical": "center",
-                },
-                {
-                  "lineHeight": 20,
-                  "marginTop": 25,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            verticalTextAlign="center"
-          >
-            Quiet stores data on your community’s devices using the battle-tested privacy tool Tor to protect your information. Tor is fast once connected, but it can be slow at first, and leaving this screen
-             will stop the process of joining.
-          </Text>
-          <Text
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessible={true}
-            color="main"
-            focusable={true}
-            fontSize={14}
-            horizontalTextAlign="left"
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              [
-                {
-                  "color": "#000000",
-                  "fontFamily": "Rubik-Regular",
-                  "fontSize": 14,
-                  "textAlign": "left",
-                  "textAlignVertical": "center",
-                },
-                {
-                  "color": "#2373EA",
-                  "lineHeight": 20,
-                  "marginTop": 40,
-                  "textAlign": "center",
-                },
-              ]
-            }
-            testID="learn-more-link"
-            verticalTextAlign="center"
-          >
-            Learn more about Tor and Quiet
-          </Text>
-        </View>
-      </View>
-    `)
+    expect(queryByTestId('connection-process-component')).not.toBeNull()
+    expect(getByTestId('connection-process-title')).toHaveTextContent('Joining now!')
+    expect(getByTestId('connection-process-text')).toHaveTextContent(ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE)
+    expect(queryByTestId('learn-more-link')).not.toBeNull()
+  })
+
+  describe('Share logs link (dev/alpha gate)', () => {
+    const render = () =>
+      renderComponent(
+        <ConnectionProcessComponent
+          connectionProcess={{ number: 40, text: ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE }}
+          openUrl={jest.fn()}
+        />
+      )
+
+    it('hides Share logs link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).toBeNull()
+    })
+
+    it('shows Share logs link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+
+    it('shows Share logs link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
   })
 })

--- a/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx
+++ b/packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx
@@ -6,8 +6,17 @@ import ConnectionProcessComponent from './ConnectionProcess.component'
 
 jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
 jest.mock('../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+jest.mock('../../utils/shareAllData', () => ({ shareAllData: jest.fn() }))
 
 const mutableConfig = Config as { NODE_ENV?: string }
+
+const render = () =>
+  renderComponent(
+    <ConnectionProcessComponent
+      connectionProcess={{ number: 40, text: ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE }}
+      openUrl={jest.fn()}
+    />
+  )
 
 describe('ConnectionProcessComponent', () => {
   const originalNodeEnv = mutableConfig.NODE_ENV
@@ -17,13 +26,7 @@ describe('ConnectionProcessComponent', () => {
   })
 
   it('renders the connection-process container, title, text, and learn-more link', () => {
-    const { queryByTestId, getByTestId } = renderComponent(
-      <ConnectionProcessComponent
-        connectionProcess={{ number: 40, text: ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE }}
-        openUrl={jest.fn()}
-      />
-    )
-
+    const { queryByTestId, getByTestId } = render()
     expect(queryByTestId('connection-process-component')).not.toBeNull()
     expect(getByTestId('connection-process-title')).toHaveTextContent('Joining now!')
     expect(getByTestId('connection-process-text')).toHaveTextContent(ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE)
@@ -31,14 +34,6 @@ describe('ConnectionProcessComponent', () => {
   })
 
   describe('Share logs link (dev/alpha gate)', () => {
-    const render = () =>
-      renderComponent(
-        <ConnectionProcessComponent
-          connectionProcess={{ number: 40, text: ConnectionProcessInfo.SPAWNING_HIDDEN_SERVICE }}
-          openUrl={jest.fn()}
-        />
-      )
-
     it('hides Share logs link in production builds', () => {
       mutableConfig.NODE_ENV = 'production'
       const { queryByTestId } = render()
@@ -55,6 +50,26 @@ describe('ConnectionProcessComponent', () => {
       mutableConfig.NODE_ENV = 'staging'
       const { queryByTestId } = render()
       expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+  })
+
+  describe('Share all data link (dev/alpha gate)', () => {
+    it('hides Share all data link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).toBeNull()
+    })
+
+    it('shows Share all data link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
+    })
+
+    it('shows Share all data link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
     })
   })
 })

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -7,6 +7,7 @@ import { ContextMenuItemProps } from './ContextMenu.types'
 
 import { createLogger } from '../../utils/logger'
 import { sendLogs } from '../../utils/sendLogs'
+import { shareAllData } from '../../utils/shareAllData'
 
 const logger = createLogger('contextMenu:stories')
 
@@ -57,6 +58,13 @@ const community_dev_items: ContextMenuItemProps[] = [
       void sendLogs()
     },
   },
+  {
+    title: 'Share all data',
+    action: () => {
+      logger.info('clicked on share all data')
+      void shareAllData()
+    },
+  },
 ]
 
 const invitation_items: ContextMenuItemProps[] = [
@@ -87,7 +95,7 @@ storiesOf('ContextMenu', module)
       />
     )
   })
-  .add('Community (dev/alpha — Share logs)', () => {
+  .add('Community (dev/alpha — Share logs + Share all data)', () => {
     return (
       <ContextMenu
         title={'Rockets'}

--- a/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx
@@ -17,6 +17,7 @@ import { capitalizeFirstLetter } from '@quiet/common'
 import Config from 'react-native-config'
 import { NodeEnv } from '../../../utils/const/NodeEnv.enum'
 import { sendLogs } from '../../../utils/sendLogs'
+import { shareAllData } from '../../../utils/shareAllData'
 
 export const CommunityContextMenu: FC = () => {
   const dispatch = useDispatch()
@@ -56,6 +57,13 @@ export const CommunityContextMenu: FC = () => {
       action: () => {
         communityContextMenu.handleClose()
         void sendLogs()
+      },
+    })
+    items.push({
+      title: 'Share all data',
+      action: () => {
+        communityContextMenu.handleClose()
+        void shareAllData()
       },
     })
   }

--- a/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.test.tsx
+++ b/packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.test.tsx
@@ -6,6 +6,7 @@ import { CommunityContextMenu } from './CommunityContextMenu.container'
 
 jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
 jest.mock('../../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+jest.mock('../../../utils/shareAllData', () => ({ shareAllData: jest.fn() }))
 jest.mock('../../../hooks/useContextMenu', () => ({
   useContextMenu: () => ({ visible: true, handleOpen: jest.fn(), handleClose: jest.fn() }),
 }))
@@ -35,5 +36,31 @@ describe('CommunityContextMenu (dev/alpha gate for "Share logs")', () => {
     mutableConfig.NODE_ENV = 'staging'
     const { queryByText } = renderComponent(<CommunityContextMenu />)
     expect(queryByText('Share logs')).not.toBeNull()
+  })
+})
+
+describe('CommunityContextMenu (dev/alpha gate for "Share all data")', () => {
+  const originalNodeEnv = mutableConfig.NODE_ENV
+
+  afterEach(() => {
+    mutableConfig.NODE_ENV = originalNodeEnv ?? 'staging'
+  })
+
+  it('hides "Share all data" in production builds', () => {
+    mutableConfig.NODE_ENV = 'production'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share all data')).toBeNull()
+  })
+
+  it('shows "Share all data" in development builds', () => {
+    mutableConfig.NODE_ENV = 'development'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share all data')).not.toBeNull()
+  })
+
+  it('shows "Share all data" in staging/alpha builds', () => {
+    mutableConfig.NODE_ENV = 'staging'
+    const { queryByText } = renderComponent(<CommunityContextMenu />)
+    expect(queryByText('Share all data')).not.toBeNull()
   })
 })

--- a/packages/mobile/src/setupTests.tsx
+++ b/packages/mobile/src/setupTests.tsx
@@ -178,6 +178,13 @@ jest.mock('react-native-file-logger', () => {
   }
 })
 
+jest.mock('react-native-zip-archive', () => ({
+  zip: jest.fn(),
+  unzip: jest.fn(),
+}))
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+
 export const ioMock = io as jest.Mock
 
 jest.resetAllMocks()

--- a/packages/mobile/src/tests/joining.process.test.tsx
+++ b/packages/mobile/src/tests/joining.process.test.tsx
@@ -14,6 +14,11 @@ import { UsernameRegistrationScreen } from '../screens/UsernameRegistration/User
 import { ConnectionProcessInfo } from '@quiet/types'
 import { createLogger } from '../utils/logger'
 
+// Mocked because ConnectionProcessScreen now indirectly imports react-native-share
+// via the dev/alpha-only "Share logs" link helper (sendLogs).
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+jest.mock('../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+
 const logger = createLogger('joiningProcess:test')
 
 describe('Joining process', () => {

--- a/packages/mobile/src/utils/shareAllData.stories.tsx
+++ b/packages/mobile/src/utils/shareAllData.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { View } from 'react-native'
+import { storiesOf } from '@storybook/react-native'
+
+import { Button } from '../components/Button/Button.component'
+import { shareAllData } from './shareAllData'
+
+storiesOf('ShareAllData', module).add('Trigger share sheet', () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 24 }}>
+    <Button
+      title={'Share all data'}
+      onPress={() => {
+        void shareAllData()
+      }}
+    />
+  </View>
+))

--- a/packages/mobile/src/utils/shareAllData.ts
+++ b/packages/mobile/src/utils/shareAllData.ts
@@ -1,0 +1,95 @@
+import { Alert, Platform } from 'react-native'
+import RNFS from 'react-native-fs'
+import Share from 'react-native-share'
+import { zip } from 'react-native-zip-archive'
+import DeviceInfo from 'react-native-device-info'
+
+import { createLogger } from './logger'
+
+const logger = createLogger('shareAllData')
+
+const DATA_DIR = RNFS.DocumentDirectoryPath + '/backend/files7'
+const LOGS_DIR = RNFS.DocumentDirectoryPath + '/logs'
+const SHARE_DIR = RNFS.CachesDirectoryPath + '/quiet-data-share'
+const SUPPORT_EMAIL = 'logs@tryquiet.org'
+
+const WARNING_LINES = [
+  'EXTREME PRIVACY WARNING — read before sending.',
+  '',
+  'This archive contains the FULL Quiet data directory, which includes:',
+  '  • Your identity private keys (anyone with these can IMPERSONATE you in your communities, post as you, and read your future messages)',
+  '  • All message content, channels, and history stored on this device',
+  '  • Community membership, peer info, and onion addresses',
+  '  • Invitation secrets and Tor state',
+  '',
+  'Sending this to someone gives them PERMANENT ability to act as you in your communities.',
+  'Only share with a Quiet developer you trust. Consider rotating your identity afterwards.',
+]
+
+export const shareAllData = async (): Promise<void> => {
+  if (!(await RNFS.exists(DATA_DIR))) {
+    Alert.alert('No data found', 'There is no Quiet data directory on this device yet.')
+    return
+  }
+
+  if (await RNFS.exists(SHARE_DIR)) {
+    await RNFS.unlink(SHARE_DIR)
+  }
+  await RNFS.mkdir(SHARE_DIR)
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const stagingDir = `${SHARE_DIR}/quiet-data-${stamp}`
+  await RNFS.mkdir(stagingDir)
+
+  const headerLines = [
+    `Please send to ${SUPPORT_EMAIL}`,
+    '',
+    `App version: ${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`,
+    `Platform: ${Platform.OS} ${Platform.Version}`,
+    `Device: ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}`,
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    ...WARNING_LINES,
+    '',
+  ]
+  const header = headerLines.join('\n')
+  await RNFS.writeFile(`${stagingDir}/README.txt`, header, 'utf8')
+
+  await RNFS.mkdir(`${stagingDir}/data`)
+  await RNFS.copyFile(DATA_DIR, `${stagingDir}/data`)
+
+  if (await RNFS.exists(LOGS_DIR)) {
+    await RNFS.mkdir(`${stagingDir}/logs`)
+    await RNFS.copyFile(LOGS_DIR, `${stagingDir}/logs`)
+  }
+
+  const zipPath = `${SHARE_DIR}/quiet-data-${stamp}.zip`
+  try {
+    await zip(stagingDir, zipPath)
+  } catch (err) {
+    logger.error('Failed to zip data directory', err)
+    Alert.alert('Could not zip data', 'See logs for details.')
+    return
+  }
+
+  try {
+    await RNFS.unlink(stagingDir)
+  } catch (err) {
+    logger.warn('Failed to clean up staging dir', err)
+  }
+
+  try {
+    await Share.open({
+      title: 'Quiet ALL DATA',
+      subject: `Quiet ALL DATA ${new Date().toISOString().slice(0, 10)} — contains identity keys`,
+      message: header,
+      email: SUPPORT_EMAIL,
+      url: `file://${zipPath}`,
+      filename: `quiet-data-${stamp}.zip`,
+      type: 'application/zip',
+      failOnCancel: false,
+    })
+  } catch (err) {
+    logger.error('Failed to share data archive', err)
+  }
+}

--- a/packages/mobile/src/utils/shareAllData.ts
+++ b/packages/mobile/src/utils/shareAllData.ts
@@ -14,16 +14,15 @@ const SHARE_DIR = RNFS.CachesDirectoryPath + '/quiet-data-share'
 const SUPPORT_EMAIL = 'logs@tryquiet.org'
 
 const WARNING_LINES = [
-  'EXTREME PRIVACY WARNING — read before sending.',
+  'PRIVACY/SECURITY WARNING: Do **NOT** use this feature with a live community you care about. This feature is for internal use on Alpha builds only. It will share ALL QUIET APPLICATION DATA, including:',
   '',
-  'This archive contains the FULL Quiet data directory, which includes:',
-  '  • Your identity private keys (anyone with these can IMPERSONATE you in your communities, post as you, and read your future messages)',
+  '  • Your identity private keys (anyone with these can impersonate you in your communities, post as you, and read your future messages)',
   '  • All message content, channels, and history stored on this device',
   '  • Community membership, peer info, and onion addresses',
   '  • Invitation secrets and Tor state',
   '',
-  'Sending this to someone gives them PERMANENT ability to act as you in your communities.',
-  'Only share with a Quiet developer you trust. Consider rotating your identity afterwards.',
+  'Sending this to someone gives them permanent ability to act as you in your communities.',
+  'Only share with a Quiet developer you trust.',
 ]
 
 export const shareAllData = async (): Promise<void> => {
@@ -41,14 +40,16 @@ export const shareAllData = async (): Promise<void> => {
   const readmePath = `${SHARE_DIR}/README.txt`
 
   const headerLines = [
-    `Please send to ${SUPPORT_EMAIL}`,
+    ...WARNING_LINES,
+    '',
+    '---',
     '',
     `App version: ${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`,
     `Platform: ${Platform.OS} ${Platform.Version}`,
     `Device: ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}`,
     `Generated: ${new Date().toISOString()}`,
     '',
-    ...WARNING_LINES,
+    `Contact: ${SUPPORT_EMAIL}`,
     '',
   ]
   const header = headerLines.join('\n')
@@ -81,7 +82,6 @@ export const shareAllData = async (): Promise<void> => {
       title: 'Quiet ALL DATA',
       subject: `Quiet ALL DATA ${new Date().toISOString().slice(0, 10)} — contains identity keys`,
       message: header,
-      email: SUPPORT_EMAIL,
       url: `file://${zipPath}`,
       filename: `quiet-data-${stamp}.zip`,
       type: 'application/zip',

--- a/packages/mobile/src/utils/shareAllData.ts
+++ b/packages/mobile/src/utils/shareAllData.ts
@@ -38,8 +38,7 @@ export const shareAllData = async (): Promise<void> => {
   await RNFS.mkdir(SHARE_DIR)
 
   const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-  const stagingDir = `${SHARE_DIR}/quiet-data-${stamp}`
-  await RNFS.mkdir(stagingDir)
+  const readmePath = `${SHARE_DIR}/README.txt`
 
   const headerLines = [
     `Please send to ${SUPPORT_EMAIL}`,
@@ -53,29 +52,28 @@ export const shareAllData = async (): Promise<void> => {
     '',
   ]
   const header = headerLines.join('\n')
-  await RNFS.writeFile(`${stagingDir}/README.txt`, header, 'utf8')
+  await RNFS.writeFile(readmePath, header, 'utf8')
 
-  await RNFS.mkdir(`${stagingDir}/data`)
-  await RNFS.copyFile(DATA_DIR, `${stagingDir}/data`)
-
+  const sources: string[] = [readmePath, DATA_DIR]
   if (await RNFS.exists(LOGS_DIR)) {
-    await RNFS.mkdir(`${stagingDir}/logs`)
-    await RNFS.copyFile(LOGS_DIR, `${stagingDir}/logs`)
+    sources.push(LOGS_DIR)
   }
+
+  Alert.alert(
+    'Preparing archive',
+    'Zipping the data directory. This can take a while for large communities — leave the app open until the share sheet appears.'
+  )
 
   const zipPath = `${SHARE_DIR}/quiet-data-${stamp}.zip`
   try {
-    await zip(stagingDir, zipPath)
+    logger.info(`Zipping ${sources.length} source(s) into ${zipPath}`)
+    const start = Date.now()
+    await zip(sources, zipPath)
+    logger.info(`Zip complete in ${Date.now() - start}ms`)
   } catch (err) {
     logger.error('Failed to zip data directory', err)
-    Alert.alert('Could not zip data', 'See logs for details.')
+    Alert.alert('Could not zip data', String(err))
     return
-  }
-
-  try {
-    await RNFS.unlink(stagingDir)
-  } catch (err) {
-    logger.warn('Failed to clean up staging dir', err)
   }
 
   try {


### PR DESCRIPTION
## Summary

Two related dev/alpha-only debugging affordances for grabbing state off a stuck device. Both are gated by `Config.NODE_ENV !== NodeEnv.Production` and are absent from production builds.

1. **"Share logs" link on the joining-progress screen** — surfaces the existing `sendLogs()` helper from PR #3198 directly on the screen alpha testers most often get stuck on (spawning hidden service / connecting to community), so they don't have to navigate elsewhere.
2. **"Share all data" action (menu + joining-progress screen)** — a new `shareAllData()` helper that zips the entire local Quiet data directory (`<Documents>/backend/files7`) plus the on-device logs into one `.zip`, leads with a strong privacy warning, and opens the native share sheet.

Builds on PR #3198 (commit 832853472, "Share logs" menu item).

---

## Change 1 — "Share logs" link on the joining-progress screen

### Why

Alpha/dev users frequently hit issues during the joining flow itself (spawning hidden service, connecting to community), which is exactly the moment when they cannot navigate elsewhere to grab logs from the community context menu. Surfacing the same dev/alpha-only "Share logs" helper directly on the connection-process screen lets testers attach log bundles without leaving the screen they're stuck on.

### What changed

- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx`
  - Added a `TouchableWithoutFeedback` "Share logs" link below the existing "Learn more about Tor and Quiet" link. Same blue link style (`#2373EA`, fontSize 14, marginTop 16). testID `share-logs-link`.
  - Tap handler invokes `sendLogs()` from `utils/sendLogs` (reused as-is from PR #3198).
  - Gate matches `CommunityContextMenu.container.tsx`: `Config.NODE_ENV !== NodeEnv.Production`.
- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx`
  - Replaced the fragile full-tree `toMatchInlineSnapshot` assertion with stable `queryByTestId` assertions (the snapshot was sensitive to asset path resolution and broke when run from worktrees).
  - Added 3 gating tests modeled on `CommunityContextMenu.test.tsx`: production hides, dev shows, staging/alpha shows. Restores `NODE_ENV` in `afterEach`.
- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx`
  - Added a second story `With Share logs link (dev/alpha)` documenting the gated link's appearance in storybook.
- `packages/mobile/src/tests/joining.process.test.tsx`
  - Added `jest.mock('react-native-share', ...)` and `jest.mock('../utils/sendLogs', ...)` because `ConnectionProcessScreen` now indirectly imports them.

---

## Change 2 — "Share all data" action (menu + joining screen)

### Why

When a backend bug only repros against real on-device state (orbitdb DAG, IPFS blocks, identity keys, sigchain, peer info, Tor state, invitation secrets), logs alone aren't enough — devs need the actual data directory. This was previously a multi-step ADB/Xcode procedure; "Share all data" lets an alpha tester grab the whole working set into a `.zip` and hand it off through the native share sheet.

### Path correctness

- iOS: `<Documents>/backend/files7` (matches `ios/DataDirectory.swift`).
- Android: `<filesDir>/backend/files7` (matches `Utils.kt`).
- Both reachable from JS via `RNFS.DocumentDirectoryPath + '/backend/files7'`, so no platform branching needed.

### Privacy framing (read carefully — this is the load-bearing safety property)

The data directory contains:
- Identity private keys (anyone with these can impersonate the user in their communities, post as them, and read their future messages)
- All message content, channels, and history stored on the device
- Community membership, peer info, and onion addresses
- Invitation secrets and Tor state

The archive's first file (`README.txt`) leads with the warning text the maintainer supplied verbatim:

> **PRIVACY/SECURITY WARNING**: Do **NOT** use this feature with a live community you care about. This feature is for internal use on Alpha builds only. It will share ALL QUIET APPLICATION DATA, including: ...

Followed by the bullet list of what's inside, an explicit note that "Sending this to someone gives them permanent ability to act as you in your communities", and finally the device/version/contact info. The Share.open `subject` line is `Quiet ALL DATA YYYY-MM-DD — contains identity keys` so the recipient sees the framing in any compose surface.

**No email prefill.** `Share.open` is called without an `email:` recipient field by design — share targets that auto-fill a To: (Android Gmail) leave it empty, so the user must consciously enter where to send instead of one-tapping "Send" on a pre-addressed mail draft.

### What changed

- `packages/mobile/src/utils/shareAllData.ts` *(new)*
  - `shareAllData()` async helper. Writes `README.txt` (warning header) into `CachesDirectoryPath/quiet-data-share/`, then invokes `react-native-zip-archive`'s `zip(sources, target)` with `[readmePath, DATA_DIR, LOGS_DIR]` so each ends up at the zip's top level (`README.txt`, `files7/`, `logs/`).
  - Pre-zip `Alert.alert('Preparing archive', …)` so the user sees something while a large data dir is being compressed (a fully-populated community can take tens of seconds).
  - Surfaces zip failures via `Alert.alert('Could not zip data', String(err))` instead of swallowing.
  - **Important fix** vs the original implementation: the first iteration tried to stage everything into a temp dir via `RNFS.copyFile(DATA_DIR, staging/data)`. That fails silently with `EISDIR` because `RNFS.copyFile` only handles single files — directories raise. Caught only because the catch was around `zip()`, not the copy. Replaced with multi-source `zip()` which natively recurses into directories. Faster too — 180 ms instead of a copy-then-zip pipeline on a small data dir.
- `packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.container.tsx`
  - Added a "Share all data" item alongside the existing "Share logs" item from PR #3198, same gate.
- `packages/mobile/src/components/ContextMenu/menus/CommunityContextMenu.test.tsx`
  - Added 3 gating tests for the new menu item (production hides, dev shows, staging shows). Mocks `../../../utils/shareAllData`.
- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.component.tsx`
  - Added a second `TouchableWithoutFeedback` "Share all data" link directly below the "Share logs" link from Change 1. Same blue link style, testID `share-all-data-link`. Both wrapped in a single `<>...</>` fragment under the same gate.
- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.test.tsx`
  - Added 3 gating tests for `share-all-data-link` matching the pattern used for `share-logs-link`. Mocks `../../utils/shareAllData`.
- `packages/mobile/src/components/ConnectionProcess/ConnectionProcess.stories.tsx`
  - Added story `With Share all data link (dev/alpha)` mirroring the share-logs story.
- `packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx`
  - Updated the dev/alpha mock community menu story to include "Share all data" alongside "Share logs". Renamed to `Community (dev/alpha — Share logs + Share all data)`.
- `packages/mobile/src/utils/shareAllData.stories.tsx` *(new)*
  - Standalone storybook story with a `Button` that fires `shareAllData()` for on-device share-sheet smoke testing.
- `packages/mobile/.storybook/index.js`
  - Registered the new `shareAllData.stories`.
- `packages/mobile/package.json`
  - Added `react-native-zip-archive ^7.0.0` (native zip on both platforms; streams from disk so multi-GB data dirs don't blow up JS heap).
- `packages/mobile/src/setupTests.tsx`
  - Added global jest mocks for `react-native-zip-archive` and `react-native-share` so transitive imports through the joining screen don't break unrelated test suites.
- `packages/mobile/CHANGELOG.md`
  - Both features listed under `## [7.1.0] Features`.

### iOS feasibility (verified during dev, not yet tested on device)

`react-native-zip-archive ^7.0.0` has a mature iOS native implementation (RNZipArchive.h/m using SSZipArchive). `RNFS`, `react-native-share`, `react-native-device-info` are already in the iOS build via the existing `sendLogs`. UIActivityViewController ignores the share-recipient param (already handled — we don't pass one anyway). After merge, iOS needs `cd ios && pod install` to pick up the new native module.

**Caveat**: large data dirs may exceed Mail's ~25MB attachment limit. AirDrop and Files handle multi-GB just fine. Recommend testing both share targets.

---

## Tested

- [x] `npm run build` (TypeScript check) — clean.
- [x] All affected jest tests pass: `ConnectionProcess`, `CommunityContextMenu`, `joining.process` — 15/15.
- [x] On-device manual test on a Pixel 8 standardDebug build: share-all-data tapped from the community menu, zip created in 180 ms, share sheet opens with `quiet-data-<timestamp>.zip`, shared to Files, archive contents verified (`README.txt` with warning at top, `files7/` populated, `logs/` populated).
- [x] On-device manual test of storybook story for the joining-screen "Share logs" link — link renders correctly below "Learn more about Tor and Quiet".
- [ ] iOS smoke test (pod install + share from menu + verify zip in Files).
- [ ] iOS test with realistic data dir (>100 MB) — verify Files / AirDrop work; expect Mail to fail on large attachments.
- [ ] Production build of both platforms with `NODE_ENV=production` to confirm both menu and link surfaces are absent.

## Closes / supersedes

This PR consolidates the work from #3214 (which was stacked on this branch). #3214 has been closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
