### PR TITLE
fix: show private channels in Ctrl+K switcher #3378

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixes
 
+* Include private channels in the desktop quick channel switcher [#3378](https://github.com/TryQuiet/quiet/issues/3378)
 * iOS tor process lifecycle improvements solving crashes and improving performance [#3349](https://github.com/TryQuiet/quiet/issues/3349)
 * Update LFA to remove flaky timestamp validator [#3365](https://github.com/TryQuiet/quiet/issues/3365)
 

--- a/packages/desktop/src/renderer/components/SearchModal/SearchModelComponent.tsx
+++ b/packages/desktop/src/renderer/components/SearchModal/SearchModelComponent.tsx
@@ -160,7 +160,13 @@ const SearchModalComponent: React.FC<SearchModalComponentProps> = ({
 
   const unread = unreadChannels.length > 0
 
-  const channelList = unread && channelInput.length === 0 ? unreadChannels : dynamicSearchedChannelsSelector
+  const priorityChannels = unread ? unreadChannels : dynamicSearchedChannelsSelector
+  const additionalPrivateChannels = publicChannelsSelector.filter(
+    channel => channel.public === false && !priorityChannels.some(priorityChannel => priorityChannel.id === channel.id)
+  )
+  const privateChannelsStartIndex = priorityChannels.length
+  const channelList =
+    channelInput.length === 0 ? [...priorityChannels, ...additionalPrivateChannels] : dynamicSearchedChannelsSelector
 
   const onChannelClickHandler = (id: string) => {
     setChannelInput('')
@@ -232,15 +238,25 @@ const SearchModalComponent: React.FC<SearchModalComponentProps> = ({
                 {channelList.length > 0 &&
                   channelList.map((item, index) => {
                     return (
-                      <ChannelItem
-                        className={classes.channelWrapper}
-                        focused={focusedIndex === index}
-                        classNameSelected={classes.channelWrapperSelected}
-                        item={item}
-                        key={index}
-                        onClickHandler={onChannelClickHandler}
-                        channelInput={channelInput}
-                      />
+                      <React.Fragment key={item.id}>
+                        {channelInput.length === 0 &&
+                          additionalPrivateChannels.length > 0 &&
+                          index === privateChannelsStartIndex && (
+                            <Grid className={classes.wrapperRecent}>
+                              <Typography variant='overline' className={classes.recentChannels}>
+                                private channels
+                              </Typography>
+                            </Grid>
+                          )}
+                        <ChannelItem
+                          className={classes.channelWrapper}
+                          focused={focusedIndex === index}
+                          classNameSelected={classes.channelWrapperSelected}
+                          item={item}
+                          onClickHandler={onChannelClickHandler}
+                          channelInput={channelInput}
+                        />
+                      </React.Fragment>
                     )
                   })}
               </Grid>

--- a/packages/desktop/src/rtl-tests/searchModal.test.tsx
+++ b/packages/desktop/src/rtl-tests/searchModal.test.tsx
@@ -50,11 +50,13 @@ describe('Switch channels', () => {
   let community: Community
   let alice: Identity
 
-  const channelFun = { name: 'fun', timestamp: 1673857606990 }
+  const channelFun = { name: 'fun', timestamp: 1673857606990, public: true }
+  const privateChannel = { name: 'secret', timestamp: 1673000000000, public: false }
   const channelsMocks = [
     channelFun,
-    { name: 'random', timestamp: 1673854900410 },
-    { name: 'test', timestamp: 1673623514097 },
+    privateChannel,
+    { name: 'random', timestamp: 1673854900410, public: true },
+    { name: 'test', timestamp: 1673623514097, public: true },
   ]
 
   beforeEach(async () => {
@@ -85,6 +87,7 @@ describe('Switch channels', () => {
           timestamp: channelMock.timestamp,
           owner: alice.userId,
           id: channelMock.name,
+          public: channelMock.public,
         },
       })
     }
@@ -110,6 +113,41 @@ describe('Switch channels', () => {
     const currentChannel = publicChannels.selectors.currentChannel(redux.store.getState())
 
     expect(currentChannel?.name).toEqual(channelFun.name)
+  })
+
+  it('Shows private channels outside the recent channel list', async () => {
+    renderComponent(
+      <>
+        <SearchModal />
+      </>,
+      redux.store
+    )
+    redux.store.dispatch(modalsActions.openModal({ name: ModalName.searchChannelModal }))
+
+    expect(await screen.findByText('private channels')).toBeVisible()
+    expect(await screen.findByText('# secret')).toBeVisible()
+  })
+
+  it('Select private channel by writing name and pressing enter', async () => {
+    renderComponent(
+      <>
+        <SearchModal />
+      </>,
+      redux.store
+    )
+    redux.store.dispatch(modalsActions.openModal({ name: ModalName.searchChannelModal }))
+
+    const input = await screen.findByPlaceholderText('Channel name')
+    await userEvent.type(input, privateChannel.name)
+    const tab = await screen.findByText('# secret')
+    await userEvent.type(tab, '{ArrowDown}')
+    await userEvent.type(tab, '{enter}')
+
+    await act(async () => {})
+
+    const currentChannel = publicChannels.selectors.currentChannel(redux.store.getState())
+
+    expect(currentChannel?.name).toEqual(privateChannel.name)
   })
 
   it('Select channel by writing name and clicking', async () => {


### PR DESCRIPTION
## Summary

- keep recent or unread channels at the top of the desktop Ctrl+K switcher
- add private channels that would otherwise be omitted from the default list
- preserve private-channel search and keyboard navigation
- add RTL regression coverage and a 9.0 changelog entry

## Root cause

With an empty search field, the switcher replaced the channel set with only the recent or unread subset. A private channel outside that subset was hidden until the user searched for it by name.

## User impact

Private channels are now available directly from the default Ctrl+K list, under a dedicated section, while the existing recent/unread prioritization remains intact.

## Validation

- `jest ./src/rtl-tests/searchModal.test.tsx ./src/renderer/components/SearchModal/SearchModal.test.tsx --runInBand --silent`
- targeted ESLint for the changed TypeScript files
- `tsc -p tsconfig.build.json --noEmit`
- `git diff --check`

Fixes #3378
