### PR TITLE
Force auth joined before registering device token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 * Don't send deletion message for private channels [#3273](https://github.com/TryQuiet/quiet/issues/3273)
+* Ensure notification registration waits for auth handshake [#3289](https://github.com/TryQuiet/quiet/issues/3289)
 
 ## [7.3.0]
 

--- a/packages/backend/src/nest/auth/sigchain.service.ts
+++ b/packages/backend/src/nest/auth/sigchain.service.ts
@@ -26,6 +26,7 @@ import EventEmitter from 'events'
 import { GetChainFilter, SigchainEvents, StoredKeyType } from './types'
 import { ModuleRef } from '@nestjs/core'
 import { DeviceCredentialsUpdatedEvent, KeysUpdatedEvent } from '@quiet/types'
+import { Base58 } from '3rd-party/auth/packages/crypto/dist'
 
 @Injectable()
 export class SigChainService extends EventEmitter {
@@ -85,6 +86,14 @@ export class SigChainService extends EventEmitter {
 
   get device(): DeviceWithSecrets {
     return this.getActiveChain().device
+  }
+
+  get activeTeamId(): Base58 | undefined {
+    try {
+      return this.getActiveChain(false)?.team?.id
+    } catch {
+      return undefined
+    }
   }
 
   getActiveChain(throwError?: true | undefined): SigChain

--- a/packages/backend/src/nest/qps/qps.service.spec.ts
+++ b/packages/backend/src/nest/qps/qps.service.spec.ts
@@ -23,6 +23,13 @@ class MockSigChainService extends EventEmitter {
   get team() {
     return this.activeChain?.team
   }
+  get activeTeamId() {
+    try {
+      return this.getActiveChain(false)?.team?.id
+    } catch {
+      return undefined
+    }
+  }
   getActiveChain(throwError = true) {
     if (this.activeChain == null) {
       if (!throwError) {

--- a/packages/backend/src/nest/qps/qps.service.spec.ts
+++ b/packages/backend/src/nest/qps/qps.service.spec.ts
@@ -23,8 +23,11 @@ class MockSigChainService extends EventEmitter {
   get team() {
     return this.activeChain?.team
   }
-  getActiveChain() {
+  getActiveChain(throwError = true) {
     if (this.activeChain == null) {
+      if (!throwError) {
+        return undefined
+      }
       throw new Error('No active chain')
     }
     return this.activeChain
@@ -74,6 +77,12 @@ describe('QPSService', () => {
     payload: { ucan: 'test-ucan' },
   }
 
+  const failureResponse = {
+    ts: DateTime.utc().toMillis(),
+    status: CommunityOperationStatus.ERROR,
+    reason: 'QPS unavailable',
+  }
+
   const pushSuccessResponse = {
     ts: DateTime.utc().toMillis(),
     status: CommunityOperationStatus.SUCCESS,
@@ -85,6 +94,7 @@ describe('QPSService', () => {
     sigChainService.activeChain = {
       team: { id: TEAM_ID },
       context: { user: sigChainService.user },
+      user: sigChainService.user,
       roles: { amIMemberOfRole: (role: string) => role === RoleName.MEMBER },
     }
   }
@@ -139,13 +149,65 @@ describe('QPSService', () => {
       expect(notificationTokensStore.addToken).toHaveBeenCalledWith('test-user-id', 'test-ucan')
     })
 
-    it('still returns UCAN if storing in notification tokens store fails', async () => {
+    it('clears cached token after successful immediate registration', async () => {
+      setReady()
+
+      await qpsService.register(DEVICE_TOKEN_PAYLOAD)
+      qssService.emitEvent(QSSEvents.QSS_AUTH_JOINED, TEAM_ID)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches token for retry when storing UCAN fails', async () => {
       setReady()
       notificationTokensStore.addToken.mockRejectedValueOnce(new Error('store not initialized'))
 
       const result = await qpsService.register(DEVICE_TOKEN_PAYLOAD)
 
-      expect(result?.payload).toEqual({ ucan: 'test-ucan' })
+      expect(result).toBeUndefined()
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(1)
+      expect(notificationTokensStore.addToken).toHaveBeenCalledTimes(1)
+
+      qssService.emitEvent(QSSEvents.QSS_AUTH_JOINED, TEAM_ID)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(2)
+      expect(notificationTokensStore.addToken).toHaveBeenCalledTimes(2)
+      expect(notificationTokensStore.addToken).toHaveBeenLastCalledWith('test-user-id', 'test-ucan')
+    })
+
+    it('caches token for retry when immediate QSS registration fails', async () => {
+      setReady()
+      qssClient.sendMessage.mockResolvedValueOnce(failureResponse)
+
+      const result = await qpsService.register(DEVICE_TOKEN_PAYLOAD)
+
+      expect(result).toBe(failureResponse)
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(1)
+      expect(notificationTokensStore.addToken).not.toHaveBeenCalled()
+
+      qssService.emitEvent(QSSEvents.QSS_AUTH_JOINED, TEAM_ID)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(2)
+      expect(notificationTokensStore.addToken).toHaveBeenCalledWith('test-user-id', 'test-ucan')
+    })
+
+    it('caches token for retry when immediate QSS registration throws', async () => {
+      setReady()
+      qssClient.sendMessage.mockRejectedValueOnce(new Error('network down'))
+
+      const result = await qpsService.register(DEVICE_TOKEN_PAYLOAD)
+
+      expect(result).toBeUndefined()
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(1)
+      expect(notificationTokensStore.addToken).not.toHaveBeenCalled()
+
+      qssService.emitEvent(QSSEvents.QSS_AUTH_JOINED, TEAM_ID)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(2)
       expect(notificationTokensStore.addToken).toHaveBeenCalledWith('test-user-id', 'test-ucan')
     })
 
@@ -183,6 +245,16 @@ describe('QPSService', () => {
     it('caches token when sigchain has no member key', async () => {
       qssClient.connected = true
       sigChainService.activeChain = null
+
+      const result = await qpsService.register(DEVICE_TOKEN_PAYLOAD)
+
+      expect(result).toBeUndefined()
+      expect(qssClient.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('caches token when QSS auth is not joined for the active team', async () => {
+      setReady()
+      qssService.joinStatus.mockReturnValue(JoinStatus.NOT_STARTED)
 
       const result = await qpsService.register(DEVICE_TOKEN_PAYLOAD)
 
@@ -243,6 +315,30 @@ describe('QPSService', () => {
       await new Promise(resolve => setTimeout(resolve, 10))
 
       expect(qssClient.sendMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('flush on QSS_AUTH_JOINED', () => {
+    it('flushes cached token when QSS auth joins for the active team', async () => {
+      qssClient.connected = true
+      qssService.joinStatus.mockReturnValue(JoinStatus.NOT_STARTED)
+      sigChainService.activeChain = null
+      await qpsService.register(DEVICE_TOKEN_PAYLOAD)
+      expect(qssClient.sendMessage).not.toHaveBeenCalled()
+
+      setReady()
+      qssService.joinStatus.mockReturnValue(JoinStatus.JOINED)
+      qssService.emitEvent(QSSEvents.QSS_AUTH_JOINED, TEAM_ID)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(qssClient.sendMessage).toHaveBeenCalledTimes(1)
+      expect(qssClient.sendMessage).toHaveBeenCalledWith(
+        WebsocketEvents.REGISTER_DEVICE_TOKEN,
+        expect.objectContaining({
+          payload: { ...DEVICE_TOKEN_PAYLOAD, teamId: TEAM_ID },
+        }),
+        true
+      )
     })
   })
 

--- a/packages/backend/src/nest/qps/qps.service.ts
+++ b/packages/backend/src/nest/qps/qps.service.ts
@@ -50,8 +50,22 @@ export class QPSService implements OnModuleInit {
     return this.qpsAllowed
   }
 
+  private get activeTeamId(): Base58 | undefined {
+    try {
+      return this.sigChainService.getActiveChain(false)?.team?.id
+    } catch {
+      return undefined
+    }
+  }
+
   private get ready(): boolean {
-    return this.qssClient.connected && this._hasMemberKey()
+    const teamId = this.activeTeamId
+    return (
+      teamId != null &&
+      this.qssClient.connected &&
+      this.qssService.joinStatus(teamId) === JoinStatus.JOINED &&
+      this._hasMemberKey()
+    )
   }
 
   onModuleInit() {
@@ -60,6 +74,7 @@ export class QPSService implements OnModuleInit {
       await this.register(payload)
     })
 
+    this.qssService.on(QSSEvents.QSS_AUTH_JOINED, () => this._flushPendingToken())
     this.qssService.on(QSSEvents.QSS_FULLY_JOINED, () => this._flushPendingToken())
     this.qssClient.on(QSSEvents.QSS_CONNECTED, () => this._flushPendingToken())
     this.qssClient.on(QSSEvents.QSS_LOG_SYNCED, (teamId: string) => void this.sendBatchPush(teamId))
@@ -77,13 +92,18 @@ export class QPSService implements OnModuleInit {
       return undefined
     }
 
+    this._pendingDeviceToken = payload
+
     if (!this.ready) {
-      this.logger.info('QSS not connected or sigchain not joined, caching device token')
-      this._pendingDeviceToken = payload
+      this.logger.info('QSS not connected or signed into the active team, caching device token')
       return undefined
     }
 
-    return this._register(payload)
+    const response = await this._register(payload)
+    if (response?.status === CommunityOperationStatus.SUCCESS) {
+      this._pendingDeviceToken = undefined
+    }
+    return response
   }
 
   public async tombstoneCurrentUserNotificationTokens(): Promise<boolean> {
@@ -154,16 +174,21 @@ export class QPSService implements OnModuleInit {
   private async _flushPendingToken(): Promise<void> {
     this.logger.debug('Checking if pending device token can be flushed')
     const hasPendingToken = this._pendingDeviceToken != undefined
+    const teamId = this.activeTeamId
     const qssConnected = this.qssClient.connected
+    const qssAuthJoined = teamId != null && this.qssService.joinStatus(teamId) === JoinStatus.JOINED
     const hasMemberKey = this._hasMemberKey()
 
-    if (!hasPendingToken || !qssConnected || !hasMemberKey) {
+    if (!hasPendingToken || !qssConnected || !qssAuthJoined || !hasMemberKey) {
       const reasons: string[] = []
       if (!hasPendingToken) {
         reasons.push('no pending device token')
       }
       if (!qssConnected) {
         reasons.push('QSS not connected')
+      }
+      if (!qssAuthJoined) {
+        reasons.push(teamId == null ? 'no active team ID' : `QSS auth not joined for team ${teamId}`)
       }
       if (!hasMemberKey) {
         reasons.push('sigchain member key unavailable')
@@ -180,7 +205,7 @@ export class QPSService implements OnModuleInit {
 
     const token = this._pendingDeviceToken
     this._pendingDeviceToken = undefined
-    this.logger.info('Flushing cached device token')
+    this.logger.info(`Flushing cached device token for team ${teamId}`)
     const response = await this._register(token)
     if (response == null || response.status !== CommunityOperationStatus.SUCCESS) {
       this.logger.warn('Failed to register cached device token')
@@ -292,6 +317,12 @@ export class QPSService implements OnModuleInit {
   private async _register(payload: DeviceTokenPayload): Promise<QPSRegisterResponse | undefined> {
     this.logger.info('Registering device token')
     try {
+      const teamId = this.activeTeamId
+      if (teamId == null) {
+        this.logger.warn('Cannot register device token before active team is available')
+        return undefined
+      }
+
       const response = await this.qssClient.sendMessage<QPSRegisterResponse>(
         WebsocketEvents.REGISTER_DEVICE_TOKEN,
         {
@@ -301,7 +332,7 @@ export class QPSService implements OnModuleInit {
             deviceToken: payload.deviceToken,
             bundleId: payload.bundleId,
             platform: payload.platform,
-            teamId: this.sigChainService.team.id,
+            teamId,
           },
         } satisfies QPSRegisterMessage,
         true
@@ -314,9 +345,14 @@ export class QPSService implements OnModuleInit {
           await this.notificationTokensStore.addToken(userId, response.payload.ucan)
         } catch (err) {
           this.logger.error('Failed to store UCAN in notification tokens store', err)
-          return response
+          return undefined
         }
         return response
+      }
+
+      if (response?.status === CommunityOperationStatus.SUCCESS) {
+        this.logger.warn('QPS registration succeeded without a UCAN')
+        return undefined
       }
 
       this.logger.warn(`QPS registration failed: ${response?.reason ?? 'unknown'}`)

--- a/packages/backend/src/nest/qps/qps.service.ts
+++ b/packages/backend/src/nest/qps/qps.service.ts
@@ -50,16 +50,8 @@ export class QPSService implements OnModuleInit {
     return this.qpsAllowed
   }
 
-  private get activeTeamId(): Base58 | undefined {
-    try {
-      return this.sigChainService.getActiveChain(false)?.team?.id
-    } catch {
-      return undefined
-    }
-  }
-
   private get ready(): boolean {
-    const teamId = this.activeTeamId
+    const teamId = this.sigChainService.activeTeamId
     return (
       teamId != null &&
       this.qssClient.connected &&
@@ -174,7 +166,7 @@ export class QPSService implements OnModuleInit {
   private async _flushPendingToken(): Promise<void> {
     this.logger.debug('Checking if pending device token can be flushed')
     const hasPendingToken = this._pendingDeviceToken != undefined
-    const teamId = this.activeTeamId
+    const teamId = this.sigChainService.activeTeamId
     const qssConnected = this.qssClient.connected
     const qssAuthJoined = teamId != null && this.qssService.joinStatus(teamId) === JoinStatus.JOINED
     const hasMemberKey = this._hasMemberKey()
@@ -317,7 +309,7 @@ export class QPSService implements OnModuleInit {
   private async _register(payload: DeviceTokenPayload): Promise<QPSRegisterResponse | undefined> {
     this.logger.info('Registering device token')
     try {
-      const teamId = this.activeTeamId
+      const teamId = this.sigChainService.activeTeamId
       if (teamId == null) {
         this.logger.warn('Cannot register device token before active team is available')
         return undefined

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -183,9 +183,9 @@ export class QSSService extends EventEmitter implements OnModuleDestroy {
       `Is user now member through self-assign?`,
       sigchain.roles.memberHasRole(sigchain.context.user.userId, RoleName.MEMBER)
     )
-    this.emit(QSSEvents.QSS_FULLY_JOINED, teamId)
     this.qssAuthConnManager.markMemberRoleReady(teamId)
     this.qssSyncManager.markMemberRoleReady(teamId)
+    this.emit(QSSEvents.QSS_FULLY_JOINED, teamId)
   }
 
   private _configureEventHandlers(): void {


### PR DESCRIPTION
Allows client to conform to QSS auth boundary being implemented by corresponding server side PR

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
