### PR TITLE
Fix #1592: give the modal Close button an accessible name

### DIFF
--- a/packages/desktop/src/renderer/components/Channel/DeleteChannel/DeleteChannel.test.tsx
+++ b/packages/desktop/src/renderer/components/Channel/DeleteChannel/DeleteChannel.test.tsx
@@ -59,6 +59,7 @@ describe('LeaveCommunity', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/ui/ErrorModal/ErrorModal.test.tsx
+++ b/packages/desktop/src/renderer/components/ui/ErrorModal/ErrorModal.test.tsx
@@ -63,6 +63,7 @@ describe('ErrorModal', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/ui/Icon/IconButton.d.ts
+++ b/packages/desktop/src/renderer/components/ui/Icon/IconButton.d.ts
@@ -4,4 +4,5 @@ export interface IIconButtonProps {
   onClick: IconButtonProps['onClick']
   children?: React.ReactNode
   dataTestId?: string
+  ariaLabel?: string
 }

--- a/packages/desktop/src/renderer/components/ui/Icon/IconButton.tsx
+++ b/packages/desktop/src/renderer/components/ui/Icon/IconButton.tsx
@@ -17,9 +17,14 @@ const StyledIconButtonMui = styled(IconButtonMui)(({ theme }) => ({
   },
 }))
 
-export const IconButton: React.FC<IIconButtonProps> = ({ children, onClick, dataTestId }) => {
+export const IconButton: React.FC<IIconButtonProps> = ({ children, onClick, dataTestId, ariaLabel }) => {
   return (
-    <StyledIconButtonMui classes={{ root: classes.root }} onClick={onClick} data-testid={dataTestId}>
+    <StyledIconButtonMui
+      classes={{ root: classes.root }}
+      onClick={onClick}
+      data-testid={dataTestId}
+      aria-label={ariaLabel}
+    >
       {children}
     </StyledIconButtonMui>
   )

--- a/packages/desktop/src/renderer/components/ui/Modal/Modal.test.tsx
+++ b/packages/desktop/src/renderer/components/ui/Modal/Modal.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+
+import { renderComponent } from '../../../testUtils/renderComponent'
+import { Modal } from './Modal'
+
+describe('Modal close control (issue #1592)', () => {
+  it('has an accessible name and can be reached and activated by keyboard', async () => {
+    const handleClose = jest.fn()
+
+    renderComponent(
+      <Modal open handleClose={handleClose} title='Test modal'>
+        <div>content</div>
+      </Modal>
+    )
+
+    // Accessible name: assistive tech must be able to identify this control as
+    // "Close", not just "button" (the bug reported in #1592).
+    const closeButton = screen.getByRole('button', { name: /close/i })
+
+    // Keyboard reachable: it must be a real, focusable control.
+    closeButton.focus()
+    expect(closeButton).toHaveFocus()
+
+    // Keyboard activatable: pressing Enter while focused must trigger the
+    // close handler. (A naive tabindex-only fix would make the element
+    // focusable but still inert on Enter/Space if it weren't a real button.)
+    await userEvent.keyboard('{Enter}')
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/desktop/src/renderer/components/ui/Modal/Modal.tsx
+++ b/packages/desktop/src/renderer/components/ui/Modal/Modal.tsx
@@ -228,6 +228,7 @@ export const Modal: React.FC<IModalProps> = ({
                         }
                       }}
                       dataTestId={`${testIdPrefix}ModalClose`}
+                      ariaLabel='Close'
                     >
                       <ClearIcon />
                     </IconButton>

--- a/packages/desktop/src/renderer/components/ui/OpenlinkModal/OpenlinkModal.test.tsx
+++ b/packages/desktop/src/renderer/components/ui/OpenlinkModal/OpenlinkModal.test.tsx
@@ -62,6 +62,7 @@ describe('OpenlinkModal', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/widgets/WarningModal/WarningModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/WarningModal/WarningModal.test.tsx
@@ -53,6 +53,7 @@ describe('WarningModal', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/widgets/possibleImpersonationAttackModal/PossibleImpersonationAttackModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/possibleImpersonationAttackModal/PossibleImpersonationAttackModal.test.tsx
@@ -61,6 +61,7 @@ describe('PossibleImpersonationAttackModal', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/widgets/update/UpdateModalComponent.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/update/UpdateModalComponent.test.tsx
@@ -60,6 +60,7 @@ describe('UpdateModal', () => {
                       data-testid="ModalActions"
                     >
                       <button
+                        aria-label="Close"
                         class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                         data-testid="ModalClose"
                         tabindex="0"

--- a/packages/desktop/src/renderer/components/widgets/userLabel/duplicate/DuplicateModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/userLabel/duplicate/DuplicateModal.test.tsx
@@ -62,6 +62,7 @@ describe('DuplicateModalComponent', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"

--- a/packages/desktop/src/renderer/components/widgets/userLabel/unregistered/UnregisteredModal.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/userLabel/unregistered/UnregisteredModal.test.tsx
@@ -62,6 +62,7 @@ describe('UnregisteredModalComponent', () => {
                     data-testid="ModalActions"
                   >
                     <button
+                      aria-label="Close"
                       class="MuiButtonBase-root MuiIconButton-root IconButtonroot MuiIconButton-sizeMedium css-1hpikoh-MuiButtonBase-root-MuiIconButton-root"
                       data-testid="ModalClose"
                       tabindex="0"


### PR DESCRIPTION
Fixes #1592

## What

3-line fix at the shared IconButton primitive, so every modal inherits it. Corrected the issue's premise: the 'not keyboard focusable' half is stale — MUI IconButton already renders a real <button tabindex=0>. Only the accessible name was genuinely missing.

## Evidence

Failing-before/passing-after RTL test. Visual inertness proven by byte-identical before/after screenshots (MD5 verified by the lead). 8 snapshots updated — exact blast radius reported.

### Screenshots

**modal-close-crop-after**

![1592-modal-close-crop-after.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1592/1592-modal-close-crop-after.png)

**modal-close-crop-before**

![1592-modal-close-crop-before.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1592/1592-modal-close-crop-before.png)

**modal-full-after**

![1592-modal-full-after.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1592/1592-modal-full-after.png)

**modal-full-before**

![1592-modal-full-before.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1592/1592-modal-full-before.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1592.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
