### PR TITLE
test(mobile): refresh JoinCommunity/CreateCommunity snapshots for Splash share-logs links

### DIFF
--- a/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
@@ -481,5 +481,96 @@ exports[`Spinner component renders loading screen if not ready 1`] = `
       v 1.0.0
     </Text>
   </View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "gap": 16,
+      }
+    }
+  >
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-logs-link"
+      verticalTextAlign="center"
+    >
+      Share logs
+    </Text>
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-all-data-link"
+      verticalTextAlign="center"
+    >
+      Share all data
+    </Text>
+  </View>
 </View>
 `;

--- a/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
@@ -481,5 +481,96 @@ exports[`JoinCommunity component renders loading screen if not ready 1`] = `
       v 1.0.0
     </Text>
   </View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "gap": 16,
+      }
+    }
+  >
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-logs-link"
+      verticalTextAlign="center"
+    >
+      Share logs
+    </Text>
+    <Text
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessible={true}
+      color="main"
+      focusable={true}
+      fontSize={14}
+      horizontalTextAlign="left"
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "color": "#000000",
+            "fontFamily": "Rubik-Regular",
+            "fontSize": 14,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          {
+            "color": "#2373EA",
+          },
+        ]
+      }
+      testID="share-all-data-link"
+      verticalTextAlign="center"
+    >
+      Share all data
+    </Text>
+  </View>
 </View>
 `;


### PR DESCRIPTION
## Summary

#3241 added dev/alpha-only "Share logs" / "Share all data" links to the Splash component but didn't refresh the snapshots in `JoinCommunity.test.tsx` and `CreateCommunity.test.tsx`, which both render `<Splash />` when `ready={false}`. The stale snapshots show up as failures in the mobile-test job on PRs branched from 7.2.0 (e.g. #3249).

This applies the same snapshot refresh on the release branch so its CI is clean too.

Diff is purely additive — exact same `<View>` / share-logs / share-data block that `<Splash />` now renders in dev/alpha.

## Test plan
- [ ] `cd packages/mobile && npx jest src/components/JoinCommunity src/components/CreateCommunity` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)