### PR TITLE
chore(ci): add organization secret migration workflow

### DIFF
--- a/.github/scripts/migrate-actions-secrets-to-organization.sh
+++ b/.github/scripts/migrate-actions-secrets-to-organization.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+organization="${MIGRATION_ORGANIZATION:?MIGRATION_ORGANIZATION is required}"
+repositories="${MIGRATION_REPOSITORIES:?MIGRATION_REPOSITORIES is required}"
+: "${GH_TOKEN:?ORG_SECRETS_MIGRATION_TOKEN must be available through GH_TOKEN}"
+
+if [[ ! "$organization" =~ ^[A-Za-z0-9][A-Za-z0-9-]*$ ]]; then
+  echo "::error::Invalid organization name: $organization" >&2
+  exit 1
+fi
+
+if [[ ! "$repositories" =~ ^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$ ]]; then
+  echo "::error::Repositories must be comma-separated names without owners or spaces" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "::error::The GitHub CLI is required" >&2
+  exit 1
+fi
+
+# Each entry is ORGANIZATION_SECRET_NAME:SOURCE_ENVIRONMENT_VARIABLE. The
+# existing GH_TOKEN uses a different environment variable so it cannot replace
+# the short-lived credential used by the GitHub CLI.
+secret_mappings=(
+  ANDROID_FIREBASE_KEY:ANDROID_FIREBASE_KEY
+  APPLE_ID:APPLE_ID
+  APPLE_ID_PASS:APPLE_ID_PASS
+  APPLE_TEAM_ID:APPLE_TEAM_ID
+  APPSTORE_PASSWORD:APPSTORE_PASSWORD
+  APPSTORE_USER:APPSTORE_USER
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID:APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY:APP_STORE_CONNECT_API_KEY_KEY
+  APP_STORE_CONNECT_API_KEY_KEY_ID:APP_STORE_CONNECT_API_KEY_KEY_ID
+  QUIET_AWS_ACCESS_KEY_ID:MIGRATION_SOURCE_AWS_ACCESS_KEY_ID
+  QUIET_AWS_SECRET_ACCESS_KEY:MIGRATION_SOURCE_AWS_SECRET_ACCESS_KEY
+  CHROMATIC_PROJECT_TOKEN:CHROMATIC_PROJECT_TOKEN
+  GH_TOKEN:MIGRATION_SOURCE_GH_TOKEN
+  GOOGLE_KEYSTORE:GOOGLE_KEYSTORE
+  GOOGLE_KEYSTORE_ALIAS:GOOGLE_KEYSTORE_ALIAS
+  GOOGLE_KEYSTORE_PASSWORD:GOOGLE_KEYSTORE_PASSWORD
+  IOS_CERTIFICATE_KEY:IOS_CERTIFICATE_KEY
+  IOS_FIREBASE_KEY:IOS_FIREBASE_KEY
+  IOS_NSE_PROFILE_KEY:IOS_NSE_PROFILE_KEY
+  IOS_PROFILE_KEY:IOS_PROFILE_KEY
+  MAC_CSC_KEY_PASSWORD:MAC_CSC_KEY_PASSWORD
+  MAC_CSC_LINK:MAC_CSC_LINK
+  MATCH_GIT_BASIC_AUTHORIZATION:MATCH_GIT_BASIC_AUTHORIZATION
+  MATCH_KEYCHAIN_PASSWORD:MATCH_KEYCHAIN_PASSWORD
+  MATCH_PASSWORD:MATCH_PASSWORD
+  SERVICE_ACCOUNT_JSON:SERVICE_ACCOUNT_JSON
+  WIN_ALIAS:WIN_ALIAS
+  WIN_CSC_KEY_PASSWORD:WIN_CSC_KEY_PASSWORD
+  WIN_CSC_LINK:WIN_CSC_LINK
+)
+
+missing_secrets=()
+for mapping in "${secret_mappings[@]}"; do
+  environment_name="${mapping#*:}"
+  if [[ -z "${!environment_name-}" ]]; then
+    missing_secrets+=("${mapping%%:*}")
+  fi
+done
+
+if (( ${#missing_secrets[@]} > 0 )); then
+  printf '::error::Source secrets are missing or empty: %s\n' "${missing_secrets[*]}" >&2
+  exit 1
+fi
+
+for mapping in "${secret_mappings[@]}"; do
+  secret_name="${mapping%%:*}"
+  environment_name="${mapping#*:}"
+
+  echo "Migrating $secret_name"
+  printf '%s' "${!environment_name}" |
+    gh secret set "$secret_name" \
+      --org "$organization" \
+      --repos "$repositories" \
+      --app actions
+done
+
+echo "Migrated ${#secret_mappings[@]} secrets to $organization for: $repositories"

--- a/.github/scripts/test-migrate-actions-secrets-to-organization.sh
+++ b/.github/scripts/test-migrate-actions-secrets-to-organization.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$script_dir/migrate-actions-secrets-to-organization.sh"
+workflow="$script_dir/../workflows/migrate-actions-secrets-to-organization.yml"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin" "$test_dir/uploads"
+
+cat >"$test_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "$1" == secret && "$2" == set ]]
+secret_name="$3"
+shift 3
+printf '%s %s\n' "$secret_name" "$*" >>"$MIGRATION_TEST_CALLS"
+cp /dev/stdin "$MIGRATION_TEST_UPLOADS/$secret_name"
+EOF
+chmod +x "$test_dir/bin/gh"
+
+secret_names=(
+  ANDROID_FIREBASE_KEY
+  APPLE_ID
+  APPLE_ID_PASS
+  APPLE_TEAM_ID
+  APPSTORE_PASSWORD
+  APPSTORE_USER
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID
+  APP_STORE_CONNECT_API_KEY_KEY
+  APP_STORE_CONNECT_API_KEY_KEY_ID
+  CHROMATIC_PROJECT_TOKEN
+  GOOGLE_KEYSTORE
+  GOOGLE_KEYSTORE_ALIAS
+  GOOGLE_KEYSTORE_PASSWORD
+  IOS_CERTIFICATE_KEY
+  IOS_FIREBASE_KEY
+  IOS_NSE_PROFILE_KEY
+  IOS_PROFILE_KEY
+  MAC_CSC_KEY_PASSWORD
+  MAC_CSC_LINK
+  MATCH_GIT_BASIC_AUTHORIZATION
+  MATCH_KEYCHAIN_PASSWORD
+  MATCH_PASSWORD
+  SERVICE_ACCOUNT_JSON
+  WIN_ALIAS
+  WIN_CSC_KEY_PASSWORD
+  WIN_CSC_LINK
+)
+
+for secret_name in "${secret_names[@]}"; do
+  export "$secret_name=value-for-$secret_name"
+done
+
+export SERVICE_ACCOUNT_JSON=$'{"type":"service_account"}\nsecond-line\n'
+export GH_TOKEN=short-lived-upload-token
+export MIGRATION_SOURCE_GH_TOKEN=existing-source-token
+export MIGRATION_SOURCE_AWS_ACCESS_KEY_ID=quiet-aws-access-key
+export MIGRATION_SOURCE_AWS_SECRET_ACCESS_KEY=quiet-aws-secret-key
+export MIGRATION_ORGANIZATION=TryQuiet
+export MIGRATION_REPOSITORIES=quiet,quiet-private
+export MIGRATION_TEST_CALLS="$test_dir/calls"
+export MIGRATION_TEST_UPLOADS="$test_dir/uploads"
+export PATH="$test_dir/bin:$PATH"
+
+"$script"
+
+[[ "$(wc -l <"$MIGRATION_TEST_CALLS")" -eq 29 ]]
+grep -Fxq 'APPLE_ID --org TryQuiet --repos quiet,quiet-private --app actions' "$MIGRATION_TEST_CALLS"
+grep -Fxq 'GH_TOKEN --org TryQuiet --repos quiet,quiet-private --app actions' "$MIGRATION_TEST_CALLS"
+grep -Fxq 'QUIET_AWS_ACCESS_KEY_ID --org TryQuiet --repos quiet,quiet-private --app actions' "$MIGRATION_TEST_CALLS"
+grep -Fxq 'QUIET_AWS_SECRET_ACCESS_KEY --org TryQuiet --repos quiet,quiet-private --app actions' "$MIGRATION_TEST_CALLS"
+[[ "$(<"$MIGRATION_TEST_UPLOADS/APPLE_ID")" == value-for-APPLE_ID ]]
+[[ "$(<"$MIGRATION_TEST_UPLOADS/GH_TOKEN")" == existing-source-token ]]
+[[ "$(<"$MIGRATION_TEST_UPLOADS/QUIET_AWS_ACCESS_KEY_ID")" == quiet-aws-access-key ]]
+[[ "$(<"$MIGRATION_TEST_UPLOADS/QUIET_AWS_SECRET_ACCESS_KEY")" == quiet-aws-secret-key ]]
+[[ ! -e "$MIGRATION_TEST_UPLOADS/ORG_SECRETS_MIGRATION_TOKEN" ]]
+printf '{"type":"service_account"}\nsecond-line\n' >"$test_dir/expected-service-account"
+cmp "$test_dir/expected-service-account" "$MIGRATION_TEST_UPLOADS/SERVICE_ACCOUNT_JSON"
+
+printf '%s\n' "${secret_names[@]}" AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY GH_TOKEN |
+  sort >"$test_dir/expected-source-secrets"
+sed -nE 's/^      [A-Z0-9_]+: \$\{\{ secrets\.([A-Z0-9_]+) \}\}$/\1/p' "$workflow" |
+  sort >"$test_dir/workflow-source-secrets"
+cmp "$test_dir/expected-source-secrets" "$test_dir/workflow-source-secrets"
+grep -Fq 'GH_TOKEN: ${{ secrets.ORG_SECRETS_MIGRATION_TOKEN }}' "$workflow"
+grep -Fxq '      MIGRATION_ORGANIZATION: TryQuiet' "$workflow"
+grep -Fxq '      MIGRATION_REPOSITORIES: quiet,quiet-private' "$workflow"
+if grep -Eq 'inputs\.(organization|repositories)' "$workflow"; then
+  echo 'Workflow target scope must not be configurable at run time' >&2
+  exit 1
+fi
+
+rm -f "$MIGRATION_TEST_CALLS"
+rm -rf "$MIGRATION_TEST_UPLOADS"
+mkdir -p "$MIGRATION_TEST_UPLOADS"
+unset APPLE_ID
+
+if "$script" >"$test_dir/missing-secret.stdout" 2>"$test_dir/missing-secret.stderr"; then
+  echo 'Expected migration to fail when a source secret is missing' >&2
+  exit 1
+fi
+
+grep -Fq 'Source secrets are missing or empty: APPLE_ID' "$test_dir/missing-secret.stderr"
+[[ ! -e "$MIGRATION_TEST_CALLS" ]]
+[[ -z "$(find "$MIGRATION_TEST_UPLOADS" -type f -print -quit)" ]]
+
+echo 'Secret migration tests passed'

--- a/.github/workflows/migrate-actions-secrets-to-organization.yml
+++ b/.github/workflows/migrate-actions-secrets-to-organization.yml
@@ -1,0 +1,59 @@
+name: Migrate Actions secrets to organization
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_migration:
+        description: Create or overwrite all listed organization secrets
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  migrate:
+    if: ${{ inputs.confirm_migration }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MIGRATION_ORGANIZATION: TryQuiet
+      MIGRATION_REPOSITORIES: quiet,quiet-private
+      ANDROID_FIREBASE_KEY: ${{ secrets.ANDROID_FIREBASE_KEY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPSTORE_PASSWORD: ${{ secrets.APPSTORE_PASSWORD }}
+      APPSTORE_USER: ${{ secrets.APPSTORE_USER }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+      APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+      MIGRATION_SOURCE_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      MIGRATION_SOURCE_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      MIGRATION_SOURCE_GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GOOGLE_KEYSTORE: ${{ secrets.GOOGLE_KEYSTORE }}
+      GOOGLE_KEYSTORE_ALIAS: ${{ secrets.GOOGLE_KEYSTORE_ALIAS }}
+      GOOGLE_KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_KEYSTORE_PASSWORD }}
+      IOS_CERTIFICATE_KEY: ${{ secrets.IOS_CERTIFICATE_KEY }}
+      IOS_FIREBASE_KEY: ${{ secrets.IOS_FIREBASE_KEY }}
+      IOS_NSE_PROFILE_KEY: ${{ secrets.IOS_NSE_PROFILE_KEY }}
+      IOS_PROFILE_KEY: ${{ secrets.IOS_PROFILE_KEY }}
+      MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+      MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+      MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+      WIN_ALIAS: ${{ secrets.WIN_ALIAS }}
+      WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+      WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+
+    steps:
+      - name: Check out migration script
+        uses: actions/checkout@v5
+
+      - name: Migrate repository secrets
+        env:
+          # Keep the upload credential separate from the existing GH_TOKEN secret.
+          GH_TOKEN: ${{ secrets.ORG_SECRETS_MIGRATION_TOKEN }}
+        run: .github/scripts/migrate-actions-secrets-to-organization.sh


### PR DESCRIPTION
Adds a manually dispatched workflow that copies the 29 repository Actions secrets to the TryQuiet organization, scoped to the `quiet` and `quiet-private` repositories only. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are written as `QUIET_AWS_ACCESS_KEY_ID`/`QUIET_AWS_SECRET_ACCESS_KEY` to avoid colliding with the QSS AWS credentials.

The upload uses the `ORG_SECRETS_MIGRATION_TOKEN` repository secret. The script aborts before writing anything if any source secret is missing.

Merge and run this before merging the follow-up PR that switches desktop builds to the `QUIET_AWS_*` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CbqXj8ETpvReCSe8N9BjN