### PR TITLE
Merge 7.2.0 fixes into develop

### DIFF
--- a/.github/secrets/decrypt_android_secrets.sh
+++ b/.github/secrets/decrypt_android_secrets.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Decrypt the Android Firebase config (google-services.json) and place it where the
+# Gradle build expects it: packages/mobile/android/app/. The file is gitignored and
+# stored encrypted as google-services.json.gpg.
+#
+# Safe to run on Linux CI runners: unlike decrypt_secrets.sh this does no macOS/iOS
+# tooling. decrypt_secrets.sh calls this so the iOS and Android jobs stay in sync.
+#
+# Must be run from the repository root.
+
+set -e
+
+if [ -z "$ANDROID_FIREBASE_KEY" ]; then
+  echo "ANDROID_FIREBASE_KEY is not set; skipping google-services.json decryption."
+  echo "Firebase push notifications will be unavailable; release builds fail by design."
+  exit 0
+fi
+
+gpg --quiet --batch --yes --decrypt --passphrase="$ANDROID_FIREBASE_KEY" \
+  --output ./.github/secrets/google-services.json \
+  ./.github/secrets/google-services.json.gpg
+
+cp ./.github/secrets/google-services.json ./packages/mobile/android/app/google-services.json
+
+echo "Decrypted google-services.json into packages/mobile/android/app/"

--- a/.github/secrets/decrypt_secrets.sh
+++ b/.github/secrets/decrypt_secrets.sh
@@ -6,14 +6,15 @@ gpg --quiet --batch --yes --decrypt --passphrase="$IOS_PROFILE_KEY" --output ./.
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_NSE_PROFILE_KEY" --output ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision.gpg
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_CERTIFICATE_KEY" --output ./.github/secrets/Certificates.p12 ./.github/secrets/Certificates.p12.gpg
 gpg --quiet --batch --yes --decrypt --passphrase="$IOS_FIREBASE_KEY" --output ./.github/secrets/GoogleService-Info.plist ./.github/secrets/GoogleService-Info.plist.gpg
-gpg --quiet --batch --yes --decrypt --passphrase="$ANDROID_FIREBASE_KEY" --output ./.github/secrets/google-services.json ./.github/secrets/google-services.json.gpg
+
+# Android Firebase config (google-services.json) - shared with the Android workflows.
+./.github/secrets/decrypt_android_secrets.sh
 
 mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
 
 cp ./.github/secrets/match_AppStore_comquietmobile.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/762df280-302c-4336-a56d-c74914169337.mobileprovision
 cp ./.github/secrets/match_AppStore_comquietmobile_QuietNotificationServiceExtension.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/247b3945-4f28-4ef1-b722-e98fb3fb59f7.mobileprovision
 cp ./.github/secrets/GoogleService-Info.plist ./packages/mobile/ios/GoogleService-Info.plist
-cp ./.github/secrets/google-services.json ./packages/mobile/android/app/google-services.json
 
 security create-keychain -p "" build.keychain
 security import ./.github/secrets/Certificates.p12 -t agg -k ~/Library/Keychains/build.keychain -P "$IOS_CERTIFICATE_KEY" -A

--- a/.github/workflows/mobile-build-apk.yml
+++ b/.github/workflows/mobile-build-apk.yml
@@ -86,6 +86,11 @@ jobs:
       - name: "Decode keystore"
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
+
       - name: "Build .apk"
         env:
           ENVFILE: ../.env.production
@@ -251,6 +256,11 @@ jobs:
       - name: "Prepare ndk configuration"
         run: |
           printf "NDK_PATH=${{ steps.setup-ndk.outputs.ndk-path }}\n" > $HOME/.gradle/gradle.properties
+
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
 
       - name: "Build debug .apk"
         run: cd ./packages/mobile/android && ENVFILE=../.env.staging ./gradlew assembleStandardDebug

--- a/.github/workflows/mobile-deploy-android.yml
+++ b/.github/workflows/mobile-deploy-android.yml
@@ -73,6 +73,11 @@ jobs:
       - name: "Decode keystore"
         run: echo ${{ SECRETS.GOOGLE_KEYSTORE }} | base64 --decode > ./packages/mobile/android/app/quietmobile.keystore
 
