### PR TITLE
chore: Bump mobile build versions to match the abandoned 7.4.1

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -174,7 +174,7 @@ android {
         applicationId = "com.quietmobile"
         minSdkVersion(rootProject.ext.minSdkVersion)
         targetSdkVersion(rootProject.ext.targetSdkVersion)
-        versionCode 628
+        versionCode 630
         versionName "7.3.0"
         resValue("string", "build_config_package", "com.quietmobile")
         testBuildType = System.getProperty("testBuildType", "debug")

--- a/packages/mobile/ios/Quiet/Info.plist
+++ b/packages/mobile/ios/Quiet/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>581</string>
+	<string>583</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false />
 	<key>LSRequiresIPhoneOS</key>

--- a/packages/mobile/ios/QuietNotificationServiceExtension/Info.plist
+++ b/packages/mobile/ios/QuietNotificationServiceExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>7.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>57</string>
+	<string>59</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false />
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have linked this PR to a related GitHub issue.
- [ ] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
