### PR TITLE
Android Foreground Notification Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 * Fix: leaving a community now purges uploaded and downloaded files; if the leave is interrupted (process killed, OS-terminated, power loss), the purge is finished on the next app launch [#3225](https://github.com/TryQuiet/quiet/issues/3225)
+* Fixed android not requesting permission for foreground push notifications [#3254](https://github.com/TryQuiet/quiet/issues/3254)
 
 ## [7.2.0]
 

--- a/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.test.ts
+++ b/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.test.ts
@@ -1,14 +1,111 @@
-import { NativeModules, Platform } from 'react-native'
+jest.mock('../nativeServices/events/nativeEventEmitter', () => ({
+  __esModule: true,
+  default: {
+    addListener: jest.fn(),
+  },
+}))
+
+import { AppState, NativeModules, Platform } from 'react-native'
+import { runSaga, stdChannel } from 'redux-saga'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call } from 'redux-saga-test-plan/matchers'
+import waitForExpect from 'wait-for-expect'
+import { communities, pushNotifications as stateManagerPushNotifications } from '@quiet/state-manager'
 
-import { deleteNotificationTokenSaga, hasGrantedNotificationPermissionSaga } from './pushNotifications.master.saga'
+import {
+  deleteNotificationTokenSaga,
+  hasGrantedNotificationPermissionSaga,
+  pushNotificationsMasterSaga,
+} from './pushNotifications.master.saga'
 import Config from 'react-native-config'
+import nativeEventEmitter from '../nativeServices/events/nativeEventEmitter'
+import { InitState } from '../init/init.slice'
+import { StoreKeys } from '../store.keys'
+import { NotificationPermissionStatus } from './pushNotifications.types'
+import { PushNotificationsState, pushNotificationsActions } from './pushNotifications.slice'
+
+const NOTIFICATION_PERMISSION_RESULT = 'notificationPermissionResult'
+const DEVICE_TOKEN_RECEIVED = 'deviceTokenReceived'
+const nativeEventHandlers = new Map<string, (payload: unknown) => void>()
 
 describe('pushNotificationMasterSaga', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
     NativeModules.FirebaseMessagingModule.deleteToken.mockReset()
+    NativeModules.FirebaseMessagingModule.getToken.mockReset()
+    NativeModules.CommunicationModule.requestNotificationPermission.mockReset()
+    NativeModules.CommunicationModule.checkNotificationPermission.mockReset()
+    nativeEventHandlers.clear()
+    ;(nativeEventEmitter.addListener as jest.Mock).mockReset()
+    ;(nativeEventEmitter.addListener as jest.Mock).mockImplementation(
+      (eventName: string, handler: (payload: unknown) => void) => {
+        nativeEventHandlers.set(eventName, handler)
+        return { remove: jest.fn() }
+      }
+    )
+    jest.spyOn(AppState, 'addEventListener').mockReturnValue({ remove: jest.fn() } as any)
+  })
+
+  it('requests Android notification permission when qps is disabled but blocks Firebase token flows', async () => {
+    Platform.OS = 'android'
+    Config.QPS_ALLOWED = 'false'
+    NativeModules.FirebaseMessagingModule.getToken.mockResolvedValue('current-token')
+
+    const channel = stdChannel()
+    const dispatched: Array<{ type: string; payload?: unknown }> = []
+    const state = {
+      [StoreKeys.Init]: {
+        ...new InitState(),
+        isWebsocketConnected: true,
+      },
+      [StoreKeys.PushNotifications]: {
+        ...new PushNotificationsState(),
+        permissionRequested: false,
+        permissionStatus: NotificationPermissionStatus.Granted,
+      },
+    }
+    const task = runSaga(
+      {
+        channel,
+        dispatch: action => {
+          dispatched.push(action)
+          channel.put(action)
+        },
+        getState: () => state,
+      },
+      pushNotificationsMasterSaga
+    )
+
+    try {
+      await waitForExpect(() => {
+        expect(NativeModules.CommunicationModule.requestNotificationPermission).toHaveBeenCalledTimes(1)
+        expect(nativeEventHandlers.get(NOTIFICATION_PERMISSION_RESULT)).toBeDefined()
+        expect(nativeEventHandlers.get(DEVICE_TOKEN_RECEIVED)).toBeDefined()
+      })
+
+      channel.put(communities.actions.setCurrentCommunity('community-id'))
+      nativeEventHandlers.get(NOTIFICATION_PERMISSION_RESULT)?.({ status: NotificationPermissionStatus.Granted })
+      nativeEventHandlers.get(DEVICE_TOKEN_RECEIVED)?.({ token: 'live-token' })
+
+      await waitForExpect(() => {
+        expect(dispatched).toEqual(
+          expect.arrayContaining([pushNotificationsActions.setPermissionStatus(NotificationPermissionStatus.Granted)])
+        )
+      })
+
+      expect(NativeModules.FirebaseMessagingModule.getToken).not.toHaveBeenCalled()
+      expect(NativeModules.FirebaseMessagingModule.deleteToken).not.toHaveBeenCalled()
+      expect(dispatched).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: stateManagerPushNotifications.actions.sendDeviceTokenToBackend.type,
+          }),
+        ])
+      )
+    } finally {
+      task.cancel()
+      await task.toPromise()
+    }
   })
 
   describe('deleteNotificationTokenSaga', () => {

--- a/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.test.ts
+++ b/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.test.ts
@@ -27,6 +27,7 @@ import { PushNotificationsState, pushNotificationsActions } from './pushNotifica
 const NOTIFICATION_PERMISSION_RESULT = 'notificationPermissionResult'
 const DEVICE_TOKEN_RECEIVED = 'deviceTokenReceived'
 const nativeEventHandlers = new Map<string, (payload: unknown) => void>()
+type DispatchedAction = { type: string; payload?: unknown }
 
 describe('pushNotificationMasterSaga', () => {
   beforeEach(() => {
@@ -52,7 +53,7 @@ describe('pushNotificationMasterSaga', () => {
     NativeModules.FirebaseMessagingModule.getToken.mockResolvedValue('current-token')
 
     const channel = stdChannel()
-    const dispatched: Array<{ type: string; payload?: unknown }> = []
+    const dispatched: DispatchedAction[] = []
     const state = {
       [StoreKeys.Init]: {
         ...new InitState(),
@@ -68,8 +69,11 @@ describe('pushNotificationMasterSaga', () => {
       {
         channel,
         dispatch: action => {
-          dispatched.push(action)
-          channel.put(action)
+          if (action && typeof action === 'object' && 'type' in action) {
+            const dispatchedAction = action as DispatchedAction
+            dispatched.push(dispatchedAction)
+            channel.put(dispatchedAction)
+          }
         },
         getState: () => state,
       },

--- a/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.ts
+++ b/packages/mobile/src/store/pushNotifications/pushNotifications.master.saga.ts
@@ -14,8 +14,6 @@ import { communities, pushNotifications } from '@quiet/state-manager'
 import { initSelectors } from '../init/init.selectors'
 import { createLogger } from '../../utils/logger'
 import Config from 'react-native-config'
-import { CompoundError } from '@quiet/types'
-import { nativeServicesActions } from '../nativeServices/nativeServices.slice'
 
 const logger = createLogger('pushNotificationsMasterSaga')
 
@@ -45,7 +43,7 @@ function* checkPermissionSaga(): Generator {
 }
 
 function* triggerPermissionRequestSaga(): Generator {
-  if (Config.QPS_ALLOWED !== 'true') {
+  if (Config.QPS_ALLOWED !== 'true' && Platform.OS !== 'android') {
     logger.info('QPS not allowed, skipping automatic permission request trigger')
     return
   }
@@ -214,6 +212,11 @@ function* watchDeviceToken(): Generator {
   try {
     while (true) {
       const { token } = yield* take(channel)
+      if (Config.QPS_ALLOWED !== 'true') {
+        logger.info('QPS not allowed, skipping live FCM token forward')
+        continue
+      }
+
       const hasGrantedPermission = yield* call(hasGrantedNotificationPermissionSaga)
       if (!hasGrantedPermission) {
         logger.info('Skipping live FCM token forward because notification permission is not granted')
@@ -231,11 +234,6 @@ function* watchDeviceToken(): Generator {
 }
 
 export function* pushNotificationsMasterSaga(): Generator {
-  if ((Platform.OS !== 'ios' && Platform.OS !== 'android') || Config.QPS_ALLOWED !== 'true') {
-    logger.info(`Skipping push notifications saga (platform=${Platform.OS}, QPS_ALLOWED=${Config.QPS_ALLOWED})`)
-    return
-  }
-
   logger.info('pushNotificationsMasterSaga starting')
   try {
     yield* fork(watchPermissionResults)


### PR DESCRIPTION
Allows android to still request push notification permissions even with the qps flag disabled. 

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
