### PR TITLE
Bind private-channel sends and attachments to their originating channel

### DIFF
--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -874,10 +874,11 @@ app.on('ready', async () => {
       id,
       name,
       ext: arg.ext,
+      channelId: arg.channelId,
     })
   })
 
-  ipcMain.on('openUploadFileDialog', async e => {
+  ipcMain.on('openUploadFileDialog', async (e, channelId: string) => {
     logger.info('ipcMain: openUploadFileDialog')
     let filesDialogResult: Electron.OpenDialogReturnValue
     if (!mainWindow) {
@@ -902,7 +903,8 @@ app.on('ready', async () => {
           filesDialogResult.filePaths.map(filePath => {
             return { path: filePath }
           })
-        )
+        ),
+        channelId
       )
     }
   })

--- a/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
@@ -1,31 +1,62 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
+import { ipcRenderer } from 'electron'
 import { files, messages, publicChannels } from '@quiet/state-manager'
 import Channel from './Channel'
 import { type ChannelComponentProps } from './ChannelComponent'
 
 const mockDispatch = jest.fn()
 const mockSelections = new Map()
+const mockListeners = new Map<string, Set<(...args: any[]) => void>>()
 
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
   useSelector: (selector: unknown) => mockSelections.get(selector),
 }))
 jest.mock('electron', () => ({
-  ipcRenderer: { on: jest.fn() },
+  ipcRenderer: {
+    send: jest.fn(),
+    on: (event: string, listener: (...args: any[]) => void) => {
+      if (!mockListeners.has(event)) mockListeners.set(event, new Set())
+      mockListeners.get(event)!.add(listener)
+    },
+    removeListener: (event: string, listener: (...args: any[]) => void) => {
+      mockListeners.get(event)?.delete(listener)
+    },
+  },
   webUtils: { getPathForFile: (file: { path: string }) => file.path },
 }))
 jest.mock('../../containers/hooks', () => ({ useModal: () => ({}) }))
 jest.mock('../../../hooks/useContextMenu', () => ({ useContextMenu: () => ({}) }))
 jest.mock('./ChannelComponent', () => ({
   __esModule: true,
-  default: ({ onInputEnter, handleFileDrop }: Pick<ChannelComponentProps, 'onInputEnter' | 'handleFileDrop'>) => (
+  default: ({ onInputEnter, handleFileDrop, openFilesDialog, handleClipboardFiles }: ChannelComponentProps) => (
     <>
       <button onClick={() => handleFileDrop({ files: [{ path: '/file.txt' }] })}>Attach</button>
       <button onClick={() => onInputEnter('message')}>Send</button>
+      <button onClick={openFilesDialog}>Dialog</button>
+      <button onClick={() => handleClipboardFiles(new ArrayBuffer(1), '.png', 'clipboard')}>Paste</button>
     </>
   ),
 }))
+
+beforeEach(() => {
+  mockDispatch.mockClear()
+  mockSelections.clear()
+  mockListeners.clear()
+})
+
+const selectChannel = (id: string, isPublic: boolean) => {
+  mockSelections.set(publicChannels.selectors.currentChannelId, id)
+  mockSelections.set(publicChannels.selectors.currentChannelName, 'same-name')
+  mockSelections.set(publicChannels.selectors.currentChannel, { id, name: 'same-name', public: isPublic })
+}
+
+const emitIpc = (event: string, ...args: any[]) => {
+  act(() => {
+    mockListeners.get(event)?.forEach(listener => listener({}, ...args))
+  })
+}
 
 it('submits text and attachments with the channel displayed by that composer', () => {
   mockSelections.set(publicChannels.selectors.currentChannelId, 'private-channel')
@@ -49,4 +80,55 @@ it('submits text and attachments with the channel displayed by that composer', (
   expect(mockDispatch).toHaveBeenCalledWith(
     files.actions.attachFile({ path: '/file.txt', name: 'file', ext: '.txt', channelId: 'public-channel' })
   )
+})
+
+it('discards an unsubmitted private attachment when switching to a same-name public channel', () => {
+  selectChannel('private-channel', false)
+  const view = render(<Channel />)
+  fireEvent.click(view.getByText('Attach'))
+
+  selectChannel('public-channel', true)
+  view.rerender(<Channel />)
+  fireEvent.click(view.getByText('Send'))
+
+  expect(mockDispatch).toHaveBeenCalledWith(
+    messages.actions.sendMessage({ message: 'message', channelId: 'public-channel' })
+  )
+  expect(mockDispatch.mock.calls.some(([action]) => action.type === files.actions.attachFile.type)).toBe(false)
+  expect(mockListeners.get('openedFiles')?.size).toBe(1)
+  expect(mockListeners.get('writeTempFileReply')?.size).toBe(1)
+})
+
+it('binds file dialog and clipboard replies to their originating channel', () => {
+  selectChannel('private-channel', false)
+  const view = render(<Channel />)
+  fireEvent.click(view.getByText('Dialog'))
+  fireEvent.click(view.getByText('Paste'))
+  expect(ipcRenderer.send).toHaveBeenCalledWith('openUploadFileDialog', 'private-channel')
+  expect(ipcRenderer.send).toHaveBeenCalledWith(
+    'writeTempFile',
+    expect.objectContaining({ channelId: 'private-channel' })
+  )
+
+  selectChannel('public-channel', true)
+  view.rerender(<Channel />)
+  const dialogFile = { path: '/dialog.txt', name: 'dialog', ext: '.txt' }
+  const clipboardFile = { path: '/clipboard.png', name: 'clipboard', ext: '.png' }
+  emitIpc('openedFiles', { dialog: dialogFile }, 'private-channel')
+  emitIpc('writeTempFileReply', { ...clipboardFile, id: 'clipboard', channelId: 'private-channel' })
+  fireEvent.click(view.getByText('Send'))
+  expect(mockDispatch.mock.calls.some(([action]) => action.type === files.actions.attachFile.type)).toBe(false)
+
+  fireEvent.click(view.getByText('Dialog'))
+  fireEvent.click(view.getByText('Paste'))
+  expect(ipcRenderer.send).toHaveBeenCalledWith('openUploadFileDialog', 'public-channel')
+  expect(ipcRenderer.send).toHaveBeenCalledWith(
+    'writeTempFile',
+    expect.objectContaining({ channelId: 'public-channel' })
+  )
+  emitIpc('openedFiles', { dialog: dialogFile }, 'public-channel')
+  emitIpc('writeTempFileReply', { ...clipboardFile, id: 'clipboard', channelId: 'public-channel' })
+  fireEvent.click(view.getByText('Send'))
+  expect(mockDispatch).toHaveBeenCalledWith(files.actions.attachFile({ ...dialogFile, channelId: 'public-channel' }))
+  expect(mockDispatch).toHaveBeenCalledWith(files.actions.attachFile({ ...clipboardFile, channelId: 'public-channel' }))
 })

--- a/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import { files, messages, publicChannels } from '@quiet/state-manager'
+import Channel from './Channel'
+import { type ChannelComponentProps } from './ChannelComponent'
+
+const mockDispatch = jest.fn()
+const mockSelections = new Map()
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: unknown) => mockSelections.get(selector),
+}))
+jest.mock('electron', () => ({
+  ipcRenderer: { on: jest.fn() },
+  webUtils: { getPathForFile: (file: { path: string }) => file.path },
+}))
+jest.mock('../../containers/hooks', () => ({ useModal: () => ({}) }))
+jest.mock('../../../hooks/useContextMenu', () => ({ useContextMenu: () => ({}) }))
+jest.mock('./ChannelComponent', () => ({
+  __esModule: true,
+  default: ({ onInputEnter, handleFileDrop }: Pick<ChannelComponentProps, 'onInputEnter' | 'handleFileDrop'>) => (
+    <>
+      <button onClick={() => handleFileDrop({ files: [{ path: '/file.txt' }] })}>Attach</button>
+      <button onClick={() => onInputEnter('message')}>Send</button>
+    </>
+  ),
+}))
+
+it('submits text and attachments with the channel displayed by that composer', () => {
+  mockSelections.set(publicChannels.selectors.currentChannelId, 'private-channel')
+  const view = render(<Channel />)
+  fireEvent.click(view.getByText('Attach'))
+  fireEvent.click(view.getByText('Send'))
+  expect(mockDispatch).toHaveBeenCalledWith(
+    messages.actions.sendMessage({ message: 'message', channelId: 'private-channel' })
+  )
+  expect(mockDispatch).toHaveBeenCalledWith(
+    files.actions.attachFile({ path: '/file.txt', name: 'file', ext: '.txt', channelId: 'private-channel' })
+  )
+
+  mockSelections.set(publicChannels.selectors.currentChannelId, 'public-channel')
+  view.rerender(<Channel />)
+  fireEvent.click(view.getByText('Attach'))
+  fireEvent.click(view.getByText('Send'))
+  expect(mockDispatch).toHaveBeenCalledWith(
+    messages.actions.sendMessage({ message: 'message', channelId: 'public-channel' })
+  )
+  expect(mockDispatch).toHaveBeenCalledWith(
+    files.actions.attachFile({ path: '/file.txt', name: 'file', ext: '.txt', channelId: 'public-channel' })
+  )
+})

--- a/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.test.tsx
@@ -24,7 +24,12 @@ jest.mock('electron', () => ({
       mockListeners.get(event)?.delete(listener)
     },
   },
-  webUtils: { getPathForFile: (file: { path: string }) => file.path },
+  webUtils: {
+    getPathForFile: (file: File & { path?: string }) => {
+      if (!(file instanceof File)) throw new TypeError('Expected a File object')
+      return file.path ?? ''
+    },
+  },
 }))
 jest.mock('../../containers/hooks', () => ({ useModal: () => ({}) }))
 jest.mock('../../../hooks/useContextMenu', () => ({ useContextMenu: () => ({}) }))
@@ -32,7 +37,15 @@ jest.mock('./ChannelComponent', () => ({
   __esModule: true,
   default: ({ onInputEnter, handleFileDrop, openFilesDialog, handleClipboardFiles }: ChannelComponentProps) => (
     <>
-      <button onClick={() => handleFileDrop({ files: [{ path: '/file.txt' }] })}>Attach</button>
+      <button
+        onClick={() => {
+          // Stand in for a native dropped File whose disk path is supplied by Electron.
+          const file = Object.assign(new File([], 'file.txt'), { path: '/file.txt' })
+          handleFileDrop({ files: [file] })
+        }}
+      >
+        Attach
+      </button>
       <button onClick={() => onInputEnter('message')}>Send</button>
       <button onClick={openFilesDialog}>Dialog</button>
       <button onClick={() => handleClipboardFiles(new ArrayBuffer(1), '.png', 'clipboard')}>Paste</button>

--- a/packages/desktop/src/renderer/components/Channel/Channel.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.tsx
@@ -67,18 +67,19 @@ const Channel = () => {
 
   const onInputEnter = useCallback(
     (message: string) => {
+      if (!currentChannelId) return
       // Send message out of input value
       if (message) {
-        dispatch(messages.actions.sendMessage({ message }))
+        dispatch(messages.actions.sendMessage({ message, channelId: currentChannelId }))
       }
       // Upload files, then send corresponding message (contaning cid) for each of them
       Object.values(filesRef.current).forEach((fileData: FileContent) => {
-        dispatch(files.actions.attachFile(fileData))
+        dispatch(files.actions.attachFile({ ...fileData, channelId: currentChannelId }))
       })
       // Reset file previews for input state
       setAttachingFiles({})
     },
-    [dispatch]
+    [dispatch, currentChannelId]
   )
 
   React.useEffect(() => {

--- a/packages/desktop/src/renderer/components/Channel/Channel.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.tsx
@@ -144,7 +144,7 @@ const ChannelContent = () => {
           [arg.id]: {
             ext: arg.ext,
             name: arg.name,
-            path: webUtils.getPathForFile(arg),
+            path: arg.path,
           },
         }
 

--- a/packages/desktop/src/renderer/components/Channel/Channel.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.tsx
@@ -19,7 +19,7 @@ import { FileActionsProps } from './File/FileComponent/FileComponent'
 import { useContextMenu } from '../../../hooks/useContextMenu'
 import { MenuName } from '../../../const/MenuNames.enum'
 
-const Channel = () => {
+const ChannelContent = () => {
   const dispatch = useDispatch()
 
   const user = useSelector(users.selectors.myUserProfile)
@@ -131,11 +131,13 @@ const Channel = () => {
       fileName: `${id}${ext}`,
       fileBuffer: new Uint8Array(imageBuffer),
       ext: ext,
+      channelId: currentChannelId,
     })
   }
 
   useEffect(() => {
-    ipcRenderer.on('writeTempFileReply', (_event, arg) => {
+    const onTempFile = (_event: Electron.IpcRendererEvent, arg: any) => {
+      if (arg.channelId !== currentChannelId) return
       setAttachingFiles(existingFiles => {
         const updatedFiles = {
           ...existingFiles,
@@ -148,18 +150,27 @@ const Channel = () => {
 
         return updatedFiles
       })
-    })
-  }, [])
+    }
+    ipcRenderer.on('writeTempFileReply', onTempFile)
+    return () => {
+      ipcRenderer.removeListener('writeTempFileReply', onTempFile)
+    }
+  }, [currentChannelId])
 
   useEffect(() => {
-    ipcRenderer.on('openedFiles', (e, filesData: FilePreviewData) => {
+    const onOpenedFiles = (_event: Electron.IpcRendererEvent, filesData: FilePreviewData, channelId: string) => {
+      if (channelId !== currentChannelId) return
       updateAttachingFiles(filesData)
-    })
-  }, [])
+    }
+    ipcRenderer.on('openedFiles', onOpenedFiles)
+    return () => {
+      ipcRenderer.removeListener('openedFiles', onOpenedFiles)
+    }
+  }, [currentChannelId])
 
   const openFilesDialog = useCallback(() => {
-    ipcRenderer.send('openUploadFileDialog')
-  }, [])
+    ipcRenderer.send('openUploadFileDialog', currentChannelId)
+  }, [currentChannelId])
 
   const openUrl = useCallback((url: string) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -246,6 +257,11 @@ const Channel = () => {
       )}
     </>
   )
+}
+
+const Channel = () => {
+  const channelId = useSelector(publicChannels.selectors.currentChannelId)
+  return <ChannelContent key={channelId} />
 }
 
 export default Channel

--- a/packages/desktop/src/rtl-tests/channel.main.test.tsx
+++ b/packages/desktop/src/rtl-tests/channel.main.test.tsx
@@ -60,7 +60,7 @@ describe('PublicChannel', () => {
     window.Notification = notification
     jest.mock('electron', () => {
       return {
-        ipcRenderer: { on: () => {}, send: jest.fn(), sendSync: jest.fn() },
+        ipcRenderer: { on: () => {}, removeListener: jest.fn(), send: jest.fn(), sendSync: jest.fn() },
         remote: {
           BrowserWindow: {
             getAllWindows: () => {

--- a/packages/desktop/src/rtl-tests/channel.main.test.tsx
+++ b/packages/desktop/src/rtl-tests/channel.main.test.tsx
@@ -498,6 +498,7 @@ describe('PublicChannel', () => {
 
     for (const msg of messagesText) {
       const message = await baseTypesFactory.build('ChannelMessage', {
+        verified: true,
         createdAt: messagesText.indexOf(msg) + 1,
         channelId: generalId,
         userId: alice.userId,
@@ -790,7 +791,8 @@ describe('PublicChannel', () => {
         })
       } else if (action === SocketActions.SEND_MESSAGE) {
         const data = input[1] as ChannelMessage
-        const payload = data
+        // Model the backend's per-message transport verification marker.
+        const payload = { ...data, verified: true }
         return socket.socketClient.emit<MessagesLoadedPayload>(SocketEvents.MESSAGES_STORED, {
           messages: [payload],
         })
@@ -1195,6 +1197,7 @@ describe('PublicChannel', () => {
 
     const baseTypesFactory = await getBaseTypesFactory()
     const message: ChannelMessage = await baseTypesFactory.build('ChannelMessage', {
+      verified: true,
       id: messageId,
       type: MessageType.File,
       message: '',
@@ -1311,6 +1314,7 @@ describe('PublicChannel', () => {
 
     const baseTypesFactory = await getBaseTypesFactory()
     const message: ChannelMessage = await baseTypesFactory.build('ChannelMessage', {
+      verified: true,
       id: messageId,
       type: MessageType.File,
       message: '',
@@ -1435,6 +1439,7 @@ describe('PublicChannel', () => {
     }
 
     const message = await baseTypesFactory.build('ChannelMessage', {
+      verified: true,
       id: messageId,
       type: MessageType.File,
       message: '',

--- a/packages/desktop/src/rtl-tests/channel.main.test.tsx
+++ b/packages/desktop/src/rtl-tests/channel.main.test.tsx
@@ -409,8 +409,15 @@ describe('PublicChannel', () => {
     )
 
     const messageText = 'Hello!'
+    const channelId = publicChannels.selectors.currentChannelId(store.getState())
+    if (!channelId) throw new Error('no current channel')
 
-    store.dispatch(messages.actions.sendMessage({ message: messageText }))
+    store.dispatch(
+      messages.actions.sendMessage({
+        message: messageText,
+        channelId,
+      })
+    )
 
     await act(async () => {})
 
@@ -831,7 +838,14 @@ describe('PublicChannel', () => {
       store
     )
 
-    store.dispatch(files.actions.attachFile(fileContent))
+    const channelId = publicChannels.selectors.currentChannelId(store.getState())
+    if (!channelId) throw new Error('no current channel')
+    store.dispatch(
+      files.actions.attachFile({
+        ...fileContent,
+        channelId,
+      })
+    )
 
     await act(async () => {
       await new Promise(resolve => {
@@ -1101,8 +1115,15 @@ describe('PublicChannel', () => {
       </>,
       store
     )
+    const channelId = publicChannels.selectors.currentChannelId(store.getState())
+    if (!channelId) throw new Error('no current channel')
     await act(async () => {
-      store.dispatch(files.actions.attachFile(fileContent))
+      store.dispatch(
+        files.actions.attachFile({
+          ...fileContent,
+          channelId,
+        })
+      )
     })
     // Confirm file component displays in HOSTED state
     expect(await screen.findByText('Show in folder')).toBeVisible()

--- a/packages/desktop/src/rtl-tests/channel.switch.test.tsx
+++ b/packages/desktop/src/rtl-tests/channel.switch.test.tsx
@@ -31,7 +31,7 @@ import { type Community, SocketActions } from '@quiet/types'
 jest.setTimeout(20_000)
 jest.mock('electron', () => {
   return {
-    ipcRenderer: { on: () => {}, send: jest.fn(), sendSync: jest.fn() },
+    ipcRenderer: { on: () => {}, removeListener: jest.fn(), send: jest.fn(), sendSync: jest.fn() },
     remote: {
       BrowserWindow: {
         getAllWindows: () => {

--- a/packages/desktop/src/rtl-tests/community.create.test.tsx
+++ b/packages/desktop/src/rtl-tests/community.create.test.tsx
@@ -179,11 +179,9 @@ describe('User', () => {
         "Messages/resetCurrentPublicChannelCache",
         "Messages/retryVerification",
         "Messages/verifyMessages",
-        "Messages/addMessageVerificationStatus",
         "Messages/resetCurrentPublicChannelCache",
         "Messages/retryVerification",
         "Messages/verifyMessages",
-        "Messages/addMessageVerificationStatus",
       ]
     `)
   })

--- a/packages/desktop/src/rtl-tests/possibleImpersonationAttack.test.tsx
+++ b/packages/desktop/src/rtl-tests/possibleImpersonationAttack.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../renderer/index', () => ({
 
 jest.mock('electron', () => {
   return {
-    ipcRenderer: { on: () => {}, send: jest.fn(), sendSync: jest.fn() },
+    ipcRenderer: { on: () => {}, removeListener: jest.fn(), send: jest.fn(), sendSync: jest.fn() },
     remote: {
       BrowserWindow: {
         getAllWindows: () => {

--- a/packages/desktop/src/rtl-tests/searchModal.test.tsx
+++ b/packages/desktop/src/rtl-tests/searchModal.test.tsx
@@ -22,7 +22,7 @@ jest.setTimeout(20_000)
 
 jest.mock('electron', () => {
   return {
-    ipcRenderer: { on: () => {}, send: jest.fn(), sendSync: jest.fn() },
+    ipcRenderer: { on: () => {}, removeListener: jest.fn(), send: jest.fn(), sendSync: jest.fn() },
     remote: {
       BrowserWindow: {
         getAllWindows: () => {

--- a/packages/desktop/src/shared/setupTests.ts
+++ b/packages/desktop/src/shared/setupTests.ts
@@ -25,13 +25,15 @@ export const ioMock = io as jest.Mock
 jest.mock('electron-store-webpack-wrapper')
 
 jest.mock('electron', () => {
-  return { ipcRenderer: { on: () => {}, send: jest.fn(), sendSync: jest.fn(), invoke: jest.fn() } }
+  return {
+    ipcRenderer: { on: () => {}, removeListener: jest.fn(), send: jest.fn(), sendSync: jest.fn(), invoke: jest.fn() },
+  }
 })
 
 jest.mock('electron-store', () => {
   return class ElectronStore {
     // eslint-disable-next-line
-    constructor() { }
+    constructor() {}
   }
 })
 

--- a/packages/mobile/src/screens/Channel/Channel.screen.test.tsx
+++ b/packages/mobile/src/screens/Channel/Channel.screen.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { act, fireEvent } from '@testing-library/react-native'
+import { Keyboard } from 'react-native'
+import { launchImageLibrary } from 'react-native-image-picker'
+import { communities, files, messages, publicChannels } from '@quiet/state-manager'
+import { type PublicChannel } from '@quiet/types'
+import { ChannelScreen } from './Channel.screen'
+import { initSelectors } from '../../store/init/init.selectors'
+import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
+
+const mockDispatch = jest.fn()
+const mockSelections = new Map()
+let mockKeyboardDidShow: () => void
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: unknown) => mockSelections.get(selector),
+}))
+jest.mock('../../hooks/useContextMenu', () => ({
+  useContextMenu: () => null,
+}))
+jest.mock('react-native-image-picker', () => ({ launchImageLibrary: jest.fn() }))
+
+describe('channel composer send context', () => {
+  const privateChannel: PublicChannel = {
+    id: 'private-channel',
+    name: 'same-name',
+    owner: 'alice',
+    description: '',
+    timestamp: 0,
+    public: false,
+    roleName: 'private-role',
+  }
+  const publicChannel: PublicChannel = { ...privateChannel, id: 'public-channel', public: true, roleName: undefined }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockDispatch.mockClear()
+    mockSelections.clear()
+    mockSelections.set(publicChannels.selectors.currentChannel, privateChannel)
+    mockSelections.set(publicChannels.selectors.currentChannelMessagesCount, 1)
+    mockSelections.set(publicChannels.selectors.currentChannelMessagesMergedBySender, {})
+    mockSelections.set(initSelectors.isWebsocketConnected, true)
+    mockSelections.set(communities.selectors.isOwner, true)
+    jest.spyOn(Keyboard, 'addListener').mockImplementation((event, listener) => {
+      if (event === 'keyboardDidShow') mockKeyboardDidShow = listener as () => void
+      return { remove: jest.fn() } as unknown as ReturnType<typeof Keyboard.addListener>
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  const attachImage = (view: ReturnType<typeof renderComponent>, name: string) => {
+    const mockImageLibrary = launchImageLibrary as jest.Mock
+    mockImageLibrary.mockImplementationOnce((_options, callback) => {
+      callback({ assets: [{ uri: `file:///${name}.png` }] })
+    })
+    fireEvent.press(view.getByTestId('attach_file_button'))
+  }
+
+  const sentActions = () =>
+    mockDispatch.mock.calls.map(([action]) => action).filter(action => messages.actions.sendMessage.match(action))
+  const attachedActions = () =>
+    mockDispatch.mock.calls.map(([action]) => action).filter(action => files.actions.attachFile.match(action))
+
+  it('discards transient text and attachments when switching private to public with the same name', () => {
+    const view = renderComponent(<ChannelScreen />)
+    const privateInput = view.getByTestId('input')
+    fireEvent.changeText(privateInput, 'private draft')
+    attachImage(view, 'private-file')
+
+    mockSelections.set(publicChannels.selectors.currentChannel, publicChannel)
+    view.rerender(<ChannelScreen />)
+    act(() => mockKeyboardDidShow())
+
+    expect(view.getByTestId('input')).not.toBe(privateInput)
+    fireEvent.press(view.getByTestId('send_message_button'))
+    act(() => jest.advanceTimersByTime(50))
+
+    expect(sentActions()).toEqual([])
+    expect(attachedActions()).toEqual([])
+  })
+
+  it('keeps a delayed send with its original text, files and channel without clearing the new composer', () => {
+    const view = renderComponent(<ChannelScreen />)
+    fireEvent.changeText(view.getByTestId('input'), 'private message')
+    attachImage(view, 'private-file')
+    fireEvent.press(view.getByTestId('send_message_button'))
+
+    mockSelections.set(publicChannels.selectors.currentChannel, publicChannel)
+    view.rerender(<ChannelScreen />)
+    fireEvent.changeText(view.getByTestId('input'), 'public message')
+    attachImage(view, 'public-file')
+    act(() => jest.advanceTimersByTime(50))
+
+    expect(sentActions()).toEqual([
+      messages.actions.sendMessage({ message: 'private message', channelId: privateChannel.id }),
+    ])
+    expect(attachedActions()).toEqual([
+      files.actions.attachFile({
+        path: 'file:///private-file.png',
+        name: 'private-file',
+        ext: '.png',
+        channelId: privateChannel.id,
+      }),
+    ])
+
+    fireEvent.press(view.getByTestId('send_message_button'))
+    act(() => jest.advanceTimersByTime(50))
+    expect(sentActions()[1]).toEqual(
+      messages.actions.sendMessage({ message: 'public message', channelId: publicChannel.id })
+    )
+    expect(attachedActions()[1]).toEqual(
+      files.actions.attachFile({
+        path: 'file:///public-file.png',
+        name: 'public-file',
+        ext: '.png',
+        channelId: publicChannel.id,
+      })
+    )
+  })
+})

--- a/packages/mobile/src/screens/Channel/Channel.screen.tsx
+++ b/packages/mobile/src/screens/Channel/Channel.screen.tsx
@@ -13,7 +13,7 @@ import { DocumentPickerResponse } from 'react-native-document-picker'
 import { Asset } from 'react-native-image-picker'
 import { getFilesData } from '@quiet/common'
 
-export const ChannelScreen: FC = () => {
+const ChannelScreenContent: FC = () => {
   const dispatch = useDispatch()
 
   const handleBackButton = useCallback(() => {
@@ -147,18 +147,20 @@ export const ChannelScreen: FC = () => {
 
   const sendMessageAction = React.useCallback(
     async (message: string) => {
+      const channelId = currentChannel?.id
+      if (!channelId) return
       if (message) {
-        dispatch(messages.actions.sendMessage({ message }))
+        dispatch(messages.actions.sendMessage({ message, channelId }))
       }
       // Attach files, then send corresponding message (contaning cid) for each of them
       Object.values(filesRef.current).forEach(async (fileData: FileContent) => {
         if (!fileData.path) return
-        dispatch(files.actions.attachFile(fileData))
+        dispatch(files.actions.attachFile({ ...fileData, channelId }))
       })
       // Reset file previews for input state
       setAttachingFiles({})
     },
-    [dispatch]
+    [dispatch, currentChannel?.id]
   )
 
   useEffect(() => {
@@ -201,4 +203,10 @@ export const ChannelScreen: FC = () => {
       unregisteredUsernameHandleBack={unregisteredUsernameHandleBack}
     />
   )
+}
+
+export const ChannelScreen: FC = () => {
+  const channel = useSelector(publicChannels.selectors.currentChannel)
+  // Text refs, pending sends and file previews belong to the channel where they started.
+  return <ChannelScreenContent key={channel?.id} />
 }

--- a/packages/state-manager/src/sagas/files/attachFile/sendFileMessage.saga.test.ts
+++ b/packages/state-manager/src/sagas/files/attachFile/sendFileMessage.saga.test.ts
@@ -64,7 +64,7 @@ describe('sendFileMessageSaga', () => {
     message = Math.random().toString(36).substr(2.9)
   })
 
-  test('saves message with media', async () => {
+  test('saves media in its submitted channel even when another channel is current', async () => {
     const currentChannel = currentChannelId(store.getState())
 
     if (!currentChannel) throw new Error('no current channel id')
@@ -81,13 +81,17 @@ describe('sendFileMessageSaga', () => {
       tmpPath: undefined,
     }
     const reducer = combineReducers(testReducers)
-    await expectSaga(sendFileMessageSaga, filesActions.attachFile(media))
+    await expectSaga(sendFileMessageSaga, filesActions.attachFile({ ...media, channelId: currentChannel }))
       .withReducer(reducer)
-      .withState(store.getState())
+      .withState({
+        ...store.getState(),
+        PublicChannels: { ...store.getState().PublicChannels, currentChannelId: generateTestChannelId('other') },
+      })
       .provide([[call.fn(generateMessageId), message]])
       .put(
         messagesActions.sendMessage({
           id: message,
+          channelId: currentChannel,
           message: '',
           type: MessageType.File,
           media,
@@ -127,13 +131,14 @@ describe('sendFileMessageSaga', () => {
     }
 
     const reducer = combineReducers(testReducers)
-    await expectSaga(sendFileMessageSaga, filesActions.attachFile(media))
+    await expectSaga(sendFileMessageSaga, filesActions.attachFile({ ...media, channelId: currentChannel }))
       .withReducer(reducer)
       .withState(store.getState())
       .provide([[call.fn(generateMessageId), message]])
       .put(
         messagesActions.sendMessage({
           id: message,
+          channelId: currentChannel,
           message: '',
           type: MessageType.File,
           media: updatedMedia,

--- a/packages/state-manager/src/sagas/files/attachFile/sendFileMessage.saga.ts
+++ b/packages/state-manager/src/sagas/files/attachFile/sendFileMessage.saga.ts
@@ -4,7 +4,6 @@ import { identitySelectors } from '../../identity/identity.selectors'
 import { filesActions } from '../files.slice'
 import { messagesActions } from '../../messages/messages.slice'
 import { generateMessageId } from '../../messages/utils/message.utils'
-import { publicChannelsSelectors } from '../../publicChannels/publicChannels.selectors'
 import { DownloadState, type FileMetadata, imagesExtensions, MessageType } from '@quiet/types'
 import { createLogger } from '../../../utils/logger'
 
@@ -14,9 +13,8 @@ export function* sendFileMessageSaga(
   action: PayloadAction<ReturnType<typeof filesActions.attachFile>['payload']>
 ): Generator {
   const identity = yield* select(identitySelectors.currentIdentity)
-
-  const currentChannel = yield* select(publicChannelsSelectors.currentChannelId)
-  if (!identity || !currentChannel) return
+  const { channelId, ...file } = action.payload
+  if (!identity || !channelId) return
 
   const fileProtocol = 'file://'
   let filePath = action.payload.path
@@ -33,13 +31,13 @@ export function* sendFileMessageSaga(
   const id = yield* call(generateMessageId)
 
   const media: FileMetadata = {
-    ...action.payload,
+    ...file,
     path: filePath,
     tmpPath: tmpPath,
     cid: `attaching_${id}`,
     message: {
       id,
-      channelId: currentChannel,
+      channelId,
     },
   }
 
@@ -54,6 +52,7 @@ export function* sendFileMessageSaga(
   yield* put(
     messagesActions.sendMessage({
       id,
+      channelId,
       message: '',
       type,
       media,

--- a/packages/state-manager/src/sagas/files/files.slice.ts
+++ b/packages/state-manager/src/sagas/files/files.slice.ts
@@ -28,7 +28,7 @@ export const filesSlice = createSlice({
       downloadStatusAdapter.removeOne(state.downloadStatus, cid)
     },
     cancelDownload: (state, _action: PayloadAction<CancelDownload>) => state,
-    attachFile: (state, _action: PayloadAction<FileContent>) => state,
+    attachFile: (state, _action: PayloadAction<FileContent & { channelId: string }>) => state,
     broadcastHostedFile: (state, _action: PayloadAction<FileMetadata>) => state,
     downloadFile: (state, _action: PayloadAction<FileMetadata>) => state,
     updateMessageMedia: (state, _action: PayloadAction<FileMetadata>) => state,

--- a/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.test.ts
+++ b/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.test.ts
@@ -2,7 +2,7 @@ import { setupCrypto } from '@quiet/identity'
 import { type Store } from '../../store.types'
 import { prepareStore, testReducers } from '../../../utils/tests/prepareStore'
 import { MockedSocket } from '../../../utils/tests/mockedSocket'
-import { combineReducers } from '@reduxjs/toolkit'
+import { combineReducers, type AnyAction } from '@reduxjs/toolkit'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call } from 'redux-saga-test-plan/matchers'
 import { applyEmitParams, type Socket } from '../../../types'
@@ -20,17 +20,18 @@ import {
   type Community,
   type FileMetadata,
   type Identity,
-  MessageType,
   type PublicChannel,
   SocketActions,
   type SendMessagePayload,
   ChannelMessage,
 } from '@quiet/types'
-import { currentChannelId, publicChannelsSelectors } from '../../publicChannels/publicChannels.selectors'
+import { currentChannelId } from '../../publicChannels/publicChannels.selectors'
 import { getSocketFactory, getReduxStoreFactory, getBaseTypesFactory } from '../../../utils/tests/factories'
 import { identitySelectors } from '../../identity/identity.selectors'
 import { identityActions } from '../../identity/identity.slice'
 import { createLogger } from '../../../utils/logger'
+import { runSaga, stdChannel } from 'redux-saga'
+import * as messageUtils from '../utils/message.utils'
 
 describe('sendMessageSaga', () => {
   let store: Store
@@ -81,6 +82,7 @@ describe('sendMessageSaga', () => {
     const logger = createLogger('sendMessageSaga-test1')
     // Get the current channel ID from the state
     const currentChannel = currentChannelId(store.getState())
+    if (!currentChannel) throw new Error('no current channel')
     const channelMessage = await baseTypesFactory.build<ChannelMessage>('ChannelMessage', {
       userId: alice.userId,
       channelId: currentChannel,
@@ -90,7 +92,7 @@ describe('sendMessageSaga', () => {
     await expectSaga(
       sendMessageSaga,
       socket as unknown as Socket,
-      messagesActions.sendMessage({ message: channelMessage.message })
+      messagesActions.sendMessage({ message: channelMessage.message, channelId: currentChannel })
     )
       .withReducer(reducer)
       .withState(store.getState())
@@ -100,9 +102,74 @@ describe('sendMessageSaga', () => {
       ])
       .not.take(identityActions.updateIdentity)
       .select(identitySelectors.currentIdentity)
-      .select(publicChannelsSelectors.currentChannelId)
       .apply(socket, socket.emit, applyEmitParams(SocketActions.SEND_MESSAGE, channelMessage))
       .run()
+  })
+
+  test('does not infer a target from the current channel when the send has no channel', async () => {
+    const emit = jest.spyOn(socket, 'emit')
+    await expectSaga(
+      sendMessageSaga,
+      socket as unknown as Socket,
+      messagesActions.sendMessage({ message: 'private', channelId: '' })
+    )
+      .withReducer(combineReducers(testReducers))
+      .withState(store.getState())
+      .run()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  test('keeps the submitted channel through message ID, identity and subscription waits', async () => {
+    const reducer = combineReducers(testReducers)
+    let state: ReturnType<typeof reducer> = {
+      ...reducer(undefined, { type: '@@INIT' }),
+      ...store.getState(),
+      Identity: { ...store.getState().Identity, identities: { ids: [], entities: {} } },
+      PublicChannels: {
+        ...store.getState().PublicChannels,
+        channelsSubscriptions: { ids: [], entities: {} },
+      },
+    }
+    const input = stdChannel()
+    const dispatch = (action: AnyAction) => {
+      state = reducer(state, action)
+      input.put(action)
+    }
+    let releaseId!: (id: string) => void
+    const generatedId = new Promise<string>(resolve => {
+      releaseId = resolve
+    })
+    // Suspend this call effect to exercise a channel switch before the send resumes.
+    const idSpy = jest.spyOn(messageUtils, 'generateMessageId').mockReturnValueOnce(generatedId as unknown as string)
+    const emit = jest.spyOn(socket, 'emit')
+    const task = runSaga(
+      { channel: input, dispatch, getState: () => state },
+      sendMessageSaga,
+      socket as unknown as Socket,
+      messagesActions.sendMessage({ message: 'private', channelId: sailingChannel.id })
+    )
+    try {
+      dispatch(publicChannelsActions.setCurrentChannel({ channelId: generateTestChannelId('public') }))
+      releaseId('fixed-send-id')
+      await Promise.resolve()
+      expect(emit).not.toHaveBeenCalled()
+      dispatch(identityActions.addNewIdentity(alice))
+      dispatch(identityActions.updateIdentity(alice))
+      expect(emit).not.toHaveBeenCalled()
+      dispatch(publicChannelsActions.setChannelSubscribed({ channelId: sailingChannel.id }))
+      await task.toPromise()
+      expect(emit).toHaveBeenCalledWith(
+        SocketActions.SEND_MESSAGE,
+        expect.objectContaining({
+          id: 'fixed-send-id',
+          message: 'private',
+          channelId: sailingChannel.id,
+        })
+      )
+    } finally {
+      task.cancel()
+      idSpy.mockRestore()
+    }
   })
 
   test('sign and send message in specific channel', async () => {
@@ -172,8 +239,8 @@ describe('sendMessageSaga', () => {
     }
 
     const media: FileMetadata = {
-      cid: 'cid',
-      path: `attaching_${messageId}`,
+      cid: `attaching_${messageId}`,
+      path: 'path/to/file',
       name: 'file',
       ext: 'ext',
       message: {
@@ -182,30 +249,20 @@ describe('sendMessageSaga', () => {
       },
     }
 
+    const emit = jest.spyOn(socket, 'emit')
     const reducer = combineReducers(testReducers)
-    await expectSaga(sendMessageSaga, socket as unknown as Socket, messagesActions.sendMessage({ message: '', media }))
+    await expectSaga(
+      sendMessageSaga,
+      socket as unknown as Socket,
+      messagesActions.sendMessage({ message: '', media, channelId: currentChannel })
+    )
       .withReducer(reducer)
       .withState(store.getState())
       .provide([
         [call.fn(generateMessageId), 4],
         [call.fn(getCurrentTime), 8],
       ])
-      .not.apply(socket, socket.emit, [
-        SocketActions.SEND_MESSAGE,
-        {
-          peerId: alice.networkInfo.peerId.id,
-          message: {
-            id: 4,
-            type: MessageType.Basic,
-            message: 'message',
-            createdAt: 8,
-            channelId: currentChannel,
-            signature: 'signature',
-            pubKey: 'publicKey',
-            media: undefined,
-          },
-        },
-      ])
       .run()
+    expect(emit).not.toHaveBeenCalled()
   })
 })

--- a/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.ts
+++ b/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.ts
@@ -1,7 +1,6 @@
 import { type Socket, applyEmitParams } from '../../../types'
 import { type PayloadAction } from '@reduxjs/toolkit'
 import { call, select, apply, put, delay, take } from 'typed-redux-saga'
-import { publicChannelsSelectors } from '../../publicChannels/publicChannels.selectors'
 import { messagesActions } from '../messages.slice'
 import { generateMessageId, getCurrentTime } from '../utils/message.utils'
 import { type ChannelMessage, MessageType, SendingStatus, SocketActions } from '@quiet/types'
@@ -17,6 +16,12 @@ export function* sendMessageSaga(
   action: PayloadAction<ReturnType<typeof messagesActions.sendMessage>['payload']>
 ): Generator {
   const payload = action.payload as ReturnType<typeof messagesActions.sendMessage>['payload']
+  // The composer chooses the destination before any asynchronous send work begins.
+  const channelId = payload.channelId
+  if (!channelId) {
+    logger.error('Failed to send message - channel ID is missing')
+    return
+  }
   const generatedMessageId = yield* call(generateMessageId)
   const id = payload.id || generatedMessageId
   let identity = yield* select(identitySelectors.currentIdentity)
@@ -31,13 +36,6 @@ export function* sendMessageSaga(
   }
 
   logger.info('Identity present', identity)
-
-  const currentChannelId = yield* select(publicChannelsSelectors.currentChannelId)
-  const channelId = payload.channelId || currentChannelId
-  if (!channelId) {
-    logger.error(`Failed to send message ${id} - channel ID is missing`)
-    return
-  }
 
   logger.info(`Sending message ${id} to channel ${channelId}`)
 

--- a/packages/state-manager/src/sagas/publicChannels/sendIntroductionMessage/sendIntroductionMessage.saga.test.ts
+++ b/packages/state-manager/src/sagas/publicChannels/sendIntroductionMessage/sendIntroductionMessage.saga.test.ts
@@ -45,6 +45,7 @@ describe('sendIntroductionMessageSaga', () => {
     await factory.create('PublicChannel')
 
     const generalChannel = publicChannelsSelectors.generalChannel(store.getState())
+    if (!generalChannel) throw new Error('no general channel')
 
     const reducer = combineReducers(testReducers)
 
@@ -60,7 +61,7 @@ describe('sendIntroductionMessageSaga', () => {
         messagesActions.sendMessage({
           type: MessageType.Info,
           message: userJoinedMessage(userProfile.nickname),
-          channelId: generalChannel?.id,
+          channelId: generalChannel.id,
         })
       )
       .put(identityActions.updateIdentity({ ...identity, introMessageSent: true }))

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -28,7 +28,7 @@ export interface PushNotificationPayload {
 export interface WriteMessagePayload {
   message: string
   id?: string
-  channelId?: string
+  channelId: string
   type?: MessageType
   media?: FileMetadata
 }


### PR DESCRIPTION
Channel switches could redirect queued text or attachments, or carry an unsent private attachment into a public composer. Bind every text/file send to its originating channel, reset transient composer state on channel changes, and carry that destination through desktop file-dialog/clipboard replies. A mobile send already pressed before its autocorrect delay completes in its original channel. Clipboard replies use the path supplied by the main process, while actual dropped Files use Electron's File API.

Fixes #420 and addresses the transient-input part of #534. This adds no persistent draft storage. Targets the `10.0.0` release through the stack below, originally based directly on the flag-only `9.0.0` release; the send diff includes no auth, dependency or protocol changes.

Validation at `f9f46023be7a36a2daeb90ef45d134cf4ff58e33`, Node20.20.1:

- Full desktop Jest suite against this branch's workspace sources: **97 suites, 272 tests and 127 snapshots pass**, with 6 pre-existing skips and 1 existing todo. The Channel/component and two affected RTL suites pass in three consecutive runs (20 tests and 8 snapshots each, 2 existing skips).
- An isolated local combination with #3471 also passes the full 97-suite desktop run against the reviewed protocol 4 auth build; no remote merge was performed.
- Desktop incoming-message fixtures now model the backend's per-message `verified` marker. The six failures reproduced on both the PR and unchanged base before these fixture/snapshot corrections; no production verification guard was relaxed.
- The clipboard mock enforces Electron's File requirement. It fails before the clipboard-path correction and passes afterward. Native Electron IPC remains outside the Jest coverage.
- 18 focused state-manager tests and 2 mobile tests passed; package typechecks and changed-file lint passed. Cases include same-name private-to-public switches, delayed mobile text/files, unsent desktop attachments, and late desktop picker/clipboard replies.

All failed jobs on the earlier head were inspected. Beyond the corrected desktop tests, [native iOS test-target compilation](https://github.com/TryQuiet/quiet/actions/runs/34521275461/job/103019113457) cannot import the app module. The [7.0.1 backward-compatibility test](https://github.com/TryQuiet/quiet/actions/runs/34521275687/job/103019114868) uses an obsolete baseline: 8.0.0 explicitly broke team-name-based sigchain storage, and 9.0.0 reset data directories. The compatibility baseline correction is supplied by parent PR #3479; the restacked branch includes that correction. Both failures were independently observed on earlier unrelated runs; this PR does not repair or skip them.

The planned final launch audit and combined E2E validation remain pending. Independent review covered the send-context changes, clipboard correction and realistic desktop fixtures.

Stack 2 of 3 for `10.0.0`: **[#3479](https://github.com/TryQuiet/quiet/pull/3479) → this PR → [#3471](https://github.com/TryQuiet/quiet/pull/3471)**. The current base is #3479's branch, so the review diff contains only the send changes. Before landing, merge #3479 into `10.0.0`, retarget this PR to `10.0.0`, then use a merge commit. Retarget #3471 to `10.0.0` after this PR lands. The restack preserves the original reviewed commits and the exact send patch.
