### PR TITLE
Warning message on mobile

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost (1.84.0)
-  - CocoaLumberjack (3.9.0):
-    - CocoaLumberjack/Core (= 3.9.0)
-  - CocoaLumberjack/Core (3.9.0)
+  - CocoaLumberjack (3.9.1):
+    - CocoaLumberjack/Core (= 3.9.1)
+  - CocoaLumberjack/Core (3.9.1)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.3)
@@ -2033,7 +2033,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  CocoaLumberjack: 5644158777912b7de7469fa881f8a3f259c2512a
+  CocoaLumberjack: e4ba3b414dfca8c1916c6303d37f63b3a95134c6
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 23d8c5470c648a635893dc0956c6dbaead54b656
@@ -2136,7 +2136,7 @@ SPEC CHECKSUMS:
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
   Tor: 39dc71bf048312e202608eb499ca5c74e841b503
-  Yoga: 1a10502f162e8fc40ff0907c82d01cfe555d00c2
+  Yoga: 2b02f3f767761bb4ffd25b1bb56fd264be57bd6b
 
 PODFILE CHECKSUM: cfc64e6e7d6e469da4bad48f367062c5e329239f
 

--- a/packages/mobile/src/components/CreateCommunity/CreateCommunity.component.tsx
+++ b/packages/mobile/src/components/CreateCommunity/CreateCommunity.component.tsx
@@ -91,7 +91,10 @@ export const CreateCommunity: FC<CreateCommunityProps> = ({
               <Button onPress={onPress} title={'Continue'} loading={loading} />
             </View>
             <View style={{ marginTop: 32 + 12 }}>
-              <Typography fontSize={14} style={{ color: '#999999', textAlign: 'center' }}>
+              <Typography
+                fontSize={14}
+                style={{ color: defaultTheme.palette.typography.grayDark, textAlign: 'center' }}
+              >
                 {"Quiet is in beta and shouldn't be used for activities requiring security."}
               </Typography>
             </View>

--- a/packages/mobile/src/components/CreateCommunity/CreateCommunity.component.tsx
+++ b/packages/mobile/src/components/CreateCommunity/CreateCommunity.component.tsx
@@ -90,6 +90,11 @@ export const CreateCommunity: FC<CreateCommunityProps> = ({
             <View style={{ marginTop: 32 + 12 }}>
               <Button onPress={onPress} title={'Continue'} loading={loading} />
             </View>
+            <View style={{ marginTop: 32 + 12 }}>
+              <Typography fontSize={14} style={{ color: '#999999', textAlign: 'center' }}>
+                {"Quiet is in beta and shouldn't be used for activities requiring security."}
+              </Typography>
+            </View>
           </KeyboardAvoidingView>
         </View>
       ) : (

--- a/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/CreateCommunity/__tests__/__snapshots__/CreateCommunity.test.tsx.snap
@@ -382,6 +382,37 @@ exports[`Spinner component renders component 1`] = `
         </Text>
       </View>
     </View>
+    <View
+      style={
+        {
+          "marginTop": 44,
+        }
+      }
+    >
+      <Text
+        color="main"
+        fontSize={14}
+        horizontalTextAlign="left"
+        style={
+          [
+            {
+              "color": "#000000",
+              "fontFamily": "Rubik-Regular",
+              "fontSize": 14,
+              "textAlign": "left",
+              "textAlignVertical": "center",
+            },
+            {
+              "color": "#999999",
+              "textAlign": "center",
+            },
+          ]
+        }
+        verticalTextAlign="center"
+      >
+        Quiet is in beta and shouldn't be used for activities requiring security.
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
+++ b/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
@@ -124,7 +124,10 @@ export const JoinCommunity: FC<JoinCommunityProps> = ({
               <Button onPress={onPress} title={'Continue'} loading={loading} />
             </View>
             <View style={{ marginTop: 32 + 12 }}>
-              <Typography fontSize={14} style={{ color: '#999999', textAlign: 'center' }}>
+              <Typography
+                fontSize={14}
+                style={{ color: defaultTheme.palette.typography.grayDark, textAlign: 'center' }}
+              >
                 {"Quiet is in beta and shouldn't be used for acticdvities requiring security."}
               </Typography>
             </View>

--- a/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
+++ b/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
@@ -123,6 +123,11 @@ export const JoinCommunity: FC<JoinCommunityProps> = ({
             <View style={{ marginTop: 32 + 12 }}>
               <Button onPress={onPress} title={'Continue'} loading={loading} />
             </View>
+            <View style={{ marginTop: 32 + 12 }}>
+              <Typography fontSize={14} style={{ color: '#999999', textAlign: 'center' }}>
+                {"Quiet is in beta and shouldn't be used for acticdvities requiring security."}
+              </Typography>
+            </View>
           </KeyboardAvoidingView>
         </View>
       ) : (

--- a/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`JoinCommunity component renders component 1`] = `
         }
         verticalTextAlign="center"
       >
-        Quiet is in beta and shouldn't be used for activities requiring security.
+        Quiet is in beta and shouldn't be used for acticdvities requiring security.
       </Text>
     </View>
   </View>

--- a/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
+++ b/packages/mobile/src/components/JoinCommunity/__tests__/__snapshots__/JoinCommunity.test.tsx.snap
@@ -382,6 +382,37 @@ exports[`JoinCommunity component renders component 1`] = `
         </Text>
       </View>
     </View>
+    <View
+      style={
+        {
+          "marginTop": 44,
+        }
+      }
+    >
+      <Text
+        color="main"
+        fontSize={14}
+        horizontalTextAlign="left"
+        style={
+          [
+            {
+              "color": "#000000",
+              "fontFamily": "Rubik-Regular",
+              "fontSize": 14,
+              "textAlign": "left",
+              "textAlignVertical": "center",
+            },
+            {
+              "color": "#999999",
+              "textAlign": "center",
+            },
+          ]
+        }
+        verticalTextAlign="center"
+      >
+        Quiet is in beta and shouldn't be used for activities requiring security.
+      </Text>
+    </View>
   </View>
 </View>
 `;


### PR DESCRIPTION
- Adding a warning message on Join Community and Create Community views as per https://github.com/TryQuiet/quiet/issues/2588
(Some modifications will be made in how it looks, as it was initially created for a different view, but it conveys the message for now.)
- To run Xcode, I had to change the version of one of the PODS: CocoaLumberjack (3.9.0) to CocoaLumberjack (3.9.1) - checked with Isla, and it should be good.
- Snapshot tests for both views are updated.


### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests

