### PR TITLE
fix(android): stop leave-community crash from missing Firebase config (#3236)

### DIFF
--- a/.github/secrets/decrypt_android_secrets.sh
+++ b/.github/secrets/decrypt_android_secrets.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Decrypt the Android Firebase config (google-services.json) and place it where the
+# Gradle build expects it: packages/mobile/android/app/. The file is gitignored and
+# stored encrypted as google-services.json.gpg.
+#
+# Safe to run on Linux CI runners: unlike decrypt_secrets.sh this does no macOS/iOS
+# tooling. decrypt_secrets.sh calls this so the iOS and Android jobs stay in sync.
+#
+# Must be run from the repository root.
+
+set -e
+
+if [ -z "$ANDROID_FIREBASE_KEY" ]; then
+  echo "ANDROID_FIREBASE_KEY is not set; skipping google-services.json decryption."
+  echo "Firebase push notifications will be unavailable; release builds fail by design."
+  exit 0
+fi
+
+gpg --quiet --batch --yes --decrypt --passphrase="$ANDROID_FIREBASE_KEY" \
+  --output ./.github/secrets/google-services.json \
+  ./.github/secrets/google-services.json.gpg
+
+cp ./.github/secrets/google-services.json ./packages/mobile/android/app/google-services.json
+
+echo "Decrypted google-services.json into packages/mobile/android/app/"

--- a/.github/secrets/decrypt_secrets.sh
+++ b/.github/secrets/decrypt_secrets.sh
@@ -6,14 +6,15 @@ gpg --quiet --batch --yes --decrypt --passphrase="$IOS_PROFILE_KEY" --output ./.
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_NSE_PROFILE_KEY" --output ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision.gpg
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_CERTIFICATE_KEY" --output ./.github/secrets/Certificates.p12 ./.github/secrets/Certificates.p12.gpg
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_FIREBASE_KEY" --output ./.github/secrets/GoogleService-Info.plist ./.github/secrets/GoogleService-Info.plist.gpg
-gpg --quiet --batch --yes --decrypt --passphrase="$ANDROID_FIREBASE_KEY" --output ./.github/secrets/google-services.json ./.github/secrets/google-services.json.gpg
+
+# Android Firebase config (google-services.json) - shared with the Android workflows.
+./.github/secrets/decrypt_android_secrets.sh
 
 mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
 
 cp ./.github/secrets/match_AppStore_comquietmobile.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/762df280-302c-4336-a56d-c74914169337.mobileprovision
 cp ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/247b3945-4f28-4ef1-b722-e98fb3fb59f7.mobileprovision
 cp ./.github/secrets/GoogleService-Info.plist ./packages/mobile/ios/GoogleService-Info.plist
-cp ./.github/secrets/google-services.json ./packages/mobile/android/app/google-services.json
 
 security create-keychain -p "" build.keychain
 security import ./.github/secrets/Certificates.p12 -t agg -k ~/Library/Keychains/build.keychain -P "$IOS_CERTIFICATE_KEY" -A

--- a/.github/workflows/mobile-build-apk.yml
+++ b/.github/workflows/mobile-build-apk.yml
@@ -86,6 +86,11 @@ jobs:
       - name: "Decode keystore"
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
+
       - name: "Build .apk"
         env:
           ENVFILE: ../.env.production
@@ -251,6 +256,11 @@ jobs:
       - name: "Prepare ndk configuration"
         run: |
           printf "NDK_PATH=${{ steps.setup-ndk.outputs.ndk-path }}\n" > $HOME/.gradle/gradle.properties
+
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
 
       - name: "Build debug .apk"
         run: cd ./packages/mobile/android && ENVFILE=../.env.staging ./gradlew assembleStandardDebug

--- a/.github/workflows/mobile-deploy-android.yml
+++ b/.github/workflows/mobile-deploy-android.yml
@@ -73,6 +73,11 @@ jobs:
       - name: "Decode keystore"
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
+
       - name: "Build .aab"
         env:
           ENVFILE: ../.env.production

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -343,7 +343,15 @@ apply from: project(":react-native-config").projectDir.getPath() + "/dotenv.grad
 if (googleServicesJsonPath.exists()) {
     apply plugin: "com.google.gms.google-services"
 } else {
-    logger.warn("google-services.json not found in packages/mobile/android/app; Firebase runtime setup will remain incomplete until it is added.")
+    def buildingRelease = gradle.startParameter.taskNames.any { it.toLowerCase().contains("release") }
+    if (buildingRelease) {
+        throw new GradleException(
+            "google-services.json not found in packages/mobile/android/app. Release builds " +
+            "require it for Firebase push notifications. Run ./.github/secrets/decrypt_android_secrets.sh " +
+            "(needs the ANDROID_FIREBASE_KEY passphrase) or add the file manually before building."
+        )
+    }
+    logger.warn("google-services.json not found in packages/mobile/android/app; Firebase push notifications will be unavailable in this build.")
 }
 
 repositories {

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Push/FirebaseMessagingModule.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Push/FirebaseMessagingModule.kt
@@ -12,19 +12,31 @@ class FirebaseMessagingModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getToken(promise: Promise) {
-        FirebaseMessaging.getInstance().token
-            .addOnSuccessListener { token -> promise.resolve(token) }
-            .addOnFailureListener { error ->
-                promise.reject("token_error", "Failed to get FCM token: ${error.localizedMessage}", error)
-            }
+        try {
+            FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token -> promise.resolve(token) }
+                .addOnFailureListener { error ->
+                    promise.reject("token_error", "Failed to get FCM token: ${error.localizedMessage}", error)
+                }
+        } catch (error: Throwable) {
+            // FirebaseMessaging.getInstance() throws synchronously (e.g. IllegalStateException
+            // "Default FirebaseApp is not initialized") when the build has no google-services.json.
+            // Reject the promise instead of letting the exception crash the app.
+            promise.reject("token_error", "Firebase is not available: ${error.localizedMessage}", error)
+        }
     }
 
     @ReactMethod
     fun deleteToken(promise: Promise) {
-        FirebaseMessaging.getInstance().deleteToken()
-            .addOnSuccessListener { promise.resolve(null) }
-            .addOnFailureListener { error ->
-                promise.reject("delete_error", "Failed to delete FCM token: ${error.localizedMessage}", error)
-            }
+        try {
+            FirebaseMessaging.getInstance().deleteToken()
+                .addOnSuccessListener { promise.resolve(null) }
+                .addOnFailureListener { error ->
+                    promise.reject("delete_error", "Failed to delete FCM token: ${error.localizedMessage}", error)
+                }
+        } catch (error: Throwable) {
+            // See getToken(): getInstance() can throw before any listener is attached.
+            promise.reject("delete_error", "Firebase is not available: ${error.localizedMessage}", error)
+        }
     }
 }


