### PR TITLE
Update Website Links to 7.2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,24 +130,24 @@
       <p>Quiet is available for all major platforms. (And eventually the web, too!)</p>
       <div class="badges" style="align-items:flex-start;">
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.1.0/Quiet-7.1.0-arm64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.2.0/Quiet-7.2.0-arm64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Apple Silicon) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Apple Silicon</p>
         </div>
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.1.0/Quiet-7.1.0-x64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.2.0/Quiet-7.2.0-x64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Intel) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Intel</p>
         </div>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.1.0/Quiet.Setup.7.1.0.exe"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.2.0/Quiet.Setup.7.2.0.exe"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.1.0/Quiet-7.1.0.AppImage"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.2.0/Quiet-7.2.0.AppImage"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
         </a>
@@ -161,7 +161,7 @@
         <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
           <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%407.1.0/app-standard-release.apk"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%407.2.0/app-standard-release.apk"
           class="qt-hero-badge w-inline-block">
           <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download">
         </a>


### PR DESCRIPTION
Updates the 5 download links on https://tryquiet.org/#Downloads from 7.1.0 → 7.2.0:

- Quiet-7.2.0-arm64.dmg (macOS Apple Silicon)
- Quiet-7.2.0-x64.dmg (macOS Intel)
- Quiet.Setup.7.2.0.exe (Windows)
- Quiet-7.2.0.AppImage (Linux)
- app-standard-release.apk (Android — mobile release tag)

All 5 target URLs verified `HTTP 200` against the published `@quiet/desktop@7.2.0` and `@quiet/mobile@7.2.0` release assets.

Per [PUBLISHING.md#L80](https://github.com/TryQuiet/quiet/blob/develop/PUBLISHING.md#L80); follows the shape of #2605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)