### PR TITLE
[codex] Add channel membership auth PoC

### DIFF
--- a/packages/backend/src/nest/auth/services/roles/channel.service.spec.ts
+++ b/packages/backend/src/nest/auth/services/roles/channel.service.spec.ts
@@ -103,3 +103,62 @@ describe('channels', () => {
     expect(adminSigChain.channels.memberInChannel(secondSigChain.context.user.userId, channelId)).toBe(true)
   })
 })
+
+describe('channel membership authorization PoC', () => {
+  const loadMemberFromAdminGraph = (adminChain: SigChain, memberChain: SigChain): void => {
+    const teamKeyring = adminChain.team!.teamKeyring()
+    const loadedTeam = new Team({
+      source: adminChain.save(),
+      context: {
+        device: memberChain.context.device,
+        user: memberChain.user,
+      },
+      teamKeyring,
+    })
+    loadedTeam.join(teamKeyring)
+    memberChain.context = {
+      device: memberChain.context.device,
+      team: loadedTeam,
+      user: memberChain.user,
+    } as MemberContext
+  }
+
+  const admitMember = (adminChain: SigChain, username: string): SigChain => {
+    const invite = adminChain.invites.createUserInvite()
+    const memberChain = SigChain.createFromInvite(username, invite.seed)
+    adminChain.invites.admitMemberFromInvite(
+      generateProof(invite.seed),
+      username,
+      memberChain.context.user.userId,
+      redactKeys(memberChain.context.user.keys)
+    )
+    loadMemberFromAdminGraph(adminChain, memberChain)
+    return memberChain
+  }
+
+  it('accepts a non-owner channel member adding another member when the backend owner check is bypassed', () => {
+    const owner = SigChain.create('test', 'owner')
+    const channelId = 'owner-only-channel'
+    const channelRoleName = owner.channels.create(channelId)
+    const nonOwner = admitMember(owner, 'non-owner')
+    const addedByNonOwner = admitMember(owner, 'added-by-non-owner')
+
+    expect(owner.roles.amIAdmin()).toBe(true)
+    expect(nonOwner.roles.amIAdmin()).toBe(false)
+    expect(owner.team!.roles(channelRoleName).createdBy).toBe(owner.user.userId)
+    expect(owner.channels.memberInChannel(addedByNonOwner.user.userId, channelId)).toBe(false)
+
+    owner.channels.addMember(nonOwner.user.userId, channelId)
+    nonOwner.team!.merge(owner.team!.graph)
+    expect(nonOwner.channels.amIMemberOfChannel(channelId)).toBe(true)
+
+    nonOwner.channels.addMember(addedByNonOwner.user.userId, channelId)
+
+    owner.team!.merge(nonOwner.team!.graph)
+    addedByNonOwner.team!.merge(nonOwner.team!.graph)
+
+    expect(owner.channels.memberInChannel(addedByNonOwner.user.userId, channelId)).toBe(true)
+    expect(addedByNonOwner.channels.amIMemberOfChannel(channelId)).toBe(true)
+    expect(addedByNonOwner.team!.decrypt(owner.team!.encrypt('private message', channelRoleName))).toBe('private message')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a focused PoC test showing that, once the backend owner check is bypassed, a non-owner private-channel member can add another member to the channel role and have that change accepted after LFA graph merge.

The test also verifies that the newly added member receives usable channel role keys by decrypting a role-scoped message after the merge.

## Why

PR #3299 constrains channel-member additions at the backend/UI path, but the underlying LFA `ADD_MEMBER_ROLE` validation accepts assignments to other users. This test documents that mismatch in shared state.

## Validation

Ran the focused backend spec under the repo-supported Node runtime:

```sh
NODE_OPTIONS="--experimental-vm-modules" DEBUG=ipfs:*,backend:* npx -y -p node@20.20.1 node node_modules/jest/bin/jest.js --runInBand --verbose --testPathIgnorePatterns=".src/(!?nodeTest*)|(.node_modules*)" --detectOpenHandles --forceExit src/nest/auth/services/roles/channel.service.spec.ts
```

Result: 11 passed.