### PR DESCRIPTION
## Problem

Leaving a community on Android crashes the whole app (#3236). On-device logcat shows an uncaught exception:

```
E AndroidRuntime: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process com.quietmobile.
E AndroidRuntime:   at com.quietmobile.Push.FirebaseMessagingModule.deleteToken(FirebaseMessagingModule.kt:24)
```

The exception kills the process — that's the reported "app turns itself off" / freeze / GrapheneOS error. iOS, macOS, Windows and Linux are unaffected.

## Root cause

`google-services.json` is gitignored and stored encrypted (`.github/secrets/google-services.json.gpg`). The only thing that decrypts and places it — `.github/secrets/decrypt_secrets.sh` — is wired **only** into the iOS workflow. Both Android workflows build with no `google-services.json`, so the `com.google.gms.google-services` Gradle plugin is skipped, `FirebaseApp` never auto-initializes, and `FirebaseMessaging.getInstance()` throws synchronously when the leave flow calls `deleteToken()`.

Introduced by `a10e467ab` (Android Push Notifications, #3188) — the Android Firebase code and the gradle/gitignore scaffolding landed, but the Android CI never got the decrypt step.

## Changes

- **`FirebaseMessagingModule.kt`** — wrap `getToken`/`deleteToken` so a synchronous `getInstance()` failure rejects the promise instead of crashing the app. (The JS `leaveCommunity` saga already catches the rejection.)
- **`decrypt_android_secrets.sh`** (new) — Linux-safe script that decrypts `google-services.json` into `packages/mobile/android/app/`; skips cleanly when `ANDROID_FIREBASE_KEY` is absent (fork PRs).
- **`decrypt_secrets.sh`** — delegates the Android config to the new script so iOS and Android share one source of truth.
- **`mobile-build-apk.yml` / `mobile-deploy-android.yml`** — run the decrypt step before the Gradle build in every Android job.
- **`build.gradle`** — fail the build loudly when `google-services.json` is missing for a release build, instead of silently shipping a crashing APK.

## Notes / verification

- Needs `ANDROID_FIREBASE_KEY` to exist as a repo Actions secret (the iOS workflow already references it).
- Not build-verified — needs a real Android Gradle build to confirm green.
- `a10e467ab` is also on `develop`; a follow-up PR should land this fix there too.
- e2e Android workflows are intentionally left untouched — the native guard makes leave safe without Firebase config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)