### PR TITLE
stop purging tor cache; add stall detector; add health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
+* Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)
 
 ### Chores
 

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
@@ -23,6 +23,8 @@ import { QSSOperationResult, QSSEvents } from '../qss/qss.types'
 import { QPSService } from '../qps/qps.service'
 import waitForExpect from 'wait-for-expect'
 import { CaptchaService } from '../captcha/captcha.service'
+import fs from 'fs'
+import path from 'path'
 
 const logger = createLogger('connections-manager.service.spec')
 
@@ -405,10 +407,37 @@ describe('ConnectionsManagerService', () => {
     expect(deleteChainSpy).toHaveBeenCalled()
     expect(purgeLocalDbArtifactsSpy).toHaveBeenCalledTimes(1)
     expect(purgeDataSpy).toHaveBeenCalledTimes(1)
+    expect(purgeDataSpy).toHaveBeenCalledWith({ removeTorDataDirectory: false })
     expect(resetHiddenServicesSpy).toHaveBeenCalledTimes(1)
     expect(resetStateSpy).toHaveBeenCalledTimes(1)
     expect(localDbOpenSpy).toHaveBeenCalledTimes(1)
     expect(closeSocketSpy).not.toHaveBeenCalled()
+  })
+
+  it('pre-community artifact erasure preserves TorDataDirectory while purging community storage', async () => {
+    const torDataDirectory = path.join(quietDir, 'TorDataDirectory')
+    const torCacheFile = path.join(torDataDirectory, 'cached-certs')
+    const communityStorageDirectory = path.join(quietDir, 'Ipfs-regression')
+
+    fs.mkdirSync(torDataDirectory, { recursive: true })
+    fs.writeFileSync(torCacheFile, 'tor cache')
+    fs.mkdirSync(communityStorageDirectory, { recursive: true })
+
+    jest.spyOn(connectionsManagerService['storageService'], 'clean').mockResolvedValue()
+    jest.spyOn(connectionsManagerService.libp2pService, 'close').mockResolvedValue()
+    jest.spyOn(connectionsManagerService.libp2pService, 'cleanDatastore').mockResolvedValue()
+    jest.spyOn(connectionsManagerService.libp2pService, 'closeDatastore').mockResolvedValue()
+    jest.spyOn(sigChainService, 'deleteChain').mockResolvedValue()
+    jest.spyOn(localDbService, 'purgeArtifacts').mockResolvedValue()
+    jest.spyOn(connectionsManagerService['tor'], 'resetHiddenServices').mockImplementation(() => {})
+    jest.spyOn(connectionsManagerService, 'resetState').mockResolvedValue()
+    jest.spyOn(localDbService, 'open').mockResolvedValue()
+    sigChainService.activeChainTeamName = community.name
+
+    await (connectionsManagerService as any).erasePreviousCommunityArtifacts()
+
+    expect(fs.existsSync(torCacheFile)).toBe(true)
+    expect(fs.existsSync(communityStorageDirectory)).toBe(false)
   })
 
   it('returns false instead of rejecting when leaveCommunity fails through the socket listener', async () => {

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -390,7 +390,7 @@ export class ConnectionsManagerService extends EventEmitter implements OnModuleI
 
     if (this.storageService) {
       this.logger.info('Purging storage data')
-      this.storageService.purgeData()
+      this.storageService.purgeData({ removeTorDataDirectory: false })
     }
 
     this.logger.info('Resetting Tor hidden services')

--- a/packages/backend/src/nest/storage/storage.service.spec.ts
+++ b/packages/backend/src/nest/storage/storage.service.spec.ts
@@ -273,5 +273,19 @@ describe('StorageService', () => {
       rmSync.mockRestore()
       fs.rmSync(lockedDir, { recursive: true, force: true })
     })
+
+    it('purgeData can preserve the Tor data directory', () => {
+      const torDataDirectory = path.join(storageService.quietDir, 'TorDataDirectory')
+      const ipfsDirectory = path.join(storageService.quietDir, 'Ipfs-test')
+      fs.mkdirSync(torDataDirectory, { recursive: true })
+      fs.mkdirSync(ipfsDirectory, { recursive: true })
+
+      storageService.purgeData({ removeTorDataDirectory: false })
+
+      expect(fs.existsSync(torDataDirectory)).toBe(true)
+      expect(fs.existsSync(ipfsDirectory)).toBe(false)
+
+      fs.rmSync(torDataDirectory, { recursive: true, force: true })
+    })
   })
 })

--- a/packages/backend/src/nest/storage/storage.service.ts
+++ b/packages/backend/src/nest/storage/storage.service.ts
@@ -15,7 +15,7 @@ import { IPFS_REPO_PATCH, ORBIT_DB_DIR, QUIET_DIR } from '../const'
 import { LocalDbService } from '../local-db/local-db.service'
 import { createLogger } from '../common/logger'
 import { removeFiles, removeDirs, createPaths, removeFilesFromDir } from '../common/utils'
-import { StorageEvents } from './storage.types'
+import { type PurgeDataOptions, StorageEvents } from './storage.types'
 import { IpfsService } from '../ipfs/ipfs.service'
 import { OrbitDbService } from './orbitDb/orbitDb.service'
 import { UserProfileStore } from './userProfile/userProfile.store'
@@ -130,12 +130,12 @@ export class StorageService extends EventEmitter {
     await this.stop()
   }
 
-  public purgeData() {
+  public purgeData({ removeTorDataDirectory = true }: PurgeDataOptions = {}) {
     this.logger.info('Purging data directories and files')
-    this._purgeDataDirectories()
+    this._purgeDataDirectories({ removeTorDataDirectory })
     this._purgeFiles()
   }
-  private _purgeDataDirectories() {
+  private _purgeDataDirectories({ removeTorDataDirectory }: Required<PurgeDataOptions>) {
     const dirsToRemove = existsSync(this.quietDir)
       ? readdirSync(this.quietDir).filter(
           i =>
@@ -145,7 +145,7 @@ export class StorageService extends EventEmitter {
             i.startsWith('Local Storage') ||
             i.startsWith('libp2pDatastore') ||
             i.startsWith('databases') ||
-            i.startsWith('TorDataDirectory')
+            (removeTorDataDirectory && i.startsWith('TorDataDirectory'))
         )
       : []
     const dirsToRemovePaths = new Set([this.ipfsRepoPath, this.orbitDbDir])

--- a/packages/backend/src/nest/storage/storage.types.ts
+++ b/packages/backend/src/nest/storage/storage.types.ts
@@ -38,3 +38,7 @@ export interface CsrReplicatedPromiseValues {
 export interface DBOptions {
   sync: boolean
 }
+
+export type PurgeDataOptions = {
+  removeTorDataDirectory?: boolean
+}

--- a/packages/backend/src/nest/tor/tor.service.tor.spec.ts
+++ b/packages/backend/src/nest/tor/tor.service.tor.spec.ts
@@ -132,6 +132,74 @@ describe('TorControl', () => {
     expect(spyOnInit).toHaveBeenCalledTimes(2)
   })
 
+  it('recovers from a loading_keys timeout stall by restarting managed Tor', async () => {
+    jest.useFakeTimers()
+    const loadingKeysTimeout =
+      '250-status/bootstrap-phase=WARN BOOTSTRAP PROGRESS=40 TAG=loading_keys SUMMARY="Loading authority key certs" WARNING="Operation timed out" REASON=TIMEOUT COUNT=1 RECOMMENDATION=ignore HOSTADDR="204.8.96.160:443"'
+    const bootstrapDone = '250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"'
+    let restarted = false
+    const sendCommandSpy = jest.spyOn(torControl, 'sendCommand').mockImplementation(async () => {
+      return {
+        code: 250,
+        messages: [restarted ? bootstrapDone : loadingKeysTimeout, '250 OK'],
+      }
+    })
+    const initSpy = jest.spyOn(torService, 'init').mockImplementation(async () => {
+      restarted = true
+    })
+    const getTorProcessIdsSpy = jest.spyOn(torService, 'getTorProcessIds').mockReturnValue(['123'])
+    const torServiceInternals = torService as any
+
+    try {
+      torServiceInternals.torDataDirectory = `${tmpAppDataPath}/TorDataDirectory`
+      torService.startBootstrapWatcher(1000)
+
+      await jest.advanceTimersByTimeAsync(31_000)
+
+      expect(sendCommandSpy).toHaveBeenCalled()
+      expect(initSpy).toHaveBeenCalledTimes(1)
+      await expect(torService.isBootstrappingFinished()).resolves.toBe(true)
+      expect(torService.bootstrapped).toBe(true)
+    } finally {
+      torServiceInternals.stopBootstrapWatcher()
+      jest.useRealTimers()
+      sendCommandSpy.mockRestore()
+      initSpy.mockRestore()
+      getTorProcessIdsSpy.mockRestore()
+    }
+  })
+
+  it('restarts managed Tor immediately when the process disappears during bootstrap', async () => {
+    jest.useFakeTimers()
+    const sendCommandSpy = jest.spyOn(torControl, 'sendCommand').mockResolvedValue({
+      code: 250,
+      messages: [
+        '250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=40 TAG=loading_keys SUMMARY="Loading authority key certs"',
+        '250 OK',
+      ],
+    })
+    const initSpy = jest.spyOn(torService, 'init').mockResolvedValue(undefined)
+    const getTorProcessIdsSpy = jest.spyOn(torService, 'getTorProcessIds').mockReturnValue([])
+    const torServiceInternals = torService as any
+
+    try {
+      torServiceInternals.torDataDirectory = `${tmpAppDataPath}/TorDataDirectory`
+      torService.startBootstrapWatcher(1000)
+
+      await jest.advanceTimersByTimeAsync(1000)
+
+      expect(getTorProcessIdsSpy).toHaveBeenCalled()
+      expect(sendCommandSpy).not.toHaveBeenCalled()
+      expect(initSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      torServiceInternals.stopBootstrapWatcher()
+      jest.useRealTimers()
+      sendCommandSpy.mockRestore()
+      initSpy.mockRestore()
+      getTorProcessIdsSpy.mockRestore()
+    }
+  })
+
   it('tor is initializing correctly with 40 seconds timeout', async () => {
     await torService.init()
   })

--- a/packages/backend/src/nest/tor/tor.service.ts
+++ b/packages/backend/src/nest/tor/tor.service.ts
@@ -10,6 +10,8 @@ import { ConfigOptions, ServerIoProviderTypes } from '../types'
 import { CONFIG_OPTIONS, QUIET_DIR, SERVER_IO_PROVIDER, TOR_PARAMS_PROVIDER, TOR_PASSWORD_PROVIDER } from '../const'
 import { TorControl } from './tor-control.service'
 import {
+  type BootstrapStallState,
+  type BootstrapStatus,
   GetInfoTorSignal,
   HiddenServiceData,
   TorControlAuthType,
@@ -21,6 +23,10 @@ import {
 import { createLogger } from '../common/logger'
 import { toString as uint8ArrayToString } from 'uint8arrays'
 import { isUint8Array } from 'util/types'
+
+const BOOTSTRAP_DONE_MESSAGE = '250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"'
+const BOOTSTRAP_STALL_MIN_DURATION_MS = 30_000
+const BOOTSTRAP_STALL_TIMEOUT_WARNING_COUNT = 3
 
 export class Tor extends EventEmitter implements OnModuleInit {
   socksPort: number
@@ -35,6 +41,8 @@ export class Tor extends EventEmitter implements OnModuleInit {
   private hiddenServices: Map<string, HiddenServiceData> = new Map()
   private initializedHiddenServices: Map<string, HiddenServiceData> = new Map()
   private markBootstrappedPromise: Promise<void> | undefined
+  private bootstrapRestartPromise: Promise<void> | undefined
+  private bootstrapStallState: BootstrapStallState | undefined
   private bootstrapGeneration = 0
   public bootstrapped = false
   constructor(
@@ -47,6 +55,7 @@ export class Tor extends EventEmitter implements OnModuleInit {
   ) {
     super()
     this.controlPort = configOptions.torControlPort
+    this.extraTorProcessParams = this.mergeDefaultTorParams(torParamsProvider.extraTorProcessParams)
 
     this.logger.info('QUIET DIR', this.quietDir)
   }
@@ -95,8 +104,13 @@ export class Tor extends EventEmitter implements OnModuleInit {
   public resetBootstrapState() {
     this.bootstrapGeneration += 1
     this.bootstrapped = false
+    this.bootstrapStallState = undefined
     this.initializedHiddenServices = new Map()
     this.markBootstrappedPromise = undefined
+    if (this.initTimeout) {
+      clearTimeout(this.initTimeout)
+      this.initTimeout = undefined
+    }
     this.stopBootstrapWatcher()
   }
 
@@ -117,6 +131,10 @@ export class Tor extends EventEmitter implements OnModuleInit {
 
       this.logger.info('Bootstrapping finished!')
       this.bootstrapped = true
+      if (this.initTimeout) {
+        clearTimeout(this.initTimeout)
+        this.initTimeout = undefined
+      }
       this.emit('bootstrapped')
       this.serverIoProvider.io.emit(SocketEvents.TOR_INITIALIZED)
       this.stopBootstrapWatcher()
@@ -168,10 +186,18 @@ export class Tor extends EventEmitter implements OnModuleInit {
 
       void (async () => {
         this.logger.info('Checking bootstrap interval', { tickCount })
-        const bootstrapDone = await this.isBootstrappingFinished()
-        if (bootstrapDone) {
-          this.stopBootstrapWatcher()
+        const restartedMissingTorProcess = await this.checkManagedTorProcessHealth()
+        if (restartedMissingTorProcess) {
+          return
         }
+
+        const bootstrapStatus = await this.getBootstrapStatus()
+        if (bootstrapStatus.done) {
+          await this.markBootstrapped()
+          this.stopBootstrapWatcher()
+          return
+        }
+        await this.checkBootstrapStall(bootstrapStatus)
       })()
         .catch(e => {
           this.logger.error(
@@ -210,13 +236,149 @@ export class Tor extends EventEmitter implements OnModuleInit {
 
   public async isBootstrappingFinished(): Promise<boolean> {
     if (this.bootstrapped) return true
-    this.logger.debug('Checking bootstrap status')
-    const output = await this.torControl.sendCommand('GETINFO status/bootstrap-phase')
-    if (output.messages[0] === '250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"') {
+    const bootstrapStatus = await this.getBootstrapStatus()
+    if (bootstrapStatus.done) {
       await this.markBootstrapped()
       return true
     }
     return false
+  }
+
+  private async getBootstrapStatus(): Promise<BootstrapStatus> {
+    this.logger.debug('Checking bootstrap status')
+    const output = await this.torControl.sendCommand('GETINFO status/bootstrap-phase')
+    return this.parseBootstrapStatus(output.messages[0] ?? '')
+  }
+
+  private parseBootstrapStatus(rawMessage: string): BootstrapStatus {
+    const progressMatch = rawMessage.match(/BOOTSTRAP PROGRESS=(\d+)/)
+    const tagMatch = rawMessage.match(/TAG=([^\s]+)/)
+    const warningMatch = rawMessage.match(/WARNING="([^"]+)"/)
+    const reasonMatch = rawMessage.match(/REASON=([^\s]+)/)
+
+    return {
+      rawMessage,
+      done: rawMessage === BOOTSTRAP_DONE_MESSAGE,
+      progress: progressMatch ? Number(progressMatch[1]) : undefined,
+      tag: tagMatch ? tagMatch[1] : undefined,
+      warning: warningMatch?.[1],
+      reason: reasonMatch?.[1],
+    }
+  }
+
+  private async checkBootstrapStall(status: BootstrapStatus): Promise<void> {
+    if (status.done || status.progress == null) {
+      this.bootstrapStallState = undefined
+      return
+    }
+
+    const checkedAt = Date.now()
+    const hasTimeoutWarning =
+      status.reason === 'TIMEOUT' || status.warning?.toLowerCase().includes('timed out') === true
+
+    if (
+      this.bootstrapStallState == null ||
+      this.bootstrapStallState.progress !== status.progress ||
+      this.bootstrapStallState.tag !== status.tag
+    ) {
+      this.bootstrapStallState = {
+        progress: status.progress,
+        tag: status.tag,
+        firstObservedAt: checkedAt,
+        timeoutWarningCount: hasTimeoutWarning ? 1 : 0,
+      }
+      return
+    }
+
+    if (hasTimeoutWarning) {
+      this.bootstrapStallState.timeoutWarningCount += 1
+    }
+
+    const stalledMs = checkedAt - this.bootstrapStallState.firstObservedAt
+    if (
+      stalledMs < BOOTSTRAP_STALL_MIN_DURATION_MS ||
+      this.bootstrapStallState.timeoutWarningCount < BOOTSTRAP_STALL_TIMEOUT_WARNING_COUNT
+    ) {
+      return
+    }
+
+    await this.restartAfterBootstrapStall(status, stalledMs, this.bootstrapStallState.timeoutWarningCount)
+  }
+
+  private async checkManagedTorProcessHealth(): Promise<boolean> {
+    if (!this.torParamsProvider.torPath || !this.torDataDirectory || this.bootstrapped) {
+      return false
+    }
+
+    let torPids: string[]
+    try {
+      torPids = this.getTorProcessIds()
+    } catch (e) {
+      this.logger.warn('Unable to check managed Tor process health during bootstrap', e)
+      return false
+    }
+
+    if (torPids.length > 0) {
+      return false
+    }
+
+    await this.restartManagedTor('Managed Tor process disappeared during bootstrap; restarting Tor', {
+      controlPort: this.controlPort,
+      socksPort: this.socksPort,
+      torPids,
+    })
+    return true
+  }
+
+  private async restartAfterBootstrapStall(
+    status: BootstrapStatus,
+    stalledMs: number,
+    timeoutWarningCount: number
+  ): Promise<void> {
+    if (!this.torParamsProvider.torPath) {
+      this.logger.warn('Tor bootstrap appears stalled, but Tor is externally managed; waiting for native Tor', {
+        progress: status.progress,
+        tag: status.tag,
+        stalledMs,
+        timeoutWarningCount,
+        status: status.rawMessage,
+      })
+      this.bootstrapStallState = undefined
+      return
+    }
+
+    await this.restartManagedTor('Tor bootstrap appears stalled; restarting Tor', {
+      progress: status.progress,
+      tag: status.tag,
+      stalledMs,
+      timeoutWarningCount,
+      controlPort: this.controlPort,
+      socksPort: this.socksPort,
+      torPids: this.torDataDirectory ? this.getTorProcessIds() : undefined,
+      status: status.rawMessage,
+    })
+  }
+
+  private async restartManagedTor(reason: string, context: Record<string, unknown>): Promise<void> {
+    if (this.bootstrapRestartPromise) {
+      await this.bootstrapRestartPromise
+      return
+    }
+
+    this.logger.warn(reason, context)
+
+    this.bootstrapRestartPromise = (async () => {
+      this.initializedHiddenServices = new Map()
+      this.bootstrapStallState = undefined
+      this.stopBootstrapWatcher()
+      await this.init()
+    })()
+
+    try {
+      await this.bootstrapRestartPromise
+    } finally {
+      this.bootstrapRestartPromise = undefined
+    }
   }
 
   public async init(timeout = 120_000): Promise<void> {
@@ -397,7 +559,7 @@ export class Tor extends EventEmitter implements OnModuleInit {
           `"${this.torDataDirectory}"`,
           '--HashedControlPassword',
           this.torPasswordProvider.torHashedPassword,
-          // ...this.torProcessParams
+          ...this.torProcessParams,
         ],
         options
       )

--- a/packages/backend/src/nest/tor/tor.types.ts
+++ b/packages/backend/src/nest/tor/tor.types.ts
@@ -47,6 +47,7 @@ export interface TorParamsProvider {
     }
     detached: boolean
   }
+  extraTorProcessParams?: TorParams
 }
 
 export interface TorPasswordProvider {
@@ -59,4 +60,20 @@ export interface HiddenServiceData {
   privKey: string
   virtPort: number
   onionAddress: string
+}
+
+export type BootstrapStatus = {
+  rawMessage: string
+  done: boolean
+  progress?: number
+  tag?: string
+  warning?: string
+  reason?: string
+}
+
+export type BootstrapStallState = {
+  progress?: number
+  tag?: string
+  firstObservedAt: number
+  timeoutWarningCount: number
 }


### PR DESCRIPTION
- Improves Tor performance by not purging TorDataDirectory during leaving and joining.
- Adds a stall detector that watches for stall patterns that I saw in my testing, can be extended later if we identify other patterns
- Adds a health check for the tor process for automatic recovery

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
