### PR TITLE
Update links for 9.0.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,24 +130,24 @@
       <p>Quiet is available for all major platforms. (And eventually the web, too!)</p>
       <div class="badges" style="align-items:flex-start;">
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%408.0.0/Quiet-8.0.0-arm64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0-arm64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Apple Silicon) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Apple Silicon</p>
         </div>
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%408.0.0/Quiet-8.0.0-x64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0-x64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Intel) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Intel</p>
         </div>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%408.0.0/Quiet.Setup.8.0.0.exe"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet.Setup.9.0.0.exe"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%408.0.0/Quiet-8.0.0.AppImage"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0.AppImage"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
         </a>
@@ -161,7 +161,7 @@
         <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
           <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%408.0.0/app-standard-release.apk"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%409.0.0/app-standard-release.apk"
           class="qt-hero-badge w-inline-block">
           <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download">
         </a>

--- a/index.html
+++ b/index.html
@@ -130,24 +130,24 @@
       <p>Quiet is available for all major platforms. (And eventually the web, too!)</p>
       <div class="badges" style="align-items:flex-start;">
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0-arm64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.2/Quiet-9.0.2-arm64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Apple Silicon) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Apple Silicon</p>
         </div>
         <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
-          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0-x64.dmg"
+          <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.2/Quiet-9.0.2-x64.dmg"
             class="qt-hero-badge w-inline-block">
             <img src="images/badge-mac.png" loading="lazy" srcset="images/badge-mac-p-500.png 500w, images/badge-mac.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for macOS (Intel) download">
           </a>
           <p class="qt-caption" style="text-align:center;margin:0;">Intel</p>
         </div>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet.Setup.9.0.0.exe"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.2/Quiet.Setup.9.0.2.exe"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-windows.png" loading="lazy" srcset="images/badge-windows-p-500.png 500w, images/badge-windows.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Windows download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.0/Quiet-9.0.0.AppImage"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%409.0.2/Quiet-9.0.2.AppImage"
           class="qt-hero-badge w-inline-block">
           <img src="images/badge-linux.png" loading="lazy" srcset="images/badge-linux-p-500.png 500w, images/badge-linux.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for Linux download">
         </a>
@@ -161,7 +161,7 @@
         <a href="https://testflight.apple.com/join/yaUjeiW7" class="qt-hero-badge w-inline-block">
           <img src="images/badge-app-store.png" loading="lazy" srcset="images/badge-app-store-p-500.png 500w, images/badge-app-store.png 730w" sizes="(max-width: 479px) 160px, 150px" alt="Quiet for iOS App Store download">
         </a>
-        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%409.0.0/app-standard-release.apk"
+        <a href="https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fmobile%409.0.2/app-standard-release.apk"
           class="qt-hero-badge w-inline-block">
           <img src="images/bagde-adroid-sdk.png" loading="lazy" alt="Quiet for Android .apk download">
         </a>


### PR DESCRIPTION
Points the desktop (macOS arm64/x64, Windows, Linux AppImage) and Android APK download links at the `@quiet/desktop@9.0.0` and `@quiet/mobile@9.0.0` releases, following the same pattern as the 8.0.0 update.

Note: as of opening this PR the 9.0.0 releases exist only on `quiet-private`, so these links will 404 until the releases and assets are published on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEFgjqYgysSvdCdNg5LZqE