### PR TITLE
fix(3371): Make usernames and profile photos tapable when adding members to private channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * iOS tor process lifecycle improvements solving crashes and improving performance [#3349](https://github.com/TryQuiet/quiet/issues/3349)
 * Update LFA to remove flaky timestamp validator [#3365](https://github.com/TryQuiet/quiet/issues/3365)
+* Make usernames and profile photos tapable when adding members to private channel [#3371](https://github.com/TryQuiet/quiet/issues/3371)
 
 ## [8.0.0]
 

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
@@ -1449,54 +1449,89 @@ describe('UpdateChannelMembership component', () => {
                           </View>
                         </View>
                         <View
+                          accessibilityState={
+                            {
+                              "busy": undefined,
+                              "checked": undefined,
+                              "disabled": undefined,
+                              "expanded": undefined,
+                              "selected": undefined,
+                            }
+                          }
+                          accessibilityValue={
+                            {
+                              "max": undefined,
+                              "min": undefined,
+                              "now": undefined,
+                              "text": undefined,
+                            }
+                          }
+                          accessible={true}
+                          collapsable={false}
+                          focusable={true}
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
                           style={
                             {
-                              "alignContent": "center",
-                              "alignItems": "center",
-                              "display": "flex",
-                              "flexDirection": "row",
-                              "gap": 16,
-                              "paddingVertical": 11,
+                              "opacity": 1,
                             }
                           }
                         >
-                          <Image
-                            alt="baz's profile image"
-                            source={
-                              {
-                                "uri": "foobar",
-                              }
-                            }
+                          <View
                             style={
                               {
-                                "borderRadius": 4,
-                                "height": 32,
-                                "width": 32,
+                                "alignContent": "center",
+                                "alignItems": "center",
+                                "display": "flex",
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "paddingVertical": 11,
                               }
                             }
-                          />
-                          <Text
-                            color="main"
-                            fontSize={16}
-                            horizontalTextAlign="left"
-                            style={
-                              [
-                                {
-                                  "color": "#000000",
-                                  "fontFamily": "Rubik-Regular",
-                                  "fontSize": 16,
-                                  "textAlign": "left",
-                                  "textAlignVertical": "center",
-                                },
-                                {
-                                  "color": "#000000",
-                                },
-                              ]
-                            }
-                            verticalTextAlign="center"
                           >
-                            baz
-                          </Text>
+                            <Image
+                              alt="baz's profile image"
+                              source={
+                                {
+                                  "uri": "foobar",
+                                }
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 32,
+                                  "width": 32,
+                                }
+                              }
+                            />
+                            <Text
+                              color="main"
+                              fontSize={16}
+                              horizontalTextAlign="left"
+                              style={
+                                [
+                                  {
+                                    "color": "#000000",
+                                    "fontFamily": "Rubik-Regular",
+                                    "fontSize": 16,
+                                    "textAlign": "left",
+                                    "textAlignVertical": "center",
+                                  },
+                                  {
+                                    "color": "#000000",
+                                  },
+                                ]
+                              }
+                              verticalTextAlign="center"
+                            >
+                              baz
+                            </Text>
+                          </View>
                         </View>
                       </View>
                     </View>

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.component.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { FlatList, ListRenderItemInfo, View } from 'react-native'
+import { FlatList, ListRenderItemInfo, TouchableOpacity, View } from 'react-native'
 
 import { ProfilePhoto } from '../../ProfilePhoto/ProfilePhoto.component'
 import { Typography } from '../../Typography/Typography.component'
@@ -55,28 +55,30 @@ export const UpdateChannelMembershipList: React.FC<UpdateChannelMembershipListPr
       : defaultTheme.palette.background.gray06
     const checkedColor = item.mutable ? defaultTheme.palette.background.gray70 : defaultTheme.palette.background.gray06
     const label = (
-      <View
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          alignContent: 'center',
-          gap: 16,
-          paddingVertical: 11,
-        }}
-      >
-        <ProfilePhoto
-          userId={item.id}
-          username={item.label}
-          photo={userProfiles[item.id]?.photo}
-          profilePhoto={userProfiles[item.id]?.profilePhoto}
-          size={32}
-          borderRadius={4}
-        />
-        <Typography fontSize={16} style={{ color: labelColor }}>
-          {item.label}
-        </Typography>
-      </View>
+      <TouchableOpacity onPress={() => updateOptionsOnCheck(item)}>
+        <View
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            alignContent: 'center',
+            gap: 16,
+            paddingVertical: 11,
+          }}
+        >
+          <ProfilePhoto
+            userId={item.id}
+            username={item.label}
+            photo={userProfiles[item.id]?.photo}
+            profilePhoto={userProfiles[item.id]?.profilePhoto}
+            size={32}
+            borderRadius={4}
+          />
+          <Typography fontSize={16} style={{ color: labelColor }}>
+            {item.label}
+          </Typography>
+        </View>
+      </TouchableOpacity>
     )
     return (
       <Checkbox


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [ ] I have updated base screenshots for visual regression tests
