### PR TITLE
Fix/appbar contextmenu a11y hitarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * iOS tor process lifecycle improvements solving crashes and improving performance [#3349](https://github.com/TryQuiet/quiet/issues/3349)
 * Update LFA to remove flaky timestamp validator [#3365](https://github.com/TryQuiet/quiet/issues/3365)
 * Improve image compression efficiency [#3364](https://github.com/TryQuiet/quiet/issues/3364)
+* Fix tapable area in two places in the Appbar [#3372] (https://github.com/TryQuiet/quiet/issues/3372)
 
 ## [8.0.0]
 

--- a/packages/mobile/src/components/Appbar/Appbar.component.tsx
+++ b/packages/mobile/src/components/Appbar/Appbar.component.tsx
@@ -31,6 +31,8 @@ export const Appbar: FC<AppbarProps> = ({
             if (back) back()
           }}
           testID={'appbar_action_item'}
+          accessibilityRole={back ? 'button' : undefined}
+          accessibilityLabel={back ? (crossBackIcon ? 'Close' : 'Go back') : undefined}
         >
           <View
             style={{
@@ -45,6 +47,7 @@ export const Appbar: FC<AppbarProps> = ({
                 source={crossBackIcon ? cross_icon : arrow_icon}
                 resizeMode='cover'
                 resizeMethod='resize'
+                accessible={false}
                 style={{
                   width: 16,
                   height: 16,
@@ -80,12 +83,15 @@ export const Appbar: FC<AppbarProps> = ({
               contextMenu.handleOpen()
             }}
             testID={'open_menu'}
+            accessibilityRole='button'
+            accessibilityLabel='More options'
           >
             <View style={{ justifyContent: 'center', alignItems: 'center', width: 64, height: 50 }}>
               <Image
                 source={menu_icon}
                 resizeMode='contain'
                 resizeMethod='resize'
+                accessible={false}
                 style={{
                   width: 16,
                   height: 16,
@@ -102,7 +108,7 @@ export const Appbar: FC<AppbarProps> = ({
             }}
             testID={'submit'}
           >
-            <View style={{ justifyContent: 'center', alignItems: 'center', width: 64, height: 50 }}>
+            <View style={{ justifyContent: 'center', alignItems: 'center', minWidth: 64, height: 50 }}>
               <Typography style={{ color: defaultTheme.palette.typography.blue }} fontSize={16}>
                 Done
               </Typography>

--- a/packages/mobile/src/components/Appbar/Appbar.component.tsx
+++ b/packages/mobile/src/components/Appbar/Appbar.component.tsx
@@ -81,7 +81,7 @@ export const Appbar: FC<AppbarProps> = ({
             }}
             testID={'open_menu'}
           >
-            <View style={{ justifyContent: 'center', alignItems: 'center', width: 64 }}>
+            <View style={{ justifyContent: 'center', alignItems: 'center', width: 64, height: 50 }}>
               <Image
                 source={menu_icon}
                 resizeMode='contain'
@@ -102,7 +102,7 @@ export const Appbar: FC<AppbarProps> = ({
             }}
             testID={'submit'}
           >
-            <View style={{ justifyContent: 'center', alignItems: 'center' }}>
+            <View style={{ justifyContent: 'center', alignItems: 'center', width: 64, height: 50 }}>
               <Typography style={{ color: defaultTheme.palette.typography.blue }} fontSize={16}>
                 Done
               </Typography>

--- a/packages/mobile/src/components/Appbar/Appbar.test.tsx
+++ b/packages/mobile/src/components/Appbar/Appbar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ReactTestInstance } from 'react-test-renderer'
 
 import { useContextMenu } from '../../hooks/useContextMenu'
 
@@ -326,6 +327,7 @@ describe('Appbar component', () => {
               style={
                 {
                   "alignItems": "center",
+                  "height": 50,
                   "justifyContent": "center",
                   "width": 64,
                 }
@@ -351,5 +353,16 @@ describe('Appbar component', () => {
         </View>
       </View>
     `)
+  })
+
+  it('renders submit button with a touch target that meets the accessibility minimum', () => {
+    const { getByTestId } = renderComponent(<Appbar title={'quiet'} submit={() => {}} />)
+
+    const submitButtonView = getByTestId('submit').children[0] as ReactTestInstance
+
+    expect(submitButtonView.props.style).toMatchObject({
+      width: 64,
+      height: 50,
+    })
   })
 })

--- a/packages/mobile/src/components/Appbar/Appbar.test.tsx
+++ b/packages/mobile/src/components/Appbar/Appbar.test.tsx
@@ -8,7 +8,9 @@ import { Appbar } from './Appbar.component'
 
 describe('Appbar component', () => {
   it('renders for channel', () => {
-    const { toJSON } = renderComponent(<Appbar title={'general'} prefix={'#'} back={() => {}} />)
+    const { toJSON, getByLabelText } = renderComponent(<Appbar title={'general'} prefix={'#'} back={() => {}} />)
+
+    expect(getByLabelText('Go back')).toBeTruthy()
 
     expect(toJSON()).toMatchInlineSnapshot(`
       <View
@@ -36,6 +38,8 @@ describe('Appbar component', () => {
           }
         >
           <View
+            accessibilityLabel="Go back"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -81,6 +85,7 @@ describe('Appbar component', () => {
               }
             >
               <Image
+                accessible={false}
                 resizeMethod="resize"
                 resizeMode="cover"
                 source={
@@ -145,7 +150,11 @@ describe('Appbar component', () => {
       handleClose: function (): any {},
     }
 
-    const { toJSON } = renderComponent(<Appbar title={'quiet'} position={'flex-start'} contextMenu={contextMenu} />)
+    const { toJSON, getByLabelText } = renderComponent(
+      <Appbar title={'quiet'} position={'flex-start'} contextMenu={contextMenu} />
+    )
+
+    expect(getByLabelText('More options')).toBeTruthy()
 
     expect(toJSON()).toMatchInlineSnapshot(`
       <View
@@ -289,6 +298,8 @@ describe('Appbar component', () => {
           }
         >
           <View
+            accessibilityLabel="More options"
+            accessibilityRole="button"
             accessibilityState={
               {
                 "busy": undefined,
@@ -334,6 +345,7 @@ describe('Appbar component', () => {
               }
             >
               <Image
+                accessible={false}
                 resizeMethod="resize"
                 resizeMode="contain"
                 source={
@@ -355,13 +367,19 @@ describe('Appbar component', () => {
     `)
   })
 
+  it('labels the back button as "Close" when crossBackIcon is set', () => {
+    const { getByLabelText } = renderComponent(<Appbar title={'general'} back={() => {}} crossBackIcon />)
+
+    expect(getByLabelText('Close')).toBeTruthy()
+  })
+
   it('renders submit button with a touch target that meets the accessibility minimum', () => {
     const { getByTestId } = renderComponent(<Appbar title={'quiet'} submit={() => {}} />)
 
     const submitButtonView = getByTestId('submit').children[0] as ReactTestInstance
 
     expect(submitButtonView.props.style).toMatchObject({
-      width: 64,
+      minWidth: 64,
       height: 50,
     })
   })

--- a/packages/mobile/src/components/ChannelMembership/ChannelMembership.test.tsx
+++ b/packages/mobile/src/components/ChannelMembership/ChannelMembership.test.tsx
@@ -112,6 +112,8 @@ describe('ChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -157,6 +159,7 @@ describe('ChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={
@@ -620,6 +623,8 @@ describe('ChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -665,6 +670,7 @@ describe('ChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={
@@ -1217,6 +1223,8 @@ describe('ChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -1262,6 +1270,7 @@ describe('ChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
@@ -429,7 +429,9 @@ describe('UpdateChannelMembership component', () => {
                   style={
                     {
                       "alignItems": "center",
+                      "height": 50,
                       "justifyContent": "center",
+                      "width": 64,
                     }
                   }
                 >
@@ -1067,7 +1069,9 @@ describe('UpdateChannelMembership component', () => {
                   style={
                     {
                       "alignItems": "center",
+                      "height": 50,
                       "justifyContent": "center",
+                      "width": 64,
                     }
                   }
                 >
@@ -1928,7 +1932,9 @@ describe('UpdateChannelMembership component', () => {
                   style={
                     {
                       "alignItems": "center",
+                      "height": 50,
                       "justifyContent": "center",
+                      "width": 64,
                     }
                   }
                 >

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.test.tsx
@@ -104,6 +104,8 @@ describe('UpdateChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -149,6 +151,7 @@ describe('UpdateChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={
@@ -431,7 +434,7 @@ describe('UpdateChannelMembership component', () => {
                       "alignItems": "center",
                       "height": 50,
                       "justifyContent": "center",
-                      "width": 64,
+                      "minWidth": 64,
                     }
                   }
                 >
@@ -744,6 +747,8 @@ describe('UpdateChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -789,6 +794,7 @@ describe('UpdateChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={
@@ -1071,7 +1077,7 @@ describe('UpdateChannelMembership component', () => {
                       "alignItems": "center",
                       "height": 50,
                       "justifyContent": "center",
-                      "width": 64,
+                      "minWidth": 64,
                     }
                   }
                 >
@@ -1607,6 +1613,8 @@ describe('UpdateChannelMembership component', () => {
               }
             >
               <View
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
                 accessibilityState={
                   {
                     "busy": undefined,
@@ -1652,6 +1660,7 @@ describe('UpdateChannelMembership component', () => {
                   }
                 >
                   <Image
+                    accessible={false}
                     resizeMethod="resize"
                     resizeMode="cover"
                     source={
@@ -1934,7 +1943,7 @@ describe('UpdateChannelMembership component', () => {
                       "alignItems": "center",
                       "height": 50,
                       "justifyContent": "center",
-                      "width": 64,
+                      "minWidth": 64,
                     }
                   }
                 >

--- a/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -314,6 +314,7 @@ exports[`Chat component renders component 1`] = `
           style={
             {
               "alignItems": "center",
+              "height": 50,
               "justifyContent": "center",
               "width": 64,
             }

--- a/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -34,6 +34,8 @@ exports[`Chat component renders component 1`] = `
       }
     >
       <View
+        accessibilityLabel="Go back"
+        accessibilityRole="button"
         accessibilityState={
           {
             "busy": undefined,
@@ -79,6 +81,7 @@ exports[`Chat component renders component 1`] = `
           }
         >
           <Image
+            accessible={false}
             resizeMethod="resize"
             resizeMode="cover"
             source={
@@ -276,6 +279,8 @@ exports[`Chat component renders component 1`] = `
       }
     >
       <View
+        accessibilityLabel="More options"
+        accessibilityRole="button"
         accessibilityState={
           {
             "busy": undefined,
@@ -321,6 +326,7 @@ exports[`Chat component renders component 1`] = `
           }
         >
           <Image
+            accessible={false}
             resizeMethod="resize"
             resizeMode="contain"
             source={

--- a/packages/mobile/src/components/DeleteChannel/DeleteChannel.test.tsx
+++ b/packages/mobile/src/components/DeleteChannel/DeleteChannel.test.tsx
@@ -44,6 +44,8 @@ describe('DeleteChannel component', () => {
             }
           >
             <View
+              accessibilityLabel="Go back"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -89,6 +91,7 @@ describe('DeleteChannel component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={

--- a/packages/mobile/src/components/LeaveCommunity/LeaveCommunity.test.tsx
+++ b/packages/mobile/src/components/LeaveCommunity/LeaveCommunity.test.tsx
@@ -44,6 +44,8 @@ describe('LeaveCommunity component', () => {
             }
           >
             <View
+              accessibilityLabel="Go back"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -89,6 +91,7 @@ describe('LeaveCommunity component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={

--- a/packages/mobile/src/components/NewUsernameRequested/NewUsernameRequested.test.tsx
+++ b/packages/mobile/src/components/NewUsernameRequested/NewUsernameRequested.test.tsx
@@ -41,6 +41,8 @@ describe('NewUsernameRequested component', () => {
             }
           >
             <View
+              accessibilityLabel="Close"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -86,6 +88,7 @@ describe('NewUsernameRequested component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={

--- a/packages/mobile/src/components/PossibleImpersonationAttack/PossibleImpersonationAttack.test.tsx
+++ b/packages/mobile/src/components/PossibleImpersonationAttack/PossibleImpersonationAttack.test.tsx
@@ -43,6 +43,8 @@ describe('PossibleImpersonationAttack component', () => {
             }
           >
             <View
+              accessibilityLabel="Close"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -88,6 +90,7 @@ describe('PossibleImpersonationAttack component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={

--- a/packages/mobile/src/components/QRCode/QRCode.test.tsx
+++ b/packages/mobile/src/components/QRCode/QRCode.test.tsx
@@ -44,6 +44,8 @@ describe('QRCode component', () => {
             }
           >
             <View
+              accessibilityLabel="Go back"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -89,6 +91,7 @@ describe('QRCode component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={

--- a/packages/mobile/src/components/UserLabel/Duplicated/DuplicatedUsername.test.tsx
+++ b/packages/mobile/src/components/UserLabel/Duplicated/DuplicatedUsername.test.tsx
@@ -39,6 +39,8 @@ describe('DuplicatedUsername component', () => {
             }
           >
             <View
+              accessibilityLabel="Close"
+              accessibilityRole="button"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -84,6 +86,7 @@ describe('DuplicatedUsername component', () => {
                 }
               >
                 <Image
+                  accessible={false}
                   resizeMethod="resize"
                   resizeMode="cover"
                   source={


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue. - this fixes https://github.com/TryQuiet/quiet/issues/3372
- [x] I have added a description of the change (and Github issue number, if any) to the root [CHANGELOG.md](https://github.com/TryQuiet/quiet/blob/develop/CHANGELOG.md).

### (Optional) Mobile checklist

Please ensure you completed the following checks if you did any changes to the mobile package:

- [ ] I have run e2e tests for mobile
- [x] I have updated base screenshots for visual regression tests

Fixes https://github.com/TryQuiet/quiet/issues/3372 and additionally changes the size of other clickable elements in the AppBar that were not up to a11 (button Done in adding members to the private channel). Tests updated accordingly. 
