### PR TITLE
test: reproduce pre-ack QSS auth sync loss (#3376)

### DIFF
--- a/packages/backend/src/nest/qss/qss-auth-conn-manager.service.spec.ts
+++ b/packages/backend/src/nest/qss/qss-auth-conn-manager.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { type ModuleRef } from '@nestjs/core'
+import EventEmitter from 'events'
+import * as uint8arrays from 'uint8arrays'
 import { TestModule } from '../common/test.module'
 import { QSSAuthConnectionManager } from './qss-auth-conn-manager.service'
 import { QSSAuthConnection } from './qss-auth-conn'
@@ -12,8 +14,50 @@ import { SigChainModule } from '../auth/sigchain.service.module'
 import { SigChainService } from '../auth/sigchain.service'
 import { JoinStatus } from '../libp2p/libp2p.auth'
 import { QSS_ALLOWED } from '../const'
-import { QSSEvents } from './qss.types'
+import { AuthSyncMessage, CommunityOperationStatus, QSSEvents, WebsocketEvents } from './qss.types'
 import { QSSAuthConnStatus } from './qss.const'
+
+describe('QSSAuthConnectionManager auth frame ordering', () => {
+  it('preserves the first auth sync frame received before auth connection initialization', async () => {
+    const teamId = 'notification-resume-team'
+    const firstAuthFrame = Uint8Array.from([1, 2, 3, 4])
+    const deliver = jest.fn()
+    const clientSocket = { connected: true, active: true }
+    const qssClient = Object.assign(new EventEmitter(), {
+      getClientSocket: jest.fn(() => clientSocket),
+    }) as unknown as QSSClient
+    const authConnection = {
+      id: 3376,
+      teamId: undefined,
+      active: true,
+      on: jest.fn(),
+      start: jest.fn(async () => {}),
+      stop: jest.fn(),
+      deliver,
+      isForClientSocket: jest.fn(() => true),
+    } as unknown as QSSAuthConnection
+    const moduleRef = {
+      create: jest.fn(async () => authConnection),
+    } as unknown as ModuleRef
+    const manager = new QSSAuthConnectionManager(qssClient, moduleRef)
+
+    // QSS can send this frame before acknowledging SIGN_IN_COMMUNITY. The
+    // client currently initializes its auth connection only after that ack.
+    qssClient.emit(WebsocketEvents.AUTH_SYNC, {
+      ts: Date.now(),
+      status: CommunityOperationStatus.SUCCESS,
+      payload: {
+        userId: 'notification-resume-user',
+        teamId,
+        message: uint8arrays.toString(firstAuthFrame, 'base64'),
+      },
+    } as AuthSyncMessage)
+    await manager.startNewConnection(teamId)
+
+    expect(deliver).toHaveBeenCalledWith(firstAuthFrame)
+    manager.close()
+  })
+})
 
 describe('QSSAuthConnectionManager', () => {
   let module: TestingModule


### PR DESCRIPTION
## What

- Adds a focused regression test for #3376.
- Models the first `AUTH_SYNC` frame arriving before the per-community `QSSAuthConnection` is initialized.
- Leaves the test intentionally failing so the diagnosis is pinned down before a production fix is proposed.

## Diagnosis

On notification-driven iOS startup, QSS can emit its first `AUTH_SYNC` frame before `SIGN_IN_COMMUNITY` is acknowledged. `QSSService` starts the auth connection only after that acknowledgement. Meanwhile, `QSSAuthConnectionManager` handles the early frame, finds no active connection, logs an error, and discards it without queuing or replaying it. The auth handshake then continues without its first frame; the attached issue logs subsequently show `DEVICE_UNKNOWN` and a QSS disconnect.

The issue logs capture this exact ordering:

- `16:25:20.807`: client sends `SIGN_IN_COMMUNITY`
- `16:25:20.950`: first auth frame is rejected because the auth connection “wasn't initialized”
- `16:25:20.952`: auth connection is initialized
- `16:25:22.037`: server returns `DEVICE_UNKNOWN`, then QSS disconnects

## Test

```sh
NODE_OPTIONS='--experimental-vm-modules' ./node_modules/.bin/jest \
  --runInBand \
  --runTestsByPath src/nest/qss/qss-auth-conn-manager.service.spec.ts \
  -t 'preserves the first auth sync frame' \
  --silent --forceExit
```

Expected red result proving the dropped frame:

```text
Expected: [1, 2, 3, 4]
Number of calls: 0
```

Prettier, ESLint, and `git diff --check` pass. This PR contains no production fix.
