### PR TITLE
Update website links to 7.3.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,24 +130,24 @@
       <p>Quiet is available for all major platforms. (And eventually the web, too!)</p>
       <div class="badges" style="align-items:flex-start;">
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.0/Quiet-7.3.0-arm64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.3/Quiet-7.3.3-arm64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Apple Silicon) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Apple Silicon</p>
         </div>
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.0/Quiet-7.3.0-x64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.3/Quiet-7.3.3-x64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Intel) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Intel</p>
         </div>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.0/Quiet.Setup.7.3.0.exe"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.3/Quiet.Setup.7.3.3.exe"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.0/Quiet-7.3.0.AppImage"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%407.3.3/Quiet-7.3.3.AppImage"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
         </a>
@@ -161,7 +161,7 @@
         <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
           <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%407.3.0/app-standard-release.apk"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%407.3.3/app-standard-release.apk"
           class="qt-hero-badge w-inline-block">
           <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download">
         </a>


### PR DESCRIPTION
Updates the download links on the [Quiet website](https://tryquiet.org/#Downloads) to point to the **7.3.3** release artifacts, per the post-release step in [PUBLISHING.md](https://github.com/TryQuiet/quiet/blob/develop/PUBLISHING.md) (example prior PR: #2605).

### Changes (`index.html`, 5 links)
| Platform | Artifact |
|----------|----------|
| macOS (Apple Silicon) | `Quiet-7.3.3-arm64.dmg` |
| macOS (Intel) | `Quiet-7.3.3-x64.dmg` |
| Windows | `Quiet.Setup.7.3.3.exe` |
| Linux | `Quiet-7.3.3.AppImage` |
| Android | `app-standard-release.apk` |

### Note on version
Targeting **7.3.3** rather than 7.3.4 because the `@quiet/desktop@7.3.4` release is currently missing both macOS `.dmg` builds (both 404), which would break the two macOS download buttons. 7.3.3 has all platforms' artifacts available. All 5 links above were verified to return HTTP 200.

The unversioned links (Google Play, TestFlight, App Store, "Get Quiet" → releases/latest) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)