### PR TITLE
test: reset compatibility baseline for 10.0.0

### DIFF
--- a/.github/workflows/e2e-back-compat-linux.yml
+++ b/.github/workflows/e2e-back-compat-linux.yml
@@ -24,24 +24,6 @@ jobs:
           submodules: recursive
           token: ${{ secrets.SUBMODULE_READ_TOKEN || github.token }}
 
-      - name: Extract version
-        id: extract_version
-        uses: Saionaro/extract-package-version@fdb5b74adc1278ddb777dfed4c988b9d098bb48d # v1.2.1
-        with:
-          path: packages/mobile
-
-      - name: Check for major version
-        id: major-ver
-        run: |
-          echo ${{ steps.extract_version.outputs.version }}
-          if [[ "${{ steps.extract_version.outputs.version }}" =~ ^[[:digit:]]+\.0\.0(-alpha.[[:digit:]]+)?$ ]]; then
-              echo "This is a major version"
-              echo "match=true" >> $GITHUB_OUTPUT
-          else
-              echo "This is NOT a major version"
-              echo "match=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Install WM
         run: sudo apt install fluxbox
 
@@ -70,10 +52,9 @@ jobs:
 
       - name: Run Backwards Compatibility test
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
-        if: ${{ steps.major-ver.outputs.match == 'false' }}
         with:
           timeout_minutes: 15
           max_attempts: 3
           command: |
             echo "Running backwards compatibility test for branch $GITHUB_HEAD_REF"
-            cd packages/e2e-tests && npm run test backwardsCompatibility.test.ts
+            cd packages/e2e-tests && npm run test -- compatibilityBaseline.test.ts backwardsCompatibility.test.ts

--- a/packages/e2e-tests/src/compatibilityBaseline.ts
+++ b/packages/e2e-tests/src/compatibilityBaseline.ts
@@ -1,0 +1,23 @@
+export const BACKWARD_COMPATIBILITY_BASE_VERSION = '10.0.0'
+
+export const compatibilityBaseline = (
+  currentVersion: string,
+  currentFileName: string,
+  download: (version: string) => string
+) => {
+  const version = /^(\d+)\.(\d+)\.(\d+)(?:-[\da-zA-Z.-]+)?(?:\+[\da-zA-Z.-]+)?$/.exec(currentVersion)
+  if (!version) throw new Error(`Invalid build version: ${currentVersion}`)
+
+  const current = version.slice(1, 4).map(Number)
+  const baseline = BACKWARD_COMPATIBILITY_BASE_VERSION.split('.').map(Number)
+  const difference = current.findIndex((part, index) => part !== baseline[index])
+  // The release branch still carries pre-10 package versions until the version bump.
+  // Through 10.0.0, exercise save/reopen with the supplied build; later builds must upgrade 10.0.0.
+  const isPlaceholder = difference === -1 || current[difference] < baseline[difference]
+
+  return {
+    isPlaceholder,
+    version: isPlaceholder ? currentVersion : BACKWARD_COMPATIBILITY_BASE_VERSION,
+    fileName: isPlaceholder ? currentFileName : download(BACKWARD_COMPATIBILITY_BASE_VERSION),
+  }
+}

--- a/packages/e2e-tests/src/tests/backwardsCompatibility.test.ts
+++ b/packages/e2e-tests/src/tests/backwardsCompatibility.test.ts
@@ -12,7 +12,8 @@ import {
   Sidebar,
 } from '../selectors'
 import { MessageIds } from '../types'
-import { BACKWARD_COMPATIBILITY_BASE_VERSION, BuildSetup, copyInstallerFile, downloadInstaller, sleep } from '../utils'
+import { BuildSetup, downloadInstaller, sleep } from '../utils'
+import { BACKWARD_COMPATIBILITY_BASE_VERSION, compatibilityBaseline } from '../compatibilityBaseline'
 import { createLogger } from '../logger'
 
 const logger = createLogger('backwardsCompatibility')