+      - name: "Decrypt Firebase config (google-services.json)"
+        run: ./.github/secrets/decrypt_android_secrets.sh
+        env:
+          ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
+
       - name: "Build .aab"
         env:
           ENVFILE: ../.env.production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,27 @@
 
 ### Features
 
+* Adds private channels with modifiable membership (no removals) to desktop [#3155](https://github.com/TryQuiet/quiet/issues/3155)
+
+## [7.2.0]
+
+### Features
+
 * Added background push notifications and background hibernation for android [#3156](https://github.com/TryQuiet/quiet/issues/3156)
+* Extends the dev/alpha-only "Share logs" and "Share all data" actions to the "Starting backend" screen (mobile) [#3241](https://github.com/TryQuiet/quiet/pull/3241)
 
 ### Fixes
 
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
 * Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)
+* Fixed Android crash on leaving a community when `google-services.json` was missing from the build [#3238](https://github.com/TryQuiet/quiet/pull/3238)
+* Fixed broken privacy policy link on the Terms of Service / Privacy Policy acceptance screen (desktop + mobile) [#3186](https://github.com/TryQuiet/quiet/pull/3186)
+* Fixed Android build failure under product flavors where react-native-config didn't load the matching `.env` file [#3197](https://github.com/TryQuiet/quiet/pull/3197)
 
 ### Chores
 
 * Refactored syncing data with QSS for modularity [#3235](https://github.com/TryQuiet/quiet/issues/3235)
+* Upgraded Electron to v32 (desktop) [#3119](https://github.com/TryQuiet/quiet/pull/3119)
 
 ## [7.1.0]
 
@@ -30,7 +41,6 @@
 
 * Registers APNS token with push notifications service [#3080](https://github.com/TryQuiet/quiet/issues/3080)
 * Adds push notification service [#3086](https://github.com/TryQuiet/quiet/issues/3086)
-* Adds private channels [#3155](https://github.com/TryQuiet/quiet/issues/3155)
 
 ### Fixes
 

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -343,7 +343,15 @@ apply from: project(":react-native-config").projectDir.getPath() + "/dotenv.grad
 if (googleServicesJsonPath.exists()) {
     apply plugin: "com.google.gms.google-services"
 } else {
-    logger.warn("google-services.json not found in packages/mobile/android/app; Firebase runtime setup will remain incomplete until it is added.")
+    def buildingRelease = gradle.startParameter.taskNames.any { it.toLowerCase().contains("release") }
+    if (buildingRelease) {
+        throw new GradleException(
+            "google-services.json not found in packages/mobile/android/app. Release builds " +
+            "require it for Firebase push notifications. Run ./.github/secrets/decrypt_android_secrets.sh " +
+            "(needs the ANDROID_FIREBASE_KEY passphrase) or add the file manually before building."
+        )
+    }
+    logger.warn("google-services.json not found in packages/mobile/android/app; Firebase push notifications will be unavailable in this build.")
 }
 
 repositories {

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Push/FirebaseMessagingModule.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Push/FirebaseMessagingModule.kt
@@ -12,19 +12,31 @@ class FirebaseMessagingModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun getToken(promise: Promise) {
-        FirebaseMessaging.getInstance().token
-            .addOnSuccessListener { token -> promise.resolve(token) }
-            .addOnFailureListener { error ->
-                promise.reject("token_error", "Failed to get FCM token: ${error.localizedMessage}", error)
-            }
+        try {
+            FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token -> promise.resolve(token) }
+                .addOnFailureListener { error ->
+                    promise.reject("token_error", "Failed to get FCM token: ${error.localizedMessage}", error)
+                }
+        } catch (error: Throwable) {
+            // FirebaseMessaging.getInstance() throws synchronously (e.g. IllegalStateException
+            // "Default FirebaseApp is not initialized") when the build has no google-services.json.
+            // Reject the promise instead of letting the exception crash the app.
+            promise.reject("token_error", "Firebase is not available: ${error.localizedMessage}", error)
+        }
     }
 
     @ReactMethod
     fun deleteToken(promise: Promise) {
-        FirebaseMessaging.getInstance().deleteToken()
-            .addOnSuccessListener { promise.resolve(null) }
-            .addOnFailureListener { error ->
-                promise.reject("delete_error", "Failed to delete FCM token: ${error.localizedMessage}", error)
-            }
+        try {
+            FirebaseMessaging.getInstance().deleteToken()
+                .addOnSuccessListener { promise.resolve(null) }
+                .addOnFailureListener { error ->
+                    promise.reject("delete_error", "Failed to delete FCM token: ${error.localizedMessage}", error)
+                }
+        } catch (error: Throwable) {
+            // See getToken(): getInstance() can throw before any listener is attached.
+            promise.reject("delete_error", "Firebase is not available: ${error.localizedMessage}", error)
+        }
     }
 }

--- a/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
@@ -481,5 +481,96 @@ exports[`Spinner component renders loading screen if not ready 1`] = `
       v 1.0.0
     </Text>
   </View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "gap": 16,
+      }
+    }
+  >
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-logs-link"
+      verticalTextAlign="center"
+    >
+      Share logs
+    </Text>
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-all-data-link"
+      verticalTextAlign="center"
+    >
+      Share all data
+    </Text>
+  </View>
 </View>
 `;

--- a/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
@@ -481,5 +481,96 @@ exports[`JoinCommunity component renders loading screen if not ready 1`] = `
       v 1.0.0
     </Text>
   </View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "gap": 16,
+      }
+    }
+  >
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-logs-link"
+      verticalTextAlign="center"
+    >
+      Share logs
+    </Text>
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-all-data-link"
+      verticalTextAlign="center"
+    >
+      Share all data
+    </Text>
+  </View>
 </View>
 `;

--- a/packages/mobile/src/components/Splash/Splash.component.tsx
+++ b/packages/mobile/src/components/Splash/Splash.component.tsx
@@ -1,9 +1,13 @@
 import React, { FC } from 'react'
-import { Image, View } from 'react-native'
+import { Image, View, TouchableWithoutFeedback } from 'react-native'
 import deviceInfoModule from 'react-native-device-info'
+import Config from 'react-native-config'
 import { Typography } from '../Typography/Typography.component'
 import { defaultTheme } from '../../styles/themes/default.theme'
 import { icons } from '../../assets'
+import { NodeEnv } from '../../utils/const/NodeEnv.enum'
+import { sendLogs } from '../../utils/sendLogs'
+import { shareAllData } from '../../utils/shareAllData'
 
 export const Splash: FC = () => {
   return (
@@ -40,6 +44,27 @@ export const Splash: FC = () => {
           {`v ${deviceInfoModule.getVersion()}`}
         </Typography>
       </View>
+
+      {/* Starting the backend can stall before any other screen is reachable,
+          which is exactly when alpha/dev testers need to grab diagnostics.
+          Surface the same dev/alpha-only "Share logs" / "Share all data"
+          helpers used on the joining screen (PR #3213), gated identically to
+          non-production builds via Config.NODE_ENV. */}
+      {Config.NODE_ENV !== NodeEnv.Production && (
+        <View style={{ gap: 16, alignItems: 'center' }}>
+          <TouchableWithoutFeedback onPress={() => void sendLogs()} testID={'share-logs-link'}>
+            <Typography fontSize={14} style={{ color: '#2373EA' }}>
+              Share logs
+            </Typography>
+          </TouchableWithoutFeedback>
+
+          <TouchableWithoutFeedback onPress={() => void shareAllData()} testID={'share-all-data-link'}>
+            <Typography fontSize={14} style={{ color: '#2373EA' }}>
+              Share all data
+            </Typography>
+          </TouchableWithoutFeedback>
+        </View>
+      )}
     </View>
   )
 }

--- a/packages/mobile/src/components/Splash/Splash.stories.tsx
+++ b/packages/mobile/src/components/Splash/Splash.stories.tsx
@@ -3,4 +3,13 @@ import React from 'react'
 
 import { Splash } from './Splash.component'
 
-storiesOf('Splash', module).add('Default', () => <Splash />)
+storiesOf('Splash', module)
+  .add('Default', () => <Splash />)
+  .add('With Share logs / Share all data links (dev/alpha)', () => (
+    // The "Share logs" and "Share all data" links are gated to non-production
+    // builds via Config.NODE_ENV. Running Storybook with any non-production
+    // NODE_ENV renders both links below the version string. Tapping "Share
+    // logs" bundles cached log files; "Share all data" zips the local Quiet
+    // data directory plus on-device logs. Both open the native share sheet.
+    <Splash />
+  ))

--- a/packages/mobile/src/components/Splash/Splash.test.tsx
+++ b/packages/mobile/src/components/Splash/Splash.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import Config from 'react-native-config'
+import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
+import { Splash } from './Splash.component'
+
+jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
+jest.mock('../../utils/sendLogs', () => ({ sendLogs: jest.fn() }))
+jest.mock('../../utils/shareAllData', () => ({ shareAllData: jest.fn() }))
+
+const mutableConfig = Config as { NODE_ENV?: string }
+
+const render = () => renderComponent(<Splash />)
+
+describe('Splash', () => {
+  const originalNodeEnv = mutableConfig.NODE_ENV
+
+  afterEach(() => {
+    mutableConfig.NODE_ENV = originalNodeEnv ?? 'staging'
+  })
+
+  it('renders the starting-backend splash', () => {
+    const { queryByTestId, getByText } = render()
+    expect(queryByTestId('loading')).not.toBeNull()
+    expect(getByText('Starting backend')).not.toBeNull()
+  })
+
+  describe('Share logs link (dev/alpha gate)', () => {
+    it('hides Share logs link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).toBeNull()
+    })
+
+    it('shows Share logs link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+
+    it('shows Share logs link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-logs-link')).not.toBeNull()
+    })
+  })
+
+  describe('Share all data link (dev/alpha gate)', () => {
+    it('hides Share all data link in production builds', () => {
+      mutableConfig.NODE_ENV = 'production'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).toBeNull()
+    })
+
+    it('shows Share all data link in development builds', () => {
+      mutableConfig.NODE_ENV = 'development'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
+    })
+
+    it('shows Share all data link in staging/alpha builds', () => {
+      mutableConfig.NODE_ENV = 'staging'
+      const { queryByTestId } = render()
+      expect(queryByTestId('share-all-data-link')).not.toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Brings the two real fixes that landed on `7.2.0` after it diverged from `develop` back into `develop`:

- **#3238** — `fix(android): stop leave-community crash from missing Firebase config` (originally cherry-picked from #3236)
- **#3241** — `feat(mobile): dev/alpha-only "Share logs" + "Share all data" on Starting backend screen`

Also restructures root `CHANGELOG.md` so the headings reflect what actually shipped where:

- Renames the existing `[unreleased]` section to `[7.2.0]` and adds the five entries that landed on 7.2.0 between 7.1.0 and the alpha.2 publish (matches what merged to the release branch in #3248).
- Opens a fresh `[unreleased]` section above for post-7.2.0 work, and moves the existing `"Adds private channels [#3155]"` entry up to it from `[7.0.1]`, where it was filed by mistake in #3177.

Per-package CHANGELOGs are untouched; lerna will populate them on the next publish from develop.

## Intentionally excluded

- **iOS Tor.framework revert** (ed29237) — its own commit message states `"The upgrade remains on develop; this revert is 7.2.0-only."` 7.2.0 is shipping with Tor 405.9.1 only to debug issue #3237; develop stays on the 0.4.9.5 upgrade from #3131.
- **The lerna `Publish` / per-package `Update packages CHANGELOG.md` commits** (alpha.0/1/2) — those are 7.2.0 alpha-release bookkeeping. Develop's per-package CHANGELOGs stay at `[7.1.0]`; lerna will populate the next version when develop next publishes.

## Conflict resolution

The cherry-pick of #3241 touched `packages/mobile/CHANGELOG.md` under a `[7.2.0]` section that doesn't exist on develop. Resolved by keeping develop's per-package CHANGELOG as-is — the Splash entry is captured instead in the root `CHANGELOG.md` restructure commit.

## Test plan

- [ ] Android: leave-community on a release build without `google-services.json` no longer crashes; release jobs fail loudly if the file is missing rather than silently shipping
- [ ] Mobile: in a dev/alpha build, "Share logs" and "Share all data" links appear on the "Starting backend" Splash screen below the version string; production build hides them
- [ ] Skim `CHANGELOG.md` — `[unreleased]` lists only #3155 (private channels); `[7.2.0]` lists the 9 items that shipped in the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)