### PR TITLE
test(desktop): regression guard for blank-line collapsing in messages (#1618)

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.blankLines.cy.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.blankLines.cy.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { mount } from 'cypress/react18'
+import { it, describe, cy } from 'local-cypress'
+import { withTheme } from '../../../storybook/decorators'
+import { TextMessageComponent } from './TextMessage'
+
+/**
+ * Visual evidence for https://github.com/TryQuiet/quiet/issues/1618.
+ *
+ * Renders a message exactly as a malicious/careless sender could produce it
+ * with shift+enter (a large run of blank lines before and after the real
+ * content), on the RECEIVING side, using the production TextMessageComponent
+ * unmodified. See TextMessage.blankLines.test.tsx and the accompanying report
+ * for why no production code change was needed here.
+ */
+const rawSenderInput = '\n\n\n\n\nHello there!\n\n\n\n\nThis has a lot of blank lines around it.\n\n\n\n\n'
+
+const codeFenceInput = '\n\n\n```\nfirst line\n\n\nlast line\n```\n\n\n'
+
+const Demo: React.FC<{ label: string; raw: string; testId: string }> = ({ label, raw, testId }) => (
+  <div style={{ padding: 16, background: '#fff', width: 520 }}>
+    <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#888', marginBottom: 4 }}>{label}</div>
+    <div
+      style={{
+        fontFamily: 'monospace',
+        fontSize: 11,
+        whiteSpace: 'pre',
+        background: '#f2f2f2',
+        border: '1px solid #ddd',
+        padding: 8,
+        marginBottom: 12,
+      }}
+    >
+      {JSON.stringify(raw)}
+    </div>
+    <div style={{ fontFamily: 'monospace', fontSize: 12, color: '#888', marginBottom: 4 }}>Rendered to the receiver:</div>
+    <div style={{ border: '1px solid #ddd', padding: 8 }}>
+      <TextMessageComponent message={raw} messageId={testId} pending={false} openUrl={() => {}} />
+    </div>
+  </div>
+)
+
+describe('TextMessage - issue #1618 blank line handling (visual evidence)', () => {
+  it('a message padded with leading/trailing blank lines does not create a blank area on the receiver side', () => {
+    mount(withTheme(() => <Demo label="Raw message string sent over the wire:" raw={rawSenderInput} testId="1618-blank" />))
+    cy.wait(0)
+    cy.screenshot('1618-blank-lines-current', { overwrite: true, capture: 'viewport' })
+  })
+
+  it('blank lines and content inside a fenced code block are left alone', () => {
+    mount(withTheme(() => <Demo label="Raw message string sent over the wire:" raw={codeFenceInput} testId="1618-codefence" />))
+    cy.wait(0)
+    cy.screenshot('1618-code-fence-preserved', { overwrite: true, capture: 'viewport' })
+  })
+})

--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.blankLines.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.blankLines.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+import { withTheme } from '../../../storybook/decorators'
+import { TextMessageComponent } from './TextMessage'
+
+/**
+ * Regression coverage for https://github.com/TryQuiet/quiet/issues/1618
+ * ("Messages can have a ton of trailing whitespace").
+ *
+ * The issue asks that leading/trailing blank lines produced with shift+enter be
+ * stripped on the RECEIVER side (so a malicious client can't force large blank
+ * areas onto other people's screens by sending literal whitespace).
+ *
+ * Investigation for this pass found that TextMessageComponent already renders
+ * this correctly today: it pipes `message` through ReactMarkdown (remark-gfm),
+ * and CommonMark's block-level parser treats runs of blank lines purely as
+ * paragraph separators - it never emits an empty paragraph for them. So blank
+ * lines before the first real content or after the last are dropped entirely,
+ * and a run of blank lines between two lines of text collapses to a single
+ * paragraph boundary (one line break, rendered by the component's
+ * `white-space: pre-line` CSS) regardless of how many blank lines the sender
+ * typed. This holds for every receiving client, so a malicious sender gains
+ * nothing by padding a message with blank lines.
+ *
+ * These tests lock that behavior in as a regression guard - they pass today
+ * without any production code change. They also confirm the one thing that
+ * must NOT be touched by any future change here: content inside a fenced code
+ * block (blank lines, indentation) is untouched by this normalization.
+ */
+const helloWorld = (msg: string) => render(withTheme(() => <TextMessageComponent message={msg} messageId={'1618'} pending={false} openUrl={() => {}} />))
+
+describe('TextMessage - issue #1618 blank line handling', () => {
+  it('strips a large run of leading and trailing blank lines', () => {
+    const message = '\n\n\n\n\nActual message content\n\n\n\n\n'
+    const { getByTestId } = helloWorld(message)
+    expect(getByTestId('messagesGroupContent-1618')).toHaveTextContent('Actual message content')
+    expect(getByTestId('messagesGroupContent-1618').innerHTML).toBe('Actual message content')
+  })
+
+  it('collapses a large run of blank lines between two lines of real text to a single line break', () => {
+    const message = 'first\n\n\n\n\n\nsecond'
+    const { getByTestId } = helloWorld(message)
+    // Only one newline should survive - no visible blank line/gap remains.
+    expect(getByTestId('messagesGroupContent-1618').innerHTML).toBe('first\nsecond')
+  })
+
+  it('renders a message that is only blank lines as empty, not as a tall blank block', () => {
+    const message = '\n\n\n\n\n\n\n\n\n\n'
+    const { getByTestId } = helloWorld(message)
+    expect(getByTestId('messagesGroupContent-1618')).toHaveTextContent('')
+  })
+
+  it('does not touch blank lines or indentation inside a fenced code block', () => {
+    // Leading/trailing blank lines around the message are stripped, but blank
+    // lines and indentation *inside* the fence must be preserved byte-for-byte.
+    const message = '\n\n\n```\n\n  indented\ncode\n\n```\n\n\n'
+    const { container } = helloWorld(message)
+    const code = container.querySelector('code')
+    expect(code).not.toBeNull()
+    expect(code!.textContent).toBe('\n  indented\ncode\n\n')
+  })
+
+  it('does not collapse blank lines around a list, blockquote, or table', () => {
+    const list = helloWorld('\n\n\n- a\n- b\n\n\n')
+    expect(list.container.querySelector('ul')).not.toBeNull()
+    expect(list.container.querySelector('ul')!.textContent?.trim()).toBe('a\nb')
+
+    const blockquote = helloWorld('\n\n\n> quoted text\n\n\n')
+    expect(blockquote.container.querySelector('blockquote')).not.toBeNull()
+    expect(blockquote.container.querySelector('blockquote')!.textContent?.trim()).toBe('quoted text')
+
+    const table = helloWorld('\n\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n\n')
+    expect(table.container.querySelector('table')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Refs #1618

## What

Desktop half ALREADY FIXED years ago (p: React.Fragment + CommonMark collapse blank-line runs) — verified independently, no production change made. The lead then found the MOBILE half is still broken by design: pushBr() promotes every blank line to a literal <br>. Rescope to mobile; do NOT close.

## Evidence

5 jest assertions + a Cypress render, all green on unmodified code, committed as a regression guard. Mobile defect demonstrated by running pushBr verbatim: 10 blank lines -> 10 literal <br> tags.

### Screenshots

**blank-lines-current**

![1618-blank-lines-current.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1618/1618-blank-lines-current.png)

**code-fence-preserved**

![1618-code-fence-preserved.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1618/1618-code-fence-preserved.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1618.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