@@ -31,6 +32,7 @@ describe('Backwards Compatibility', () => {
   let generalChannelMessageIds: MessageIds
   let dataDir: string
   let settings: Settings
+  let baselineVersion: string
 
   const communityName = 'testcommunity'
   const ownerUsername = 'bob'
@@ -39,15 +41,18 @@ describe('Backwards Compatibility', () => {
   const generalChannelName = 'general'
   const newChannelName = 'mid-night-club'
 
-  const isAlpha = BuildSetup.getEnvFileName()?.toString().includes('alpha')
-
   beforeAll(async () => {
-    // download the old version of the app
-    const appFilename = downloadInstaller()
-    const copiedFilename = copyInstallerFile(appFilename)
-    const chromeDriver126Path = require.resolve('electron-chromedriver-126/chromedriver.js')
+    const currentFileName = BuildSetup.getEnvFileName()
+    if (!currentFileName) throw new Error('FILE_NAME must identify the supplied AppImage')
+    const currentVersion = new BuildSetup({ fileName: currentFileName }).getVersionFromEnv()
+    const baseline = compatibilityBaseline(currentVersion, currentFileName, downloadInstaller)
+    baselineVersion = baseline.version
+    logger.info(baseline.isPlaceholder ? 'Same-build restart placeholder' : 'Released-version upgrade', {
+      baseline: baselineVersion,
+      current: currentVersion,
+    })
     dataDir = `e2e_back_compat_${(Math.random() * 10 ** 18).toString(36)}`
-    ownerAppOldVersion = new App({ dataDir, fileName: copiedFilename, chromeDriverPath: chromeDriver126Path })
+    ownerAppOldVersion = new App({ dataDir, fileName: baseline.fileName })
   })
 
   beforeEach(async () => {
@@ -61,7 +66,7 @@ describe('Backwards Compatibility', () => {
     await ownerAppOldVersion?.cleanup(true)
   })
 
-  describe(`Old version - ${BACKWARD_COMPATIBILITY_BASE_VERSION}`, () => {
+  describe(`Baseline - ${BACKWARD_COMPATIBILITY_BASE_VERSION} (same-build placeholder before release)`, () => {
     describe(`Owner opens older version of the app`, () => {
       itif(process.platform == 'linux')('Owner opens the app', async () => {
         await ownerAppOldVersion.open()
@@ -115,14 +120,14 @@ describe('Backwards Compatibility', () => {
         expect(await generalChannel.isReady()).toBeTruthy()
 
         const generalChannelText = await generalChannel.element.getText()
-        expect(generalChannelText).toEqual('# general')
+        expect(generalChannelText).toEqual('general')
       })
 
-      itif(process.platform == 'linux')(`Verify version - ${BACKWARD_COMPATIBILITY_BASE_VERSION}`, async () => {
+      itif(process.platform == 'linux')('Verify baseline build version', async () => {
         settings = await new Sidebar(ownerAppOldVersion.driver).openSettings()
         expect(await settings.isReady()).toBeTruthy()
         const settingVersion = await settings.getVersion()
-        expect(settingVersion).toEqual(BACKWARD_COMPATIBILITY_BASE_VERSION)
+        expect(settingVersion).toEqual(baselineVersion)
       })
 
       itif(process.platform == 'linux')(`Close settings modal`, async () => {
@@ -148,8 +153,8 @@ describe('Backwards Compatibility', () => {
     describe('Second channel', () => {
       itif(process.platform == 'linux')('Owner creates second channel', async () => {
         sidebar = new Sidebar(ownerAppOldVersion.driver)
-        await sidebar.addNewChannel(newChannelName, true, false)
-        await sidebar.switchChannel(newChannelName, true, false)
+        await sidebar.addNewChannel(newChannelName)
+        await sidebar.switchChannel(newChannelName)
         const channels = await sidebar.getChannelList()
         expect(channels.length).toEqual(2)
       })

--- a/packages/e2e-tests/src/tests/compatibilityBaseline.test.ts
+++ b/packages/e2e-tests/src/tests/compatibilityBaseline.test.ts
@@ -1,0 +1,38 @@
+import { compatibilityBaseline } from '../compatibilityBaseline'
+
+describe('compatibility baseline', () => {
+  it.each(['9.0.2', '10.0.0-alpha.1', '10.0.0', '10.0.0+build.1'])(
+    'reopens the supplied %s build without downloading an unpublished baseline',
+    version => {
+      const download = jest.fn(() => 'released.AppImage')
+      const fileName = `Quiet-${version}.AppImage`
+
+      expect(compatibilityBaseline(version, fileName, download)).toEqual({
+        isPlaceholder: true,
+        version,
+        fileName,
+      })
+      expect(download).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['10.0.1-alpha.0', '10.0.1', '10.1.0', '11.0.0'])(
+    'requires the released 10.0.0 installer for %s',
+    version => {
+      const download = jest.fn(() => 'Quiet-10.0.0.AppImage')
+
+      expect(compatibilityBaseline(version, `Quiet-${version}.AppImage`, download)).toEqual({
+        isPlaceholder: false,
+        version: '10.0.0',
+        fileName: 'Quiet-10.0.0.AppImage',
+      })
+      expect(download).toHaveBeenCalledWith('10.0.0')
+    }
+  )
+
+  it.each(['', '10', '10.0', 'not-a-version'])('rejects malformed build version %j', version => {
+    const download = jest.fn()
+    expect(() => compatibilityBaseline(version, 'current.AppImage', download)).toThrow('Invalid build version')
+    expect(download).not.toHaveBeenCalled()
+  })
+})

--- a/packages/e2e-tests/src/utils.ts
+++ b/packages/e2e-tests/src/utils.ts
@@ -10,10 +10,11 @@ import { RetryConfig } from './types'
 import { config } from 'dotenv'
 
 import { createLogger } from './logger'
+import { BACKWARD_COMPATIBILITY_BASE_VERSION } from './compatibilityBaseline'
 
 const logger = createLogger('utils')
 
-export const BACKWARD_COMPATIBILITY_BASE_VERSION = '7.0.1' // version to test against
+export { BACKWARD_COMPATIBILITY_BASE_VERSION } from './compatibilityBaseline'
 const appImagesPath = `${__dirname}/../Quiet`
 const defaultChromeDriverPath = require.resolve('electron-chromedriver/chromedriver.js')
 


### PR DESCRIPTION
The upgrade test still downloads 7.0.1, although 10.0.0 starts a new compatibility generation. Set the baseline to 10.0.0 and use the supplied AppImage for a same-build save/reopen placeholder through 10.0.0, including prereleases and the release branch’s current pre-bump version. Later versions require the released 10.0.0 installer.

Retain the channel, message, readiness and persistence assertions. Update the baseline’s old UI/driver assumptions to the current UI and Electron 32 driver, and run the suite on major releases instead of skipping them. This changes test infrastructure only; it does not add old-data migration or bump application versions.

Validation: 12 installer-selection tests pass with the package’s Jest 29 configuration; E2E source typecheck, changed-file ESLint, formatting and workflow parsing pass. Local typecheck uses the exact branch sources and release auth742 declarations via an external config. The packaged Linux Selenium restart test and helper suite also pass in [CI at this exact head](https://github.com/TryQuiet/quiet/actions/runs/34531821862/job/103054110896): **2 suites, 38 tests passed**. This exercises the supplied-build placeholder; the local machine had no current AppImage.

Stack 1 of 3 for `10.0.0`: **this PR → [#3466](https://github.com/TryQuiet/quiet/pull/3466) → [#3471](https://github.com/TryQuiet/quiet/pull/3471)**. Each child targets the preceding branch so its review diff contains only its own changes. Land this PR into `10.0.0` using a merge commit, then retarget #3466 to `10.0.0` before landing it. Preserve the stack branches until their children have been retargeted.
