### PR TITLE
Fix Android Push Notification Cursor Race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 * Fix: leaving a community now purges uploaded and downloaded files; if the leave is interrupted (process killed, OS-terminated, power loss), the purge is finished on the next app launch [#3225](https://github.com/TryQuiet/quiet/issues/3225)
+* Fixes race condition with android push notifications [#3255](https://github.com/TryQuiet/quiet/issues/3255)
 
 ## [7.2.0]
 

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
@@ -151,6 +151,17 @@ public class CommunicationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public static void saveNseLastSyncSeq(String teamId, double syncSeq) {
+        if (!QuietStorage.isAppForeground()) {
+            Log.i(
+                    TAG,
+                    "Skipping NSE sync seq update from backend because app is backgrounded. Firebase service will update. teamId="
+                            + teamId
+                            + " syncSeq="
+                            + (long) syncSeq
+            );
+            return;
+        }
+
         QuietStorage.saveLastSyncSeq((long) syncSeq, teamId);
     }
 


### PR DESCRIPTION
Fixes a problem where the log cursor would race between the backend and the native code and cause dropped push notifications.

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
