### PR TITLE
feat(mobile): "Share logs" + "Share all data" on the "Starting backend" screen

### DIFF
--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Added background push notifications and background hibernation for android [#3156](https://github.com/TryQuiet/quiet/issues/3156)
+* Extends the dev/alpha-only "Share logs" and "Share all data" actions to the "Starting backend" screen (mobile) [#3241](https://github.com/TryQuiet/quiet/pull/3241)
 
 ### Fixes
 

--- a/packages/mobile/src/components/Splash/Splash.component.tsx
+++ b/packages/mobile/src/components/Splash/Splash.component.tsx
@@ -1,9 +1,13 @@
 import React, { FC } from 'react'
-import { Image, View } from 'react-native'
+import { Image, View, TouchableWithoutFeedback } from 'react-native'
 import deviceInfoModule from 'react-native-device-info'
+import Config from 'react-native-config'
 import { Typography } from '../Typography/Typography.component'
 import { defaultTheme } from '../../styles/themes/default.theme'
 import { icons } from '../../assets'
+import { NodeEnv } from '../../utils/const/NodeEnv.enum'
+import { sendLogs } from '../../utils/sendLogs'
+import { shareAllData } from '../../utils/shareAllData'
 
 export const Splash: FC = () => {
   return (
@@ -40,6 +44,27 @@ export const Splash: FC = () => {
           {`v ${deviceInfoModule.getVersion()}`}
         </Typography>
       </View>
+
+      {/* Starting the backend can stall before any other screen is reachable,
+          which is exactly when alpha/dev testers need to grab diagnostics.
+          Surface the same dev/alpha-only "Share logs" / "Share all data"
+          helpers used on the joining screen (PR #3213), gated identically to
+          non-production builds via Config.NODE_ENV. */}
+      {Config.NODE_ENV !== NodeEnv.Production && (
+        <View style={{ gap: 16, alignItems: 'center' }}>
+          <TouchableWithoutFeedback onPress={() => void sendLogs()} testID={'share-logs-link'}>
+            <Typography fontSize={14} style={{ color: '#2373EA' }}>
+              Share logs
+            </Typography>
+          </TouchableWithoutFeedback>
+
+          <TouchableWithoutFeedback onPress={() => void shareAllData()} testID={'share-all-data-link'}>
+            <Typography fontSize={14} style={{ color: '#2373EA' }}>
+              Share all data
+            </Typography>
+          </TouchableWithoutFeedback>
+        </View>
+      )}
     </View>
   )
 }

--- a/packages/mobile/src/components/Splash/Splash.stories.tsx
+++ b/packages/mobile/src/components/Splash/Splash.stories.tsx
@@ -3,4 +3,13 @@ import React from 'react'
 
 import { Splash } from './Splash.component'
 
-storiesOf('Splash', module).add('Default', () => <Splash />)
+storiesOf('Splash', module)
+  .add('Default', () => <Splash />)
+  .add('With Share logs / Share all data links (dev/alpha)', () => (
+    // The "Share logs" and "Share all data" links are gated to non-production
+    // builds via Config.NODE_ENV. Running Storybook with any non-production
+    // NODE_ENV renders both links below the version string. Tapping "Share
+    // logs" bundles cached log files; "Share all data" zips the local Quiet
+    // data directory plus on-device logs. Both open the native share sheet.
+    <Splash />
+  ))

--- a/packages/mobile/src/components/Splash/Splash.test.tsx
+++ b/packages/mobile/src/components/Splash/Splash.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import Config from 'react-native-config'
+import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
+import { Splash } from './Splash.component'
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+jest.mock('../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+jest.mock('../../utils/shareAllData', () => ({ shareAllData: jest.fn() }))
+
+const mutableConfig = Config as { NODE_ENV?: string }
+
+const render = () => renderComponent(<Splash />)
+
+describe('Splash', () => {
+  const originalNodeEnv = mutableConfig.NODE_ENV
+
+  afterEach(() => {
+    mutableConfig.NODE_ENV = originalNodeEnv ?? 'staging'
+  })
+
+  it('renders the starting-backend splash', () => {
+    const { queryByTestId, getByText } = render()
+    expect(queryByTestId('loading')).not.toBeNull()
+    expect(getByText('Starting backend')).not.toBeNull()
+  })
+
+  describe('Share logs link (dev/alpha gate)', () => {
+    it('hides Share logs link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).toBeNull()
+    })
+
+    it('shows Share logs link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+
+    it('shows Share logs link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+  })
+
+  describe('Share all data link (dev/alpha gate)', () => {
+    it('hides Share all data link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).toBeNull()
+    })
+
+    it('shows Share all data link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
+    })
+
+    it('shows Share all data link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## What

Extends the dev/alpha-only **"Share logs"** and **"Share all data"** actions — added to the joining screen and community menu in #3198 / #3213 — to the **"Starting backend"** splash screen.

## Why

The backend can stall during startup *before any other screen is reachable*. When that happens the "Starting backend" splash is the only thing the user sees, so an alpha/dev tester has no way to capture diagnostics — they can't reach the joining screen or the community context menu where the existing share helpers live. This puts the same helpers on the one screen they're stuck on.

## Changes

- **`Splash.component.tsx`** — adds two `TouchableWithoutFeedback` links ("Share logs", "Share all data") below the version string, gated by `Config.NODE_ENV !== NodeEnv.Production` exactly like the `ConnectionProcess` (joining) screen. Tap handlers reuse the existing `sendLogs()` and `shareAllData()` utilities as-is — no new sharing logic.
- **`Splash.test.tsx`** (new) — dev/alpha gating tests for both links (production hides; development and staging show), modeled on `ConnectionProcess.test.tsx`.
- **`Splash.stories.tsx`** — adds a documented dev/alpha Storybook entry.
- **`CHANGELOG.md`** — notes the extension under mobile 7.2.0.

## Gating

Both links are hidden in production builds and visible only in `development` / `staging` (alpha) builds — identical to the existing joining-screen and menu items. No production exposure.

## Testing

`Splash.test.tsx` — 7 tests pass (container render + 3 gating tests per link). Existing `splash.screen.test.tsx` still loads/passes with the new transitive imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)