### PR TITLE
[codex] clean up PR 3324 nits

### DIFF
--- a/packages/backend/src/nest/auth/sigchain.ts
+++ b/packages/backend/src/nest/auth/sigchain.ts
@@ -15,14 +15,12 @@ import EventEmitter from 'events'
 import { LockboxService } from './services/crypto/lockbox.service'
 import { ChannelService } from './services/roles/channel.service'
 import { LFAEvents, RANDOM_TEAM_NAME_LENGTH, SigchainEvents } from './types'
-import { Serializer } from '../common/serializer.service'
 import { randomKey } from '@localfirst/crypto'
 
 const logger = createLogger('auth:sigchain')
 const lfaLogger = createLogger('localfirst')
 
 class SigChain extends EventEmitter {
-  private static serializer = new Serializer()
   private _context: auth.MemberContext | auth.InviteeMemberContext
   private _users: UserService | null = null
   private _devices: DeviceService | null = null

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.spec.ts
@@ -410,7 +410,7 @@ describe('ConnectionsManagerService', () => {
     const resetStateSpy = jest.spyOn(connectionsManagerService, 'resetState').mockResolvedValue()
     const localDbOpenSpy = jest.spyOn(localDbService, 'open').mockResolvedValue()
     const closeSocketSpy = jest.spyOn(connectionsManagerService, 'closeSocket').mockResolvedValue()
-    sigChainService.activeChainTeamId = community.name
+    sigChainService.activeChainTeamId = community.teamId
 
     await (connectionsManagerService as any).erasePreviousCommunityArtifacts()
 
@@ -581,7 +581,7 @@ describe('ConnectionsManagerService', () => {
     jest.spyOn(connectionsManagerService['tor'], 'resetHiddenServices').mockImplementation(() => {})
     jest.spyOn(connectionsManagerService, 'resetState').mockResolvedValue()
     jest.spyOn(localDbService, 'open').mockResolvedValue()
-    sigChainService.activeChainTeamId = community.name
+    sigChainService.activeChainTeamId = community.teamId
 
     await (connectionsManagerService as any).erasePreviousCommunityArtifacts()
 

--- a/packages/backend/src/nest/connections-manager/connections-manager.service.ts
+++ b/packages/backend/src/nest/connections-manager/connections-manager.service.ts
@@ -36,7 +36,6 @@ import {
   Identity,
   PeerId as QuietPeerId,
   InvitationDataVersion,
-  InvitationDataV2,
   PermissionsError,
   CommunityOwnership,
   InitCommunityPayload,
@@ -82,7 +81,6 @@ import { SigchainEvents } from '../auth/types'
 import { QPSService } from '../qps/qps.service'
 import { CaptchaService } from '../captcha/captcha.service'
 import { SigChain } from '../auth/sigchain'
-import { teamKeyring } from '3rd-party/auth/packages/auth/dist/team/selectors'
 
 /**
  * A monolith service that handles lots of events received from the state-manager.

--- a/packages/backend/src/nest/qss/qss.service.ts
+++ b/packages/backend/src/nest/qss/qss.service.ts
@@ -32,14 +32,7 @@ import { SigChainService } from '../auth/sigchain.service'
 import { RoleName } from '../auth/services/roles/roles'
 import { LocalDbService } from '../local-db/local-db.service'
 import { QSS_RECONNECT_BACKOFF_FACTOR, QSS_RECONNECT_DELAY_MS, QSS_RECONNECT_MAX_DELAY_MS } from './qss.const'
-import {
-  CompoundError,
-  InvitationDataV3,
-  NseQssUrlUpdatedEvent,
-  SocketActions,
-  SocketEvents,
-  type InvitationDataV5,
-} from '@quiet/types'
+import { CompoundError, NseQssUrlUpdatedEvent, SocketActions, SocketEvents, type InvitationDataV5 } from '@quiet/types'
 import { LocalDbEvents } from '../local-db/local-db.types'
 import { SocketService } from '../socket/socket.service'
 import { QSSSyncManager } from './qss-sync-manager.service'

--- a/packages/common/src/invitationLink/invitationLink.test.ts
+++ b/packages/common/src/invitationLink/invitationLink.test.ts
@@ -1,12 +1,4 @@
-import {
-  InvitationDataV1,
-  InvitationDataV2,
-  InvitationDataV3,
-  InvitationDataVersion,
-  InvitationPair,
-  type InvitationDataV4,
-  type InvitationDataV5,
-} from '@quiet/types'
+import { InvitationDataVersion, InvitationPair, type InvitationDataV4, type InvitationDataV5 } from '@quiet/types'
 import {
   argvInvitationLink,
   composeInvitationDeepUrl,

--- a/packages/state-manager/src/sagas/appConnection/connection.selectors.test.ts
+++ b/packages/state-manager/src/sagas/appConnection/connection.selectors.test.ts
@@ -128,11 +128,11 @@ describe('communitiesSelectors', () => {
     expect(invitationUrl).toEqual('')
   })
 
-  it('invitationUrl selector returns proper v2 url when community and long lived invite are defined', async () => {
+  it('invitationUrl selector returns proper v4 url when community and long lived invite are defined', async () => {
     const store = prepareStore().store
     const factory = await getReduxStoreFactory(store)
 
-    logger.info('invitationUrl selector returns proper v2 url when community and long lived invite are defined')
+    logger.info('invitationUrl selector returns proper v4 url when community and long lived invite are defined')
     const psk = '12345'
     const ownerOrbitDbIdentity = 'testOwnerOrbitDbIdentity'
     await factory.create<ReturnType<typeof communitiesActions.addNewCommunity>['payload']>('Community', {
@@ -179,7 +179,7 @@ describe('communitiesSelectors', () => {
     expect(selectorInvitationUrl).toEqual(expectedUrl)
   })
 
-  it('invitationUrl selector returns proper v3 url when community and long lived invite are defined and qss is enabled', async () => {
+  it('invitationUrl selector returns proper v5 url when community and long lived invite are defined and qss is enabled', async () => {
     const store = prepareStore().store
     const factory = await getReduxStoreFactory(store)
 


### PR DESCRIPTION
## Summary
- remove stale old invite-version and unused helper imports from the PR 3324 changes
- align connection-manager test setup with team-id active-chain naming
- update invitation URL test labels from v2/v3 to v4/v5

## Validation
- `git diff --check`
- focused ESLint on touched files
- targeted Jest was attempted from an auxiliary worktree, but could not run cleanly there because that worktree has no local `node_modules` and ts-jest/module resolution did not pick up Jest globals/package exports from the original install