### PR TITLE
Create community gets stuck after a brief network flap

### DIFF
--- a/packages/backend/src/nest/qss/qss.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss.service.spec.ts
@@ -1782,4 +1782,36 @@ describe('QSSService', () => {
       ingestSpy.mockRestore()
     })
   })
+
+  // Regression coverage for the architectural shape called out in
+  // poc/qss-flap-stalls-create-upstream: clicking "Create community"
+  // on a slightly flaky link consumed the renderer-side captcha token
+  // and then the create flow bailed out because the in-flight ack came
+  // back as 'socket has been disconnected'. createCommunity() returns
+  // false; QSS_CONNECTED does not re-fire while the websocket is still
+  // up; nothing reschedules the create. The fix is a one-shot,
+  // backoff-delayed retry of QSS_HANDLE_SIGN_IN scheduled from inside
+  // the sign-in handler. Without the fix createCommunity is called
+  // exactly once; with the fix it is called a second time after ~50 ms
+  // (QSS_RECONNECT_DELAY_MS).
+  describe('QSS_HANDLE_SIGN_IN retry on createCommunity false (regression)', () => {
+    it('retries createCommunity once after a single false result', async () => {
+      await initCommunity({ qssEnabled: true, qssSetup: false })
+      mockedAllowed = jest.spyOn(qssService, 'qssAllowed', 'get').mockReturnValue(true)
+
+      const createSpy = jest
+        .spyOn(qssService, 'createCommunity')
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+
+      await qssService.connect('ws://localhost:3000')
+      expect(qssService.connected).toBeTruthy()
+
+      await waitForExpect(() => {
+        expect(createSpy).toHaveBeenCalledTimes(2)
+      }, 5000)
+
+      createSpy.mockRestore()
+    })
+  })
 })

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -75,6 +75,15 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
   private _enabledOverride = false
 
   /**
+   * Timer for retrying QSS_HANDLE_SIGN_IN after a single sign-in / create-community attempt
+   * fails on a still-connected client. Without this, a transient ack timeout or mid-flight
+   * disconnect during create or sign-in leaves the auto-flow stuck because QSS_CONNECTED
+   * does not re-fire while the websocket is still up.
+   */
+  private _signInRetryTimer: NodeJS.Timeout | undefined
+  private _signInRetryDelayMs = QSS_RECONNECT_DELAY_MS
+
+  /**
    * Map of team IDs to intervals pulling log entries
    */
   private readonly _logPullIntervals: Map<string, NodeJS.Timeout> = new Map()
@@ -240,7 +249,12 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
         sigChain.team != null &&
         this.sigChainService.users.getAllUsers().length === 1
       ) {
-        await this.createCommunity(sigChain)
+        const created = await this.createCommunity(sigChain)
+        if (created) {
+          this._clearSignInRetryTimer(true)
+        } else {
+          this._scheduleSignInRetry('createCommunity returned false')
+        }
       } else {
         const teamId =
           sigChain.team != null
@@ -248,9 +262,57 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
             : (initStatus.community.inviteData as InvitationDataV3).authData!.teamId!
         const teamName = sigChain.team != null ? sigChain.team.teamName : initStatus.community.name
         this.logger.trace('QSS Sign in', teamId, teamName)
-        await this.signInToCommunity(teamId, sigChain, teamName)
+        const result = await this.signInToCommunity(teamId, sigChain, teamName)
+        if (result === QSSOperationResult.SUCCESS) {
+          this._clearSignInRetryTimer(true)
+        } else if (result === QSSOperationResult.ERROR) {
+          this._scheduleSignInRetry('signInToCommunity returned ERROR')
+        }
       }
     })
+  }
+
+  /**
+   * Schedule a single QSS_HANDLE_SIGN_IN retry after the configured backoff delay.
+   *
+   * The QSS auto-flow only re-emits QSS_HANDLE_SIGN_IN on QSS_CONNECTED. If a sign-in
+   * or create-community attempt fails while the websocket is still up (ack timeout, the
+   * socket bouncing between checks, etc.) and the client does not actually disconnect,
+   * QSS_CONNECTED never fires again and the flow is stuck. This breaks the loop by
+   * scheduling a single retry from inside _handleQssHandleSignIn whose timer fires
+   * outside the sign-in mutex, so it can re-acquire and try again.
+   *
+   * Backoff matches _scheduleReconnect so a sustained failure climbs to the same cap
+   * (60 s) instead of looping every 50 ms.
+   */
+  private _scheduleSignInRetry(reason: string): void {
+    if (this._paused || this._signInRetryTimer != null) {
+      return
+    }
+    const delayMs = this._signInRetryDelayMs
+    this._signInRetryDelayMs = Math.min(delayMs * QSS_RECONNECT_BACKOFF_FACTOR, QSS_RECONNECT_MAX_DELAY_MS)
+    this.logger.warn(`Scheduling QSS sign-in retry in ${delayMs} ms (${reason})`)
+    this._signInRetryTimer = setTimeout(() => {
+      this._signInRetryTimer = undefined
+      if (this._paused) {
+        return
+      }
+      if (!this.connected) {
+        this.logger.trace('Skipping QSS sign-in retry because client is not connected')
+        return
+      }
+      this.emit(QSSEvents.QSS_HANDLE_SIGN_IN)
+    }, delayMs)
+  }
+
+  private _clearSignInRetryTimer(resetDelay = false): void {
+    if (this._signInRetryTimer != null) {
+      clearTimeout(this._signInRetryTimer)
+      this._signInRetryTimer = undefined
+    }
+    if (resetDelay) {
+      this._signInRetryDelayMs = QSS_RECONNECT_DELAY_MS
+    }
   }
 
   private _handleSelfAssignMember = async (teamId: string): Promise<void> => {
@@ -521,6 +583,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
     this._paused = true
     this._teardownEventHandlers()
     this._clearReconnectTimer(true)
+    this._clearSignInRetryTimer(true)
     for (const interval of this._logPullIntervals.values()) {
       clearInterval(interval)
     }
@@ -1417,6 +1480,7 @@ export class QSSService extends EventEmitter implements OnModuleDestroy, OnModul
     this.logger.info(`Closing QSS service`)
     this._paused = true
     this._clearReconnectTimer(true)
+    this._clearSignInRetryTimer(true)
     for (const interval of this._logPullIntervals.values()) {
       clearInterval(interval)
     }


### PR DESCRIPTION
## Summary

Clicking **Create community** on a slightly flaky link (WiFi router rebooting, phone briefly switching cellular bands, captive-portal hiccup, etc.) leaves the spinner up indefinitely. The websocket eventually recovers, but the create flow has bailed out and the backend has no path to recover on its own — the only way forward is for the user to solve the hCaptcha challenge a second time, but the renderer never re-prompts.

This PR ships the smallest backend fix for the architectural shape behind it, plus a focused regression test in `qss.service.spec.ts`. The full toxiproxy chaos repro lives on a fork branch (link below) so this PR doesn't depend on the stress harness infra that isn't in upstream `7.1.0`.

## Failure trace from the running backend

```
QSS connected
GET_CAPTCHA_SITE_KEY ack    -> ok
VERIFY_CAPTCHA       ack    -> ok                   <-- token consumed
GEN_PUB_KEYS         ack    -> ok
CREATE_COMMUNITY     emit   -> socket disconnects mid-flight
ERROR Error while sending message to QSS Error: socket has been disconnected
ERROR Failed to create a community! Response was nullish

(reconnect, captchaVerified is now false)
GET_CAPTCHA_SITE_KEY ack    -> ok
INFO  Requesting hCaptcha token from renderer process
WARN  Failed to obtain hCaptcha token for verification     <-- 30 s renderer timeout
WARN  Can't create community on QSS because captcha verification failed
(loop forever)
```

## Code-path walkthrough (production code only, no test logic)

The auto-flow:

1. `QSSService.connect()` opens the websocket through `QSSClient.createSocketAndConnect`. On success the client emits `QSS_CONNECTED` (`qss.client.ts:189`).
2. `QSSService._handleQssConnected` (`qss.service.ts:199-202`) emits `QSS_HANDLE_SIGN_IN`.
3. `QSSService._handleQssHandleSignIn` (`qss.service.ts:217-254`) takes the `_signInMutex` and, since `qssSetup` is false on a fresh community, calls `createCommunity` -> `_createCommunityImpl` (`qss.service.ts:671-779`).
4. `_createCommunityImpl` does, in order:
   - `requestCaptchaVerification` (line 687) -> `getCaptchaSiteKey` -> `verifyCaptchaToken`
   - `GEN_PUB_KEYS` send-with-ack (line 717-721)
   - `CREATE_COMMUNITY` send-with-ack (line 762-766)

What the flap does:

- `verifyCaptchaToken` succeeds. Inside it, `qss.client.ts:319` clears the renderer-side cached token: `this.captchaService.hcaptchaToken = null`. hCaptcha tokens are single-use, so this is correct in isolation.
- The next message (`GEN_PUB_KEYS` or `CREATE_COMMUNITY`) is in flight when the proxy drops. socket.io's `emitWithAck` rejects with `Error: socket has been disconnected`.
- `QSSClient.sendMessage` swallows the rejection: `qss.client.ts:269-271` catches all errors, logs at error level, and returns `undefined`.
- `_createCommunityImpl` reads `null`, logs `Failed to create a community! Response was nullish`, returns `false`. The `_signInMutex.runExclusive` callback resolves cleanly with no record that the in-flight failure was actually a disconnect.

What happens on reconnect: only ONE `QSS_HANDLE_SIGN_IN` is emitted by `_handleQssConnected`. Since `_createCommunityImpl` returns `false` once and nothing reschedules, the auto-flow never tries again unless the websocket disconnects-and-reconnects a second time. Once the link settles cleanly there is no further `QSS_CONNECTED`, and the create is wedged.

## The fix (`qss.service.ts`)

Add a single backoff-delayed retry of `QSS_HANDLE_SIGN_IN` scheduled from inside the sign-in handler:

- New `_signInRetryTimer` + `_signInRetryDelayMs` (matches the existing `_reconnectQueueProcessor` pattern, capped at `QSS_RECONNECT_MAX_DELAY_MS = 60 s`, doubles per failure via `QSS_RECONNECT_BACKOFF_FACTOR`).
- In `_handleQssHandleSignIn`: capture the result of `createCommunity` / `signInToCommunity` and call `_scheduleSignInRetry(...)` on `false` / `ERROR`. Reset the backoff on `true` / `SUCCESS`.
- The retry's `setTimeout` fires *outside* `_signInMutex`, so re-entering `_handleQssHandleSignIn` works.
- `pause()` and `close()` clear the timer to avoid leaks during shutdown.

This is the smallest backend-side fix that breaks the wedge. It also addresses the architectural twin tracked in #3216 — the same retry mechanism handles `signInToCommunity` returning `ERROR` after a flap.

### Caveat for the captcha-consumed case in particular

hCaptcha tokens are single-use, so a same-socket retry of `CREATE_COMMUNITY` cannot reuse the original token. The retry path will call `requestCaptchaVerification` again, which calls `captchaService.getToken(siteKey)`, which emits `HCAPTCHA_CHALLENGE_REQUEST` so the renderer can pop the captcha modal. **Whether the renderer actually re-shows the modal in that state is a separate fix at a different layer** (renderer needs to listen to `HCAPTCHA_CHALLENGE_REQUEST` while a create is "in progress" in its own UI state). This PR only addresses the backend-side wedge — it ensures the backend keeps trying instead of going silent, and it ensures each retry emits a fresh challenge request so the renderer at least *can* re-prompt.

## The regression test (`qss.service.spec.ts`)

```ts
describe('QSS_HANDLE_SIGN_IN retry on createCommunity false (regression)', () => {
  it('retries createCommunity once after a single false result', async () => {
    // qssSetup=false so the create branch runs
    await initCommunity({ qssEnabled: true, qssSetup: false })
    mockedAllowed.mockReturnValue(true)
    const createSpy = jest.spyOn(qssService, 'createCommunity')
      .mockResolvedValueOnce(false)  // first attempt fails
      .mockResolvedValueOnce(true)   // retry succeeds
    await qssService.connect('ws://localhost:3000')
    await waitForExpect(() => {
      expect(createSpy).toHaveBeenCalledTimes(2)        // <-- without fix, called 1×
    }, 5000)
  })
})
```

Without the fix, `createCommunity` is called exactly once. With the fix it is called a second time after the ~50 ms initial backoff. Test exercises the production `_handleQssHandleSignIn` auto-flow end-to-end (no internal mocking of the retry mechanism).

## Full toxiproxy chaos PoC

The deterministic toxiproxy stress repro that originally surfaced this bug lives on a fork branch — it depends on a stress harness (`packages/backend/src/nest/qss/stress/harness.ts`, invariants helpers, `jest.stress.config.js`, etc.) that isn't in upstream `7.1.0`. To run it locally:

- Fork PR: https://github.com/holmesworcester/quiet/pull/14
- Branch: `holmesworcester:poc/qss-flap-stalls-create`
- Test: `packages/backend/src/nest/qss/stress/scenarios/flap-stalls-create.stress.spec.ts`

The fork run boots a backend behind a TCP proxy and toggles the proxy at 5 Hz for 4 s while the QSSService auto-flow runs. After the link goes back to clean, it polls `qssSetup` for 90 s. On stock 7.1.0 the poll never succeeds; with the retry fix in this PR, the auto-flow recovers within the first backoff cycle.

## Test plan

- [x] `qss.service.spec.ts` regression test passes locally with the fix; fails (createCommunity called once) without it.
- [x] `tsc -p tsconfig.build.json --noEmit` clean for changes in this PR.
- [ ] Maintainer: run the toxiproxy PoC on `holmesworcester:poc/qss-flap-stalls-create` against this branch's `qss.service.ts` to confirm the 90 s post-flap deadline goes green.
- [ ] Maintainer follow-up: renderer-side handling of `HCAPTCHA_CHALLENGE_REQUEST` during an in-progress create so the user is re-prompted automatically (out of scope here).
