### PR TITLE
docs: complete 7.2.0 CHANGELOG with merged fixes since last alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,20 @@
 ### Features
 
 * Added background push notifications and background hibernation for android [#3156](https://github.com/TryQuiet/quiet/issues/3156)
+* Extends the dev/alpha-only "Share logs" and "Share all data" actions to the "Starting backend" screen (mobile) [#3241](https://github.com/TryQuiet/quiet/pull/3241)
 
 ### Fixes
 
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
 * Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)
+* Fixed Android crash on leaving a community when `google-services.json` was missing from the build [#3238](https://github.com/TryQuiet/quiet/pull/3238)
+* Fixed broken privacy policy link on the Terms of Service / Privacy Policy acceptance screen (desktop + mobile) [#3186](https://github.com/TryQuiet/quiet/pull/3186)
+* Fixed Android build failure under product flavors where react-native-config didn't load the matching `.env` file [#3197](https://github.com/TryQuiet/quiet/pull/3197)
 
 ### Chores
 
 * Refactored syncing data with QSS for modularity [#3235](https://github.com/TryQuiet/quiet/issues/3235)
+* Upgraded Electron to v32 (desktop) [#3119](https://github.com/TryQuiet/quiet/pull/3119)
 
 ## [7.1.0]
 

--- a/packages/desktop/CHANGELOG.md
+++ b/packages/desktop/CHANGELOG.md
@@ -5,15 +5,20 @@
 ### Features
 
 * Added background push notifications and background hibernation for android [#3156](https://github.com/TryQuiet/quiet/issues/3156)
+* Extends the dev/alpha-only "Share logs" and "Share all data" actions to the "Starting backend" screen (mobile) [#3241](https://github.com/TryQuiet/quiet/pull/3241)
 
 ### Fixes
 
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
 * Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)
+* Fixed Android crash on leaving a community when `google-services.json` was missing from the build [#3238](https://github.com/TryQuiet/quiet/pull/3238)
+* Fixed broken privacy policy link on the Terms of Service / Privacy Policy acceptance screen (desktop + mobile) [#3186](https://github.com/TryQuiet/quiet/pull/3186)
+* Fixed Android build failure under product flavors where react-native-config didn't load the matching `.env` file [#3197](https://github.com/TryQuiet/quiet/pull/3197)
 
 ### Chores
 
 * Refactored syncing data with QSS for modularity [#3235](https://github.com/TryQuiet/quiet/issues/3235)
+* Upgraded Electron to v32 (desktop) [#3119](https://github.com/TryQuiet/quiet/pull/3119)
 
 ## [7.1.0]
 

--- a/packages/mobile/CHANGELOG.md
+++ b/packages/mobile/CHANGELOG.md
@@ -11,10 +11,14 @@
 
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
 * Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)
+* Fixed Android crash on leaving a community when `google-services.json` was missing from the build [#3238](https://github.com/TryQuiet/quiet/pull/3238)
+* Fixed broken privacy policy link on the Terms of Service / Privacy Policy acceptance screen (desktop + mobile) [#3186](https://github.com/TryQuiet/quiet/pull/3186)
+* Fixed Android build failure under product flavors where react-native-config didn't load the matching `.env` file [#3197](https://github.com/TryQuiet/quiet/pull/3197)
 
 ### Chores
 
 * Refactored syncing data with QSS for modularity [#3235](https://github.com/TryQuiet/quiet/issues/3235)
+* Upgraded Electron to v32 (desktop) [#3119](https://github.com/TryQuiet/quiet/pull/3119)
 
 ## [7.1.0]
 


### PR DESCRIPTION
## Summary

The 7.2.0 CHANGELOG (root + per-package) was missing several entries for PRs that merged between 7.1.0 and the alpha.2 publish. This adds them so the published 7.2.0 changelog reflects what shipped.

Added (Features):
- mobile #3241 — Splash "Share logs" / "Share all data" (dev/alpha)

Added (Fixes):
- android #3238 — leave-community crash from missing Firebase config
- #3186 — broken privacy policy link on join-server acceptance screen (desktop + mobile)
- android #3197 — product-flavor `.env` not loaded by react-native-config

Added (Chores):
- desktop #3119 — Electron 32 upgrade

Deliberately omitted: the iOS Tor.framework revert (ed29237). 7.2.0 ends up on the same Tor 405.9.1 framework that 7.1.0 shipped, so the net change vs 7.1.0 is zero.

The three CHANGELOGs (root, `packages/desktop`, `packages/mobile`) are kept in sync — the historical convention is identical human-edited content across all three, with only lerna's auto-publish entries differing by package name.

## Test plan
- [ ] Skim the rendered 7.2.0 section in `CHANGELOG.md`, `packages/desktop/CHANGELOG.md`, `packages/mobile/CHANGELOG.md` and confirm everything you expect to ship in 7.2.0 is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)