### PR TITLE
Make the README security caveat a GitHub WARNING alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Quiet is an alternative to team chat apps like Slack, Discord, and Element that 
 <br/>
 <br/>
 
-> NOTE: Quiet is not audited and should not be used when privacy and security are critical. It lacks basic features and probably won't replace your Slack or Discord yet. That said, it works surprisingly well and we use it daily as a Slack replacement.
+> [!WARNING]
+> **Quiet is not audited and should not be used when privacy and security are critical.**
+>
+> It lacks basic features and probably won't replace your Slack or Discord yet. That said, it works surprisingly well and we use it daily as a Slack replacement.
 
 
 Quiet is for fans of software freedom, decentralization and privacy tech, and for anyone craving a future where humanity can collaborate effectively online without trusting our communities, networks, and data to giant corporations.


### PR DESCRIPTION
Fixes #2998

## What

Promoted the muted `> NOTE:` blockquote to a GitHub `[!WARNING]` alert with the key sentence in bold; softer sentences kept verbatim in a second paragraph. Rejected an H2 (pollutes the outline/anchors) and CAUTION (red is for hazards).

## Evidence

One-hunk README diff verified by the lead. No screenshot possible for github.com rendering; report shows before/after markdown with a palette-accurate illustration.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2998.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
