### PR TITLE
chore(ci): use scoped Quiet AWS secrets

### DIFF
--- a/.github/scripts/test-desktop-build-organization-secrets.sh
+++ b/.github/scripts/test-desktop-build-organization-secrets.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workflow="$script_dir/../workflows/desktop-build.yml"
+
+if grep -Eq 'secrets\.AWS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY)' "$workflow"; then
+  echo 'Desktop Build still references an unscoped AWS organization secret name' >&2
+  exit 1
+fi
+
+[[ "$(grep -Fc 'secrets.QUIET_AWS_ACCESS_KEY_ID' "$workflow")" -eq 6 ]]
+[[ "$(grep -Fc 'secrets.QUIET_AWS_SECRET_ACCESS_KEY' "$workflow")" -eq 6 ]]
+
+echo 'Desktop Build organization-secret scope test passed'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -181,8 +181,8 @@ jobs:
       - name: "Release"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           ARCH: x86_64
         run: cd packages/desktop && USE_HARD_LINKS=false node_modules/.bin/electron-builder -p always --linux ${{ env.ELECTRON_BUILDER_PROPS }}
 
@@ -192,8 +192,8 @@ jobs:
       - name: "Push electron-updater new checksum to S3"
         uses: TryQuiet/upload-s3-action@c1c7c2268c91fbbc1293455e7b4bb2292267d2bd # master
         with:
-          aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: ${{ env.S3_BUCKET }}
           source_dir: ${{ env.CHECKSUM_PATH }}
           destination_dir: ''
@@ -280,8 +280,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           USE_HARD_LINKS: false
         with:
           timeout_minutes: 60
@@ -392,8 +392,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           USE_HARD_LINKS: false
         with:
           timeout_minutes: 60
@@ -511,8 +511,8 @@ jobs:
       - name: Publish mac updater metadata
         uses: TryQuiet/upload-s3-action@c1c7c2268c91fbbc1293455e7b4bb2292267d2bd # master
         with:
-          aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_key_id: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           aws_bucket: ${{ env.S3_BUCKET }}
           source_dir: mac-update-info/publish/${{ env.MAC_UPDATE_CHANNEL_FILE }}
           destination_dir: ''
@@ -595,8 +595,8 @@ jobs:
           CERTIFICATE_PATH: ${{ steps.write_file.outputs.filePath }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           WINDOWS_ALIAS: ${{ secrets.WIN_ALIAS }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.QUIET_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.QUIET_AWS_SECRET_ACCESS_KEY }}
           USE_HARD_LINKS: false
         run: cd packages/desktop && node_modules/.bin/electron-builder -p always --win ${{ env.ELECTRON_BUILDER_PROPS }}
 


### PR DESCRIPTION
Switches every desktop build job to `QUIET_AWS_ACCESS_KEY_ID` / `QUIET_AWS_SECRET_ACCESS_KEY`, the organization-level names created by the migration workflow. Includes a regression test that fails if the workflow reverts to the unscoped names.

Depends on the migration workflow PR having been merged and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CbqXj8ETpvReCSe8N9BjN