### PR TITLE
Prepare 10.0.0 alpha storage and final QSS pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,24 @@
 
 ## [10.0.0]
 
+### Features
+
+* Enable administrators to create private channels on desktop and mobile without a feature flag
+
+### Breaking
+
+* Use protocol 4 with member, role, device and server removal and key rotation disabled, including making those operations inert when received from modified clients [#3471](https://github.com/TryQuiet/quiet/pull/3471)
+* Start with new 10.x desktop and mobile data directories; existing 9.x communities and identities are not migrated
+
 ### Fixes
 
+* Recover peer synchronization across reconnects and overlapping transports [#3480](https://github.com/TryQuiet/quiet/pull/3480)
+* Prevent repeated community leave requests from acknowledging teardown early and deleting newly created community state [#3424](https://github.com/TryQuiet/quiet/issues/3424)
+* Fix AppImage external links and desktop protocol registration when launcher library variables are present [#3453](https://github.com/TryQuiet/quiet/issues/3453)
+* Recover from consumed QSS captcha grants and synchronize captcha renewal state [#3428](https://github.com/TryQuiet/quiet/issues/3428)
+* Resume unsent mobile joins safely after a local backend connection is lost [#3426](https://github.com/TryQuiet/quiet/issues/3426)
+* Recover mobile local backend connections and allow stalled QR invitations to be retried [#3427](https://github.com/TryQuiet/quiet/issues/3427)
+* Keep delayed text and attachment sends bound to their originating channel and clear transient composer state on channel changes [#420](https://github.com/TryQuiet/quiet/issues/420) [#534](https://github.com/TryQuiet/quiet/issues/534)
 * Allow authorized historical private-channel deletions to sync without blocking later channels [#3406](https://github.com/TryQuiet/quiet/issues/3406)
 
 ## [9.0.0]

--- a/packages/common/src/const.ts
+++ b/packages/common/src/const.ts
@@ -1,5 +1,5 @@
 export const DESKTOP_DEV_DATA_DIR = 'Quietdev'
-export const DESKTOP_DATA_DIR = 'Quiet9'
+export const DESKTOP_DATA_DIR = 'Quiet10'
 
 export enum Site {
   DOMAIN = 'tryquiet.org',

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Communication/CommunicationModule.java
@@ -528,7 +528,7 @@ public class CommunicationModule extends ReactContextBaseJavaModule {
 
         Context context = reactContext.getApplicationContext();
         try {
-            FileUtils.deleteDirectory(new File(context.getFilesDir(), "backend/files9"));
+            FileUtils.deleteDirectory(new File(context.getFilesDir(), "backend/files10"));
         } catch (IOException e) {
             Log.e("CommunicationModule", e.toString());
         }

--- a/packages/mobile/android/app/src/main/java/com/quietmobile/Utils/Utils.kt
+++ b/packages/mobile/android/app/src/main/java/com/quietmobile/Utils/Utils.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.suspendCoroutine
 
 object Utils {
     fun createDirectory(context: Context): String {
-        val dataDirectory = File(context.filesDir, "backend/files9")
+        val dataDirectory = File(context.filesDir, "backend/files10")
         dataDirectory.mkdirs()
 
         return dataDirectory.absolutePath

--- a/packages/mobile/ios/DataDirectory.swift
+++ b/packages/mobile/ios/DataDirectory.swift
@@ -6,7 +6,7 @@ class DataDirectory: NSObject {
     let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
     let documentsDirectory = paths[0]
     let docURL = URL(string: documentsDirectory)!
-    let dataPath = docURL.appendingPathComponent("backend/files9")
+    let dataPath = docURL.appendingPathComponent("backend/files10")
     if !FileManager.default.fileExists(atPath: dataPath.path) {
       do {
         try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)

--- a/packages/mobile/src/utils/shareAllData.ts
+++ b/packages/mobile/src/utils/shareAllData.ts
@@ -8,7 +8,7 @@ import { createLogger } from './logger'
 
 const logger = createLogger('shareAllData')
 
-const DATA_DIR = RNFS.DocumentDirectoryPath + '/backend/files9'
+const DATA_DIR = RNFS.DocumentDirectoryPath + '/backend/files10'
 const LOGS_DIR = RNFS.DocumentDirectoryPath + '/logs'
 const SHARE_DIR = RNFS.CachesDirectoryPath + '/quiet-data-share'
 const SUPPORT_EMAIL = 'logs@tryquiet.org'


### PR DESCRIPTION
The 10.0.0 protocol disables removals and rotations, so loading 9.x community history is unsupported. Use new `Quiet10` desktop and `backend/files10` mobile storage directories, keeping mobile cleanup and data export on the same path.

Pin QSS to reviewed commit `4227d340397135b120fd96a80f7538592ef520c5` from merged TryQuiet/quiet-storage-service#57. Both Quiet and QSS continue to pin Auth `6f534c89bceb875e8c71997943e5e76e48ccbd88`. Complete the root changelog for the merged release stack. Package versions are advanced by the release command.

Validation: `npm run test:submodule-policy` passes from this commit, including a fresh checkout, intentional mismatched-pin rejection, and both bootstrap pin-preservation regressions. No runtime `Quiet9` or `files9` references remain. QSS's full local suite passes 282 unit tests and 27 E2E tests; all four fresh QSS #57 CI jobs pass.

Release handoff: prerelease the QSS `release/10.0.0` branch and wait for its development deployment before publishing Quiet's alpha from a clean `10.0.0` checkout with initialized recursive submodules. Quiet alpha uses `test.quiet`; the separate stable-production bucket change remains a production-release task. Existing native iOS test-harness failures remain a validation limitation of the audited stack.
