### PR TITLE
Fit Android drawers to resized windows and verify photo picking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 
 ### Fixes
 
+* Keep bottom drawers within their available container when the app window resizes or rotates. [#3013](https://github.com/TryQuiet/quiet/issues/3013)
 * Keep image previews within the available window after rotating to landscape. [#3013](https://github.com/TryQuiet/quiet/issues/3013)
 * The user profile tab at the bottom of the sidebar now has the correct opacity and layout, and the faint horizontal stripe that appeared on some platforms and window sizes is gone now. [#3184](https://github.com/TryQuiet/quiet/pull/3184)
 * Improved tor lifecycle handling [#3233](https://github.com/TryQuiet/quiet/issues/3233)

--- a/packages/mobile/.storybook/index.js
+++ b/packages/mobile/.storybook/index.js
@@ -10,6 +10,7 @@ addDecorator(withNavigation)
 
 configure(() => {
   require('../src/components/AndroidCompatibility/AndroidCompatibility.stories')
+  require('../src/components/AndroidCompatibility/AndroidDrawer.stories')
   require('../src/components/JoinCommunity/JoinCommunity.stories')
   require('../src/components/LeaveCommunity/LeaveCommunity.stories')
   require('../src/components/ConnectionProcess/ConnectionProcess.stories')

--- a/packages/mobile/docs/android-api-36.md
+++ b/packages/mobile/docs/android-api-36.md
@@ -69,8 +69,8 @@ On API 36 and API 35, verify:
   status/navigation bars and cutouts with the keyboard open and closed. Check
   both gesture and three-button navigation.
 - Rotate and resize a tablet (at least 600dp); retain navigation and unsent
-  text. Pay particular attention to bottom drawers, which currently size from
-  the physical screen rather than the available app window.
+  text. Bottom drawers now size to their measured parent; check the complete
+  CAPTCHA and server-offer content with the keyboard open and closed.
 - Select/cancel photos and documents; attach, send, and open them.
 - Background messaging and notifications, followed by reopening the app;
   inspect WorkManager stop reasons and confirm backend recovery.
@@ -111,6 +111,29 @@ actual landscape dimensions, draft retention, and full composer/image-view
 visibility. Each test relaunches the app to isolate native modal state. The
 preview uses a local bundled image and fixture-owned visibility state; these
 checks do not exercise attachment downloading or opening from a channel message.
+
+Additional focused UI checks use the same Storybook build:
+
+```sh
+npx detox test android-drawer-window -c android.att.storybook --device-name <adb-serial>
+npx detox test android-photo-picker -c android.att.storybook --device-name <adb-serial>
+```
+
+`DrawerWindow` constrains the production drawer's parent, shrinks it while open,
+and rotates the activity. It checks the drawer bounds and visibility of content
+at both ends, then closes and reopens through the real close control. This
+exercises layout responses; it does not automate Android's multi-window task UI
+or the complete CAPTCHA/server-offer flows.
+
+The photo suite opens the production channel's attachment button and operates
+the external system picker. It checks cancel/selection, draft retention, local
+image preview, and removal without a backend. Android 16's app-owned-photo
+permission-dialog change applies to partial-media permission requests; Quiet
+uses individual picker grants and declares no `READ_MEDIA_IMAGES`,
+`READ_MEDIA_VIDEO`, or `READ_MEDIA_VISUAL_USER_SELECTED` permission. See
+[app-owned photos](https://developer.android.com/about/versions/16/behavior-changes-16#app-owned-photos).
+Cloud media, videos, file transfer, and permission revocation need separate
+coverage. The document-picker handler currently has no rendered entry point.
 
 ## Validation results
 

--- a/packages/mobile/docs/android-api-36.md
+++ b/packages/mobile/docs/android-api-36.md
@@ -127,7 +127,9 @@ or the complete CAPTCHA/server-offer flows.
 
 The photo suite opens the production channel's attachment button and operates
 the external system picker. It checks cancel/selection, draft retention, local
-image preview, and removal without a backend. Android 16's app-owned-photo
+image preview, and removal without a backend. It requires an English-language
+system picker and `ANDROID_HOME` or `ANDROID_SDK_ROOT` pointing to the SDK. The
+suite creates and removes its own uniquely named media fixture. Android 16's app-owned-photo
 permission-dialog change applies to partial-media permission requests; Quiet
 uses individual picker grants and declares no `READ_MEDIA_IMAGES`,
 `READ_MEDIA_VIDEO`, or `READ_MEDIA_VISUAL_USER_SELECTED` permission. See
@@ -193,10 +195,23 @@ After merging current `develop` (`e0a92300a`) in `152302980`:
   configured release workflow before uploading. Local debug/Storybook builds
   tolerate the missing configuration and do not validate push notifications.
 
+The separate UI follow-up, tested on the same updated base:
+
+- Fresh Storybook debug / AndroidTest builds, mobile TypeScript, and full mobile
+  lint passed. Seven focused tests across three unit suites and one snapshot
+  passed, including drawer layout events and fixed-height clamping.
+- The native drawer resize/rotation/close/reopen test passed on API 35 and 36,
+  with full visibility and measured bounds assertions for both parent sizes.
+- Native photo cancellation and selection/removal both passed on API 35 and 36.
+  The tests retain the draft and verify the displayed thumbnail's actual cached
+  file bytes against the seeded image. The helper supports both the older media
+  provider picker and Android 16's newer system photo-picker UI.
+
 These emulator runs used x86_64 images translating ARM64 binaries. Full backend
-onboarding and messaging, attachment selection/download/opening, drawer layouts,
-background recovery, and the iOS smoke checks remain unverified. Focused channel
-and modal tests above cover native UI dispatch without the running backend.
+onboarding and messaging, attachment transfer/download/opening from messages,
+complete CAPTCHA/server-offer flows, Android multi-window task controls,
+background recovery, and the iOS smoke checks remain unverified. The focused
+channel, modal, drawer, and local-photo tests run without the backend.
 Complete the remaining release checks above on native ARM64 Android hardware
 or a suitable ARM64 emulator before publishing.
 

--- a/packages/mobile/e2e/android-drawer-window.test.js
+++ b/packages/mobile/e2e/android-drawer-window.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict')
+const describeAndroid = device.getPlatform() === 'android' ? describe : describe.skip
+
+const expectDrawerFits = async () => {
+  const viewport = await element(by.id('android-drawer-viewport')).getAttributes()
+  const drawer = await element(by.id('android-window-drawer')).getAttributes()
+  assert(drawer.height > 0, 'The drawer must have a positive height')
+  assert(drawer.height <= viewport.height, 'The drawer must fit the available parent window')
+  await expect(element(by.id('android-window-drawer'))).toBeVisible(100)
+  await expect(element(by.id('android-window-drawer-close'))).toBeVisible(100)
+  await expect(element(by.id('android-drawer-content-top'))).toBeVisible(100)
+  await expect(element(by.id('android-drawer-content-bottom'))).toBeVisible(100)
+  return viewport
+}
+
+describeAndroid('Android drawer window compatibility', () => {
+  it('keeps drawer content and close control visible when its parent shrinks and the activity rotates', async () => {
+    await device.launchApp({ newInstance: true })
+    await device.setOrientation('portrait')
+    await waitFor(element(by.id('BottomMenu.Sidebar'))).toBeVisible().withTimeout(120000)
+    await element(by.id('BottomMenu.Sidebar')).tap()
+    await waitFor(element(by.id('Storybook.ListView.SearchBar'))).toBeVisible().withTimeout(10000)
+    await element(by.id('Storybook.ListView.SearchBar')).replaceText('AndroidCompatibility')
+    await element(by.text('DrawerWindow')).tap()
+    await element(by.id('BottomMenu.Canvas')).tap()
+
+    await element(by.id('android-drawer-open')).tap()
+    const expanded = await expectDrawerFits()
+    await element(by.id('android-drawer-resize')).tap()
+    const compact = await expectDrawerFits()
+    assert(compact.height < expanded.height, 'The available parent window must actually shrink')
+    await device.takeScreenshot('android-drawer-compact-portrait')
+
+    try {
+      await device.setOrientation('landscape')
+      const landscape = await expectDrawerFits()
+      assert(landscape.width > compact.width, 'The activity must actually rotate into a wider window')
+      await device.takeScreenshot('android-drawer-compact-landscape')
+
+      await element(by.id('android-window-drawer-close')).tap()
+      await waitFor(element(by.id('android-window-drawer'))).not.toExist().withTimeout(10000)
+      await element(by.id('android-drawer-open')).tap()
+      await expectDrawerFits()
+    } finally {
+      await device.setOrientation('portrait')
+    }
+  })
+})

--- a/packages/mobile/e2e/android-photo-picker.test.js
+++ b/packages/mobile/e2e/android-photo-picker.test.js
@@ -1,0 +1,86 @@
+// Uses production ChannelScreen and the native photo picker on API 35/36.
+// Requires an English-language Android emulator with the system photo picker.
+const createPhotoPicker = require('./utils/androidPhotoPicker')
+const describeAndroid = device.getPlatform() === 'android' ? describe : describe.skip
+const draft = 'Keep this draft while choosing a photo'
+const thumbnail = () => element(by.id('attachment-preview-image'))
+
+describeAndroid('Android photo picker compatibility', () => {
+  let picker
+
+  beforeAll(async () => {
+    picker = await createPhotoPicker(device)
+    await picker.seed()
+  })
+
+  afterAll(async () => {
+    await device.enableSynchronization()
+    if (picker) await picker.cleanup()
+  })
+
+  beforeEach(async () => {
+    await device.launchApp({ newInstance: true })
+    await device.setOrientation('portrait')
+    await waitFor(element(by.id('BottomMenu.Sidebar')))
+      .toBeVisible()
+      .withTimeout(120000)
+    await element(by.id('BottomMenu.Sidebar')).tap()
+    await waitFor(element(by.id('Storybook.ListView.SearchBar')))
+      .toBeVisible()
+      .withTimeout(10000)
+    await element(by.id('Storybook.ListView.SearchBar')).replaceText('AndroidCompatibility')
+    await element(by.text('SystemBack')).tap()
+    await element(by.id('BottomMenu.Canvas')).tap()
+    await waitFor(element(by.id('android-compatibility-reset')))
+      .toBeVisible()
+      .withTimeout(10000)
+    await element(by.id('android-compatibility-reset')).tap()
+    await element(by.id('channel_tile_general')).tap()
+    await waitFor(element(by.id('chat_general')))
+      .toBeVisible()
+      .withTimeout(10000)
+    await element(by.id('input')).tap()
+    await element(by.id('input')).replaceText(draft)
+    await device.pressBack()
+    await expect(thumbnail()).not.toExist()
+  })
+
+  const assertDraft = async () => {
+    await expect(element(by.id('android-compatibility-channel-state'))).toHaveText('general')
+    await expect(element(by.id('input'))).toHaveText(draft)
+  }
+
+  const openPicker = async () => {
+    await device.disableSynchronization()
+    await picker.openFromChannel()
+    await picker.waitUntilOpen()
+  }
+
+  it('cancels the native photo picker without leaving the channel or changing the draft', async () => {
+    try {
+      await openPicker()
+      await device.pressBack()
+    } finally {
+      await device.enableSynchronization()
+    }
+    await assertDraft()
+    await expect(thumbnail()).not.toExist()
+  })
+
+  it('selects a real local photo, displays its cached thumbnail, and removes it without losing the draft', async () => {
+    let verifyCopy
+    try {
+      await openPicker()
+      verifyCopy = await picker.selectFixture()
+    } finally {
+      await device.enableSynchronization()
+    }
+    await waitFor(thumbnail()).toBeVisible().withTimeout(10000)
+    await verifyCopy(await thumbnail().getAttributes())
+    await assertDraft()
+    await device.takeScreenshot('android-native-photo-selected')
+    await element(by.label('Remove image attachment')).tap()
+    await expect(thumbnail()).not.toExist()
+    await assertDraft()
+  })
+})

--- a/packages/mobile/e2e/utils/androidPhotoPicker.js
+++ b/packages/mobile/e2e/utils/androidPhotoPicker.js
@@ -1,0 +1,149 @@
+const assert = require('node:assert/strict')
+const { execFile } = require('node:child_process')
+const { randomUUID, createHash } = require('node:crypto')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+const appId = 'com.quietmobile.storybook.debug'
+const quote = value => `'${String(value).replace(/'/g, "'\\''")}'`
+const digest = data => createHash('sha256').update(data).digest('hex')
+const delay = () => new Promise(resolve => setTimeout(resolve, 250))
+
+// Detox 20.17.1 exposes UIAutomator through this internal proxy. Keep its use
+// here: normal Detox elements cannot inspect the separate system picker app.
+module.exports = async function androidPhotoPicker(device) {
+  const adb = path.join(process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT, 'platform-tools', 'adb')
+  const execute = (args, options = {}) => execFileAsync(adb, ['-s', device.id, ...args], { timeout: 15000, ...options })
+  const shell = async (...args) => (await execute(['shell', args.map(quote).join(' ')])).stdout
+  const fixture = path.resolve(__dirname, '../../src/assets/icons/png/quiet_icon.png')
+  const name = `quiet-picker-${randomUUID()}.png`
+  const directory = `/sdcard/Pictures/${name.slice(0, -4)}`
+  const mediaPath = `${directory}/${name}`
+  const hierarchyPath = `/data/user/0/${appId}/cache/${name}.xml`
+  const ui = device.getUiDevice()
+  let mediaUri
+  const copiedFiles = []
+
+  const poll = async (read, description) => {
+    const deadline = Date.now() + 15000
+    do {
+      const result = await read()
+      if (result) return result
+      await delay()
+    } while (Date.now() < deadline)
+    throw new Error(`Timed out waiting for ${description}`)
+  }
+
+  const nodes = async () => {
+    await ui.dumpWindowHierarchy(hierarchyPath)
+    const xml = await shell('run-as', appId, 'cat', hierarchyPath)
+    return Array.from(xml.matchAll(/<node\s+([^>]+)>/g), node =>
+      Object.fromEntries(Array.from(node[1].matchAll(/([\w-]+)="([^"]*)"/g), attribute => [attribute[1], attribute[2]]))
+    )
+  }
+
+  const find = (predicate, description) =>
+    poll(async () => {
+      const matches = (await nodes()).filter(predicate)
+      assert(matches.length <= 1, `Expected one ${description}, found ${matches.length}`)
+      return matches[0]
+    }, description)
+
+  const tap = async node => {
+    const bounds = node.bounds.match(/^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$/)
+    assert(bounds, `Missing native bounds: ${JSON.stringify(node)}`)
+    const [, left, top, right, bottom] = bounds.map(Number)
+    assert(right > left && bottom > top, 'The native picker target must have nonempty bounds')
+    await ui.click(Math.floor((left + right) / 2), Math.floor((top + bottom) / 2))
+  }
+
+  return {
+    async openFromChannel() {
+      // The composer moves while Android dismisses the keyboard. Resolve its
+      // final native bounds before tapping the production paperclip.
+      await poll(
+        async () => (await shell('dumpsys', 'input_method')).includes('mDecorViewVisible=false'),
+        'keyboard dismissal'
+      )
+      await tap(await find(node => node['resource-id'] === 'attach_file_button', 'the production attachment button'))
+    },
+
+    async seed() {
+      await shell('mkdir', '-p', directory)
+      await execute(['push', fixture, mediaPath])
+      // A distinct future date identifies only our fixture in the native
+      // accessibility tree, without selecting another photo or fixed coordinates.
+      await shell('touch', '-t', '209901010000', mediaPath)
+      await shell('am', 'broadcast', '-a', 'android.intent.action.MEDIA_SCANNER_SCAN_FILE', '-d', `file://${mediaPath}`)
+      mediaUri = await poll(async () => {
+        const rows = await shell(
+          'content',
+          'query',
+          '--uri',
+          'content://media/external/images/media',
+          '--projection',
+          '_id',
+          '--where',
+          `_display_name='${name}'`
+        )
+        const id = rows.match(/_id=(\d+)/)
+        return id && `content://media/external/images/media/${id[1]}`
+      }, 'the seeded photo in MediaStore')
+    },
+
+    async waitUntilOpen() {
+      await poll(
+        async () =>
+          /^com\.(?:google\.android|android)\.(?:providers\.media\.module|photopicker)$/.test(
+            await ui.getCurrentPackageName()
+          ),
+        'the system photo picker'
+      )
+      await find(node => node.text === 'Photos', 'the native photo picker tab')
+    },
+
+    async selectFixture() {
+      const before = new Set((await shell('run-as', appId, 'ls', 'cache')).split('\n'))
+      await tap(await find(node => /Photo taken on .*2099/.test(node['content-desc']), 'the seeded photo'))
+      await tap(
+        await find(
+          node =>
+            (node['resource-id'].endsWith(':id/button_add') ||
+              /^Add\s*\(1\)$/.test(node.text) ||
+              node.text === 'Done') &&
+            node.enabled === 'true',
+          'the photo picker confirmation button'
+        )
+      )
+      return async thumbnailAttributes => {
+        const candidates = (await shell('run-as', appId, 'ls', 'cache'))
+          .split('\n')
+          .filter(file => !before.has(file) && /^rn_image_picker_lib_temp_[\w-]+\.png$/.test(file))
+        // The library also copies media while resolving originalPath. Verify
+        // the file used by the production thumbnail, then clean all own copies.
+        assert(
+          candidates.includes(`${thumbnailAttributes.label}.png`),
+          'The thumbnail must use the newly selected native picker cache file'
+        )
+        const expected = digest(await fs.readFile(fixture))
+        for (const candidate of candidates) {
+          const copy = (
+            await execute(['exec-out', 'run-as', appId, 'cat', `cache/${candidate}`], { encoding: 'buffer' })
+          ).stdout
+          assert.equal(digest(copy), expected, 'The native picker must return the seeded image bytes')
+          copiedFiles.push(candidate)
+        }
+      }
+    },
+
+    async cleanup() {
+      if (mediaUri) await shell('content', 'delete', '--uri', mediaUri)
+      await shell('rm', '-f', mediaPath)
+      await shell('rmdir', directory)
+      for (const copiedFile of copiedFiles) await shell('run-as', appId, 'rm', '-f', `cache/${copiedFile}`)
+      await shell('run-as', appId, 'rm', '-f', hierarchyPath)
+    },
+  }
+}

--- a/packages/mobile/src/components/AndroidCompatibility/AndroidDrawer.stories.tsx
+++ b/packages/mobile/src/components/AndroidCompatibility/AndroidDrawer.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import { Button, Platform, StatusBar, Text, View, useWindowDimensions } from 'react-native'
+import { storiesOf } from '@storybook/react-native'
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
+import { ModalBottomDrawer } from '../ModalBottomDrawer/ModalBottomDrawer.component'
+
+// A smaller parent reproduces the available space of a resized activity or a
+// safe-area container without relying on a device's multi-window controls.
+const DrawerWindowStory = () => {
+  const { height } = useWindowDimensions()
+  const [compact, setCompact] = useState(false)
+  const [visible, setVisible] = useState(false)
+
+  if (Platform.OS !== 'android') return <Text>This fixture exercises Android window resizing.</Text>
+
+  return (
+    <SafeAreaProvider>
+      <SafeAreaView style={{ flex: 1, backgroundColor: 'white' }}>
+        <StatusBar barStyle='dark-content' />
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Button title='Open drawer' testID='android-drawer-open' onPress={() => setVisible(true)} />
+          <Button title='Resize window' testID='android-drawer-resize' onPress={() => setCompact(value => !value)} />
+        </View>
+        <View
+          testID='android-drawer-viewport'
+          style={{ height: Math.min(height * (compact ? 0.35 : 0.6), compact ? 220 : 400), backgroundColor: '#ddd' }}
+        >
+          <ModalBottomDrawer
+            visible={visible}
+            onClose={() => setVisible(false)}
+            heightRatio={1}
+            testIdPrefix='android-window-drawer'
+          >
+            <View style={{ flex: 1, justifyContent: 'space-between', paddingHorizontal: 12 }}>
+              <Text testID='android-drawer-content-top'>Top of drawer content</Text>
+              <Text testID='android-drawer-content-bottom'>Bottom of drawer content</Text>
+            </View>
+          </ModalBottomDrawer>
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
+  )
+}
+
+storiesOf('AndroidCompatibility', module).add('DrawerWindow', () => <DrawerWindowStory />)

--- a/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.component.tsx
+++ b/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.component.tsx
@@ -24,7 +24,10 @@ const FilePreviewComponent: React.FC<FilePreviewComponentProps> = ({ fileData, o
         marginTop: 10,
       }}
     >
-      <TouchableWithoutFeedback onPress={onClick}>
+      <TouchableWithoutFeedback
+        onPress={onClick}
+        accessibilityLabel={imageType ? 'Remove image attachment' : `Remove attachment ${fileData.name}`}
+      >
         <View
           style={{
             position: 'absolute',
@@ -60,6 +63,7 @@ const FilePreviewComponent: React.FC<FilePreviewComponentProps> = ({ fileData, o
       >
         {imageType && fileData.path ? (
           <Image
+            testID='attachment-preview-image'
             source={{ uri: fileData.path }}
             alt={fileData.name}
             style={{

--- a/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.test.tsx
+++ b/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.test.tsx
@@ -53,6 +53,7 @@ describe('FileAttachmentPreview component', () => {
             }
           >
             <View
+              accessibilityLabel="Remove image attachment"
               accessibilityState={
                 {
                   "busy": undefined,
@@ -126,6 +127,7 @@ describe('FileAttachmentPreview component', () => {
                     "width": 64,
                   }
                 }
+                testID="attachment-preview-image"
               />
             </View>
           </View>
@@ -140,6 +142,7 @@ describe('FileAttachmentPreview component', () => {
             }
           >
             <View
+              accessibilityLabel="Remove attachment otherfile.txt"
               accessibilityState={
                 {
                   "busy": undefined,

--- a/packages/mobile/src/components/ModalBottomDrawer/ModalBottomDrawer.component.tsx
+++ b/packages/mobile/src/components/ModalBottomDrawer/ModalBottomDrawer.component.tsx
@@ -1,5 +1,13 @@
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
-import { Animated, Dimensions, Easing, PanResponder, TouchableWithoutFeedback, View, Image } from 'react-native'
+import {
+  Animated,
+  Easing,
+  PanResponder,
+  TouchableWithoutFeedback,
+  View,
+  Image,
+  useWindowDimensions,
+} from 'react-native'
 import { defaultPalette } from '../../styles/palettes/default.palette'
 import { icons } from '../../assets'
 import { ModalBottomDrawerProps } from './ModalBottomDrawer.types'
@@ -13,8 +21,12 @@ export const ModalBottomDrawer: FC<ModalBottomDrawerProps> = ({
   heightRatio = 2 / 3,
   heightPx,
 }) => {
-  const screenH = Dimensions.get('screen').height
-  const SHEET_H = Math.min(Math.round(heightPx ?? screenH * heightRatio), screenH)
+  const { height: windowHeight } = useWindowDimensions()
+  const [containerHeight, setContainerHeight] = useState<number>()
+  // The parent can be smaller than the activity window (for example, inside a
+  // safe area). Its layout also changes when the activity rotates or resizes.
+  const availableHeight = containerHeight ?? windowHeight
+  const SHEET_H = Math.min(Math.round(heightPx ?? availableHeight * heightRatio), availableHeight)
   const OPEN_Y = 0
   const CLOSED_Y = SHEET_H // translateY relative to its anchored position
 
@@ -114,6 +126,8 @@ export const ModalBottomDrawer: FC<ModalBottomDrawerProps> = ({
 
   return (
     <View
+      testID={`${testIdPrefix}-container`}
+      onLayout={({ nativeEvent }) => setContainerHeight(nativeEvent.layout.height)}
       pointerEvents='box-none'
       style={{
         position: 'absolute',
@@ -142,6 +156,7 @@ export const ModalBottomDrawer: FC<ModalBottomDrawerProps> = ({
         testID={testIdPrefix}
         style={{
           height: SHEET_H,
+          maxHeight: '100%',
           width: '100%',
           backgroundColor: defaultPalette.background.white,
           borderTopLeftRadius: 12,
@@ -180,7 +195,12 @@ export const ModalBottomDrawer: FC<ModalBottomDrawerProps> = ({
             paddingHorizontal: 4,
           }}
         >
-          <TouchableWithoutFeedback onPress={onClose}>
+          <TouchableWithoutFeedback
+            testID={`${testIdPrefix}-close`}
+            accessibilityRole='button'
+            accessibilityLabel='Close drawer'
+            onPress={onClose}
+          >
             <View style={{ width: 56, height: 56, alignItems: 'center', justifyContent: 'center' }}>
               <Image
                 source={icons.arrow_left}

--- a/packages/mobile/src/components/ModalBottomDrawer/ModalBottomDrawer.test.tsx
+++ b/packages/mobile/src/components/ModalBottomDrawer/ModalBottomDrawer.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react-native'
+import { Dimensions, Text } from 'react-native'
+
+import { ModalBottomDrawer } from './ModalBottomDrawer.component'
+
+const initialDimensions = {
+  window: Dimensions.get('window'),
+  screen: Dimensions.get('screen'),
+}
+
+const resizeContainer = (width: number, height: number) =>
+  fireEvent(screen.getByTestId('drawer-container'), 'layout', {
+    nativeEvent: { layout: { x: 0, y: 0, width, height } },
+  })
+
+describe('ModalBottomDrawer window sizing', () => {
+  beforeEach(() => {
+    Dimensions.set({
+      window: { width: 390, height: 760, scale: 1, fontScale: 1 },
+      screen: { width: 390, height: 844, scale: 1, fontScale: 1 },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    Dimensions.set(initialDimensions)
+  })
+
+  it('fits a full-height drawer inside its safe-area parent and updates after rotation', () => {
+    const onClose = jest.fn()
+    render(
+      <ModalBottomDrawer visible onClose={onClose} testIdPrefix='drawer' heightRatio={1}>
+        <Text>Captcha content</Text>
+      </ModalBottomDrawer>
+    )
+
+    // The window is the initial bound, never the larger physical display.
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 760, maxHeight: '100%' })
+
+    resizeContainer(390, 704)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 704 })
+
+    act(() => {
+      Dimensions.set({
+        window: { width: 844, height: 390, scale: 1, fontScale: 1 },
+        screen: { width: 844, height: 390, scale: 1, fontScale: 1 },
+      })
+    })
+    resizeContainer(796, 330)
+
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 330 })
+    expect(screen.getByText('Captcha content')).toBeOnTheScreen()
+    fireEvent.press(screen.getByRole('button', { name: 'Close drawer' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('resizes a proportional drawer when only its parent changes size', () => {
+    render(<ModalBottomDrawer visible onClose={jest.fn()} testIdPrefix='drawer' />)
+
+    resizeContainer(390, 600)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 400 })
+
+    // A parent layout change need not produce a Dimensions change event.
+    resizeContainer(390, 300)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 200 })
+
+    resizeContainer(390, 600)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 400 })
+  })
+
+  it('clamps a fixed-height drawer to its container and restores its requested height when space returns', () => {
+    render(<ModalBottomDrawer visible onClose={jest.fn()} testIdPrefix='drawer' heightPx={600} />)
+
+    resizeContainer(390, 704)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 600 })
+
+    resizeContainer(390, 320)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 320 })
+
+    resizeContainer(390, 704)
+    expect(screen.getByTestId('drawer')).toHaveStyle({ height: 600 })
+  })
+})


### PR DESCRIPTION
Bottom drawers sized themselves from the physical display, so a drawer could extend outside a smaller app container and fail to adapt when it resized. They now use the measured container height, clamp fixed heights, and keep their close control accessible. Adds native coverage for shrinking and rotating the drawer's parent, then closing and reopening it.

Also verifies Quiet's existing photo-selection flow through the real Android system picker: cancellation preserves the channel draft; selection produces a visible thumbnail whose cached bytes match the seeded image; removal preserves the draft. Adds an accessible image-removal label. The test helper supports both Android 15's media-provider picker and Android 16's newer picker UI, and cleans up only its own fixture media.

Stacked on #3420; merge that SDK update first, then retarget this PR to `develop`. Partial follow-up to #3013. The React Native migration and remaining release checks stay open.

### Current develop integration — September 21, 2026

Refreshed onto the updated #3420 parent, including `develop` at `0ab5e2010`. The implementation merged cleanly. Fresh validation at `c358210c1` (subsequent changes only merge/record documentation):

- 11-package bootstrap, mobile TypeScript and full mobile lint pass (14 warnings, no errors).
- Full mobile Jest: 74 suites / 252 tests / 44 snapshots pass, with three existing suites/tests skipped.
- Fresh Storybook app and instrumentation APK builds pass.
- All three native scenarios pass on both API 35 and API 36: drawer parent shrink/rotation and close/reopen; photo-picker cancellation; selection with byte-for-byte cached-image verification, thumbnail display and removal. Photo cases retain the draft and current channel.

Merge after #3420 and retarget to `develop`. These tests use production UI components with the backend disabled; full attachment transfer, iOS behavior and actual multi-window task controls remain outside this focused coverage.

### Earlier validation

- Rebuilt Storybook debug and AndroidTest APKs on the SDK branch with current `develop` merged.
- Three native scenarios passed on each of API 35 and 36: drawer resize/rotation and photo cancel/select/remove. The tests exercise production components without the backend.
- Seven focused unit tests across three suites and one snapshot passed; mobile TypeScript and full mobile lint passed.
- Independent code review found no material issues. Full attachment transfer, complete CAPTCHA/server-offer content, actual multi-window task controls, and iOS checks remain outside this focused coverage.

Commands, evidence, and remaining checks are in `packages/mobile/docs/android-api-36.md`.

### Pull Request Checklist

- [x] I have linked this PR to a related GitHub issue.
- [x] I have added a description of the change and issue number to the root CHANGELOG.md.

### Mobile checklist

- [x] I have run E2E tests for mobile (focused device coverage described above).
- [ ] I have updated base screenshots for visual regression tests.
