### PR TITLE
Fix identicon dark background in dark mode (#2959)

### DIFF
--- a/packages/desktop/src/renderer/components/Jdenticon/Jdenticon.darkmode.cy.tsx
+++ b/packages/desktop/src/renderer/components/Jdenticon/Jdenticon.darkmode.cy.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+import { it, cy, describe } from 'local-cypress'
+import { mount } from 'cypress/react18'
+
+import Jdenticon from './Jdenticon'
+import { lightTheme, darkTheme } from '../../theme'
+
+// Regression harness for #2959 — identicons must render on the same light
+// background in both light and dark mode. Mirrors the two real render sites
+// (ProfilePhoto and MentionElement) which wrap Jdenticon in a container whose
+// background comes from theme.palette.background.paper.
+const Harness = ({ theme }: { theme: typeof lightTheme }) => (
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <div style={{ padding: 24, background: theme.palette.background.default, display: 'flex', gap: 24 }}>
+        {/* ProfilePhoto-style usage */}
+        <Jdenticon
+          value='profile-photo-example'
+          size='96'
+          style={{
+            background: theme.palette.background.paper,
+            width: '96px',
+            height: '96px',
+            borderRadius: '4px',
+          }}
+        />
+        {/* MentionElement-style usage */}
+        <div
+          style={{
+            maxHeight: 18,
+            maxWidth: 18,
+            borderRadius: 4,
+            backgroundColor: theme.palette.background.paper,
+          }}
+        >
+          <div style={{ width: 17, height: 17, marginLeft: 1, marginTop: 1 }}>
+            <Jdenticon size='17' value='mention-example' />
+          </div>
+        </div>
+      </div>
+    </ThemeProvider>
+  </StyledEngineProvider>
+)
+
+describe('Jdenticon dark mode background (#2959)', () => {
+  it('renders on a light background in light mode', () => {
+    mount(<Harness theme={lightTheme} />)
+    cy.wait(0)
+    // jdenticon paints its own background as a <rect> before the identicon shapes.
+    // It must always match the light theme's paper color, never the active theme's.
+    cy.get('svg rect').should('have.attr', 'fill', lightTheme.palette.background.paper)
+    cy.screenshot('2959-light', { overwrite: true })
+  })
+
+  it('renders on the same light background in dark mode, not the dark theme background', () => {
+    mount(<Harness theme={darkTheme} />)
+    cy.wait(0)
+    cy.get('svg rect').should('have.attr', 'fill', lightTheme.palette.background.paper)
+    cy.get('svg rect').should('not.have.attr', 'fill', darkTheme.palette.background.paper)
+    cy.screenshot('2959-dark', { overwrite: true })
+  })
+})

--- a/packages/desktop/src/renderer/components/Jdenticon/Jdenticon.tsx
+++ b/packages/desktop/src/renderer/components/Jdenticon/Jdenticon.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import * as jdenticon from 'jdenticon/browser'
+import { lightTheme } from '../../theme'
+
+// Identicons are always drawn on this fixed light background, regardless of the
+// active app theme (see #2959 — a dark mode background made icons unreadable).
+const BACK_COLOR = lightTheme.palette.background.paper
 
 // Copied from react-jdenticon because its peer dependency clashes with react 18
 const Jdenticon = ({ value = 'test', size = '100%', style = {} }) => {
   const icon = React.useRef(null)
   React.useEffect(() => {
     if (!icon.current) return
-    jdenticon.update(icon.current, value)
+    jdenticon.update(icon.current, value, { backColor: BACK_COLOR })
   }, [value])
 
   return (


### PR DESCRIPTION
Fixes #2959

## What

Fixed at the shared component by passing jdenticon's own backColor, so the light background is painted inside the SVG and can't be defeated by caller styling. Root cause: both call sites used theme.palette.background.paper (#F0F0F0 light / #222222 dark).

## Evidence

Before/after screenshots in both themes, independently re-run by the lead. New Cypress regression spec asserts the SVG background rect stays pinned to the light colour; confirmed red against the unfixed component.

### Screenshots

**after-dark**

![2959-after-dark.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2959/2959-after-dark.png)

**after-light**

![2959-after-light.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2959/2959-after-light.png)

**before-dark**

![2959-before-dark.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2959/2959-before-dark.png)

**before-light**

![2959-before-light.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2959/2959-before-light.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2959.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
