### PR TITLE
android-studio-build-debug

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -333,14 +333,21 @@ tasks.register("copyDownloadableDepsToLibs", Copy) {
 // Keys are matched by dotenv.gradle's getCurrentFlavor(), which captures the
 // trailing CamelCase segment of the gradle task name and lowercases it (e.g.
 // installStandardDebug -> "standarddebug"). With product flavors in play the
-// bare buildType keys ("debug", "release") never match, so keys must include
-// the flavor prefix.
+// bare buildType keys ("debug", "release") never match flavor-qualified task
+// names, so those keys are also listed. But some invocations (e.g. plain
+// "assembleDebug", which Android Studio's Make/Run actions can issue) omit
+// the flavor entirely and only resolve to "debug"/"release" - without a
+// fallback here, no env file matches, no BuildConfig fields get generated,
+// and the app fails to compile with "Unresolved reference" errors. The bare
+// keys below cover that case, defaulting to the "standard" flavor's env files.
 project.ext.envConfigFiles = [
         standarddebug   : ".env.development",
         standardrelease : ".env.staging",
         standardprod    : ".env.production",
         storybookdebug  : ".env.storybook",
         storybookrelease: ".env.storybook",
+        debug           : ".env.development",
+        release         : ".env.staging",
 ]
 
 apply from: project(":react-native-config").projectDir.getPath() + "/dotenv.gradle"


### PR DESCRIPTION
Fixing: https://github.com/TryQuiet/quiet/issues/3411

- What broke: Android Studio's Run button failed to compile the app.
- Why: the env-file-to-task-name mapping only handled flavor-qualified task names, not the bare debug/release tasks Android Studio issues.
- Fix: added fallback keys defaulting to the standard flavor.
- Tested: confirmed working on a real device.

**Does this change affect users who run builds under the previous rules? - No.**                                                                                                                                         
                                                                                                                                                                                                           
The fix only adds two new entries to the map (debug and release). It doesn't remove, rename, or change any of the existing ones (standarddebug, standardrelease, standardprod, storybookdebug, storybookrelease). So:                                                                                                                                                                                   
                                                                                                                                                                                                           
  - Anyone already building via a flavor-qualified command or variant (e.g. ./gradlew installStandardDebug, or picking standardDebug in Android Studio's Build Variants panel) — nothing changes for them. 
  Same keys, same files, same behavior as before.                                                                                                                                                          
  - The .env.development and .env.staging files the fallback points to already exist in the repo (just confirmed) — so nobody needs to create anything new or run an extra setup step.                     
                                                                                                                                                                                                           
  **Who does it actually affect?** Only teammates who were hitting the exact same wall you were — using Android Studio's plain Run/Debug button without an explicit flavor selected, which issues a bare       
  assembleDebug/assembleRelease task. For them, this turns a broken build into a working one. It doesn't ask them to do anything differently; it just makes the thing they were already doing work.        
                                                                                                            
