### PR TITLE
Fix message-date marker never rolling over past midnight (#2751, #1661)

### DIFF
--- a/packages/state-manager/src/sagas/publicChannels/dayRollover.test.ts
+++ b/packages/state-manager/src/sagas/publicChannels/dayRollover.test.ts
@@ -1,0 +1,120 @@
+import { setupCrypto } from '@quiet/identity'
+import { type Store } from '../store.types'
+import { StoreKeys } from '../store.keys'
+import { prepareStore } from '../../utils/tests/prepareStore'
+import { currentChannelMessagesMergedBySender } from './publicChannels.selectors'
+import { publicChannelsActions, PublicChannelsState } from './publicChannels.slice'
+import { publicChannelsAdapter, channelMessagesAdapter } from './publicChannels.adapter'
+import { usersActions } from '../users/users.slice'
+import { DateTime } from 'luxon'
+import { type PublicChannelStorage } from '@quiet/types'
+
+/**
+ * Regression coverage for https://github.com/TryQuiet/quiet/issues/2751 (and its
+ * duplicate #1661): the 'Today' / 'Yesterday' message-date marker never rolled over
+ * on its own - it stayed frozen at whatever formatMessageDisplayDate() first computed,
+ * until a new message arrived and changed dailyGroupedCurrentChannelMessages' input.
+ *
+ * formatMessageDisplayDate() itself was never wrong (see formatMessageDisplayDate.test.ts) -
+ * the bug was that nothing ever asked it again once the local calendar day changed.
+ *
+ * NOTE on setup: this test seeds the channel directly via prepareStore's preloaded state
+ * (using the same publicChannelsAdapter/channelMessagesAdapter the real reducer uses)
+ * rather than dispatching publicChannelsActions.addChannel, and doesn't use the shared
+ * getReduxStoreFactory/factory-girl test helper. Both addChannel's reducer and that
+ * helper reference ChannelOperationStatus.SUCCESS/.FAILED from @quiet/types, and the
+ * symlinked @quiet/types build available in this environment predates that enum
+ * (confirmed pre-existing: the same crash happens on the untouched
+ * publicChannels.selectors.test.ts, unrelated to this fix). Preloading state sidesteps
+ * that environment issue entirely.
+ */
+describe('day rollover (#2751 / #1661): message-date marker updates without a new message', () => {
+  const channelId = 'general'
+  const userId = 'userId_alice'
+
+  let store: Store
+
+  beforeAll(() => {
+    setupCrypto()
+    process.env.LC_ALL = 'en_US.UTF-8'
+  })
+
+  beforeEach(() => {
+    // Fake timers so we can move the wall clock across local midnight below without
+    // waiting 24 real hours - this is the "fake timers" evidence for the fix.
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-09-11T23:00:00'))
+
+    const messages = channelMessagesAdapter.addOne(channelMessagesAdapter.getInitialState(), {
+      id: 'msg-sent-at-2300',
+      type: 1, // MessageType.Basic
+      message: 'hello, future me',
+      createdAt: DateTime.now().toSeconds(),
+      channelId,
+      userId,
+    } as any)
+
+    const channels = publicChannelsAdapter.addOne(publicChannelsAdapter.getInitialState(), {
+      id: channelId,
+      name: 'general',
+      description: 'Welcome to #general',
+      owner: userId,
+      timestamp: DateTime.now().toSeconds(),
+      public: true,
+      messages,
+    } as unknown as PublicChannelStorage)
+
+    store = prepareStore({
+      [StoreKeys.PublicChannels]: {
+        ...new PublicChannelsState(),
+        channels,
+        currentChannelId: channelId,
+      },
+    }).store
+
+    store.dispatch(
+      usersActions.setUserProfile({
+        userId,
+        nickname: 'alice',
+        bio: '',
+      } as any)
+    )
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('labels the message "Today" right after it is sent', () => {
+    const groups = currentChannelMessagesMergedBySender(store.getState())
+    expect(Object.keys(groups)).toEqual(['Today'])
+  })
+
+  it('keeps showing "Today" once real time has crossed into tomorrow, until something bumps dayTick (documents the root cause)', () => {
+    // Prime reselect's memoized cache the same way the UI would have, back when it was
+    // still "Today" - this is the call the real app makes on every render.
+    expect(Object.keys(currentChannelMessagesMergedBySender(store.getState()))).toEqual(['Today'])
+
+    jest.setSystemTime(new Date('2026-09-12T00:05:00'))
+
+    // No new message, no dispatch of any kind - just calling the selector again with a
+    // later wall clock. reselect still returns its memoized answer from setup time.
+    const groups = currentChannelMessagesMergedBySender(store.getState())
+    expect(Object.keys(groups)).toEqual(['Today'])
+  })
+
+  it('relabels the message "Yesterday" once dayTickSaga bumps dayTick after local midnight, with no new message', () => {
+    // Prime reselect's memoized cache at 'Today', same as the previous test - proving
+    // the fix actually invalidates a real stale cache, not just a first-ever computation.
+    expect(Object.keys(currentChannelMessagesMergedBySender(store.getState()))).toEqual(['Today'])
+
+    jest.setSystemTime(new Date('2026-09-12T00:05:00'))
+
+    // This is exactly what dayTickSaga (./dayTick/dayTick.saga.ts) dispatches once its
+    // delay() past local midnight fires - see dayTick.saga.test.ts for that half.
+    store.dispatch(publicChannelsActions.tickCurrentDay())
+
+    const groups = currentChannelMessagesMergedBySender(store.getState())
+    expect(Object.keys(groups)).toEqual(['Yesterday'])
+  })
+})

--- a/packages/state-manager/src/sagas/publicChannels/dayTick/dayTick.saga.test.ts
+++ b/packages/state-manager/src/sagas/publicChannels/dayTick/dayTick.saga.test.ts
@@ -1,0 +1,91 @@
+import { dayTickSaga, msUntilNextLocalMidnight } from './dayTick.saga'
+import { publicChannelsActions } from '../publicChannels.slice'
+
+describe('msUntilNextLocalMidnight', () => {
+  it('waits until just after the next local midnight on an ordinary evening', () => {
+    const now = new Date(2026, 8, 11, 22, 0, 0, 0) // Sept 11 2026, 22:00 local
+    const waitMs = msUntilNextLocalMidnight(now)
+
+    const nextMidnight = new Date(now.getTime() + waitMs)
+    expect(nextMidnight.getHours()).toBe(0)
+    expect(nextMidnight.getMinutes()).toBe(0)
+    expect(nextMidnight.getDate()).toBe(now.getDate() + 1)
+    // ~2h away, plus the small fixed post-midnight buffer.
+    expect(waitMs).toBeGreaterThan(2 * 60 * 60 * 1000)
+    expect(waitMs).toBeLessThan(2 * 60 * 60 * 1000 + 5000)
+  })
+
+  it('still returns a small positive wait right before midnight', () => {
+    const now = new Date(2026, 8, 11, 23, 59, 59, 500) // Sept 11 2026, 23:59:59.5 local
+    const waitMs = msUntilNextLocalMidnight(now)
+
+    expect(waitMs).toBeGreaterThan(0)
+    expect(waitMs).toBeLessThan(2000)
+  })
+
+  it('always targets the next midnight from wherever "now" actually is, so a process waking up days late self-corrects instead of drifting', () => {
+    // Simulates dayTickSaga only getting a chance to re-check the clock several days
+    // after it originally armed a delay() - e.g. the laptop was asleep for a while.
+    const wokeUpLate = new Date(2026, 8, 15, 9, 0, 0, 0)
+    const waitMs = msUntilNextLocalMidnight(wokeUpLate)
+
+    // Still just "until tonight's midnight", never a stale multi-day-old target.
+    expect(waitMs).toBeGreaterThan(0)
+    expect(waitMs).toBeLessThan(24 * 60 * 60 * 1000)
+  })
+
+  // DST correctness (the local midnight to local midnight gap is 23h on a
+  // spring-forward day and 25h on a fall-back day, because msUntilNextLocalMidnight
+  // asks the JS engine for "tomorrow at 00:00:00 local" via the field-based Date
+  // constructor - new Date(y, m, d + 1, 0, 0, 0) - rather than adding a fixed
+  // 86400000ms) is NOT exercised as a jest test here: this project's jest scripts
+  // hardcode TZ=UTC (see package.json "test"), and Node/V8 caches the process's
+  // timezone the first time anything touches Date/Intl, so reassigning
+  // process.env.TZ mid-test has no effect inside this harness (verified empirically -
+  // it silently no-ops, it does not throw). Forcing a real zone would mean spawning a
+  // whole separate process, which is disproportionate for one property that's
+  // otherwise guaranteed by the platform. Verified instead with a standalone script:
+  //
+  //   TZ=America/New_York node -e "
+  //     const a = new Date(2026,10,1,0,0,0,0); const b = new Date(2026,10,2,0,0,0,0);
+  //     console.log((b - a) / 3600000)"           // => 25 (fall-back day)
+  //   TZ=America/New_York node -e "
+  //     const a = new Date(2026,2,8,0,0,0,0); const b = new Date(2026,2,9,0,0,0,0);
+  //     console.log((b - a) / 3600000)"           // => 23 (spring-forward day)
+})
+
+describe('dayTickSaga', () => {
+  // Step the real generator and inspect the plain redux-saga effect descriptors it
+  // yields, rather than driving it through actual saga middleware: this is an infinite
+  // while(true) loop, and typed-redux-saga's delay()/put() helpers only produce a
+  // meaningful effect object when iterated by a real generator (calling them directly,
+  // e.g. to build an "expected" value, just returns an inert, contentless Generator) -
+  // so structural assertions on the real yields are the reliable way to test this.
+  it('waits until next local midnight, dispatches tickCurrentDay, then loops forever', () => {
+    const now = new Date(2026, 8, 11, 22, 0, 0, 0) // Sept 11 2026, 22:00 local
+    jest.useFakeTimers()
+    jest.setSystemTime(now)
+
+    const gen = dayTickSaga()
+    const expectedWaitMs = msUntilNextLocalMidnight(now)
+
+    const firstDelay = gen.next().value as any
+    expect(firstDelay.type).toBe('CALL')
+    expect(firstDelay.payload.fn.name).toBe('delayP')
+    expect(firstDelay.payload.args[0]).toBe(expectedWaitMs)
+
+    const tick = gen.next().value as any
+    expect(tick.type).toBe('PUT')
+    expect(tick.payload.action).toEqual(publicChannelsActions.tickCurrentDay())
+
+    // Loops back around and schedules the *following* midnight too - this saga is
+    // meant to run for the lifetime of the app, not fire once. (The fake clock hasn't
+    // moved, so the next target is computed the same way.)
+    const secondDelay = gen.next().value as any
+    expect(secondDelay.type).toBe('CALL')
+    expect(secondDelay.payload.fn.name).toBe('delayP')
+    expect(secondDelay.payload.args[0]).toBe(expectedWaitMs)
+
+    jest.useRealTimers()
+  })
+})

--- a/packages/state-manager/src/sagas/publicChannels/dayTick/dayTick.saga.ts
+++ b/packages/state-manager/src/sagas/publicChannels/dayTick/dayTick.saga.ts
@@ -1,0 +1,54 @@
+import { delay, put } from 'typed-redux-saga'
+import { publicChannelsActions } from '../publicChannels.slice'
+import { createLogger } from '../../../utils/logger'
+
+const logger = createLogger('dayTickSaga')
+
+// One extra second of buffer past midnight so we never fire a hair early due to
+// sub-millisecond scheduling jitter.
+const POST_MIDNIGHT_BUFFER_MS = 1000
+
+/**
+ * Milliseconds from `now` until just after the next local midnight.
+ *
+ * Deliberately recomputed from the wall clock on every call (including every
+ * loop iteration of dayTickSaga below) instead of assuming a fixed 24h period.
+ * That makes it self-correcting across:
+ *  - DST transitions, where the next midnight can be 23h or 25h away - the
+ *    field-based `Date` constructor below asks the JS engine for "tomorrow at
+ *    00:00:01 local time" directly, rather than adding 86400000ms;
+ *  - the process being suspended (e.g. laptop sleep) across one or more
+ *    midnights - whenever it wakes and this is next called, `now` reflects
+ *    the real current time, so it schedules against the *next* midnight from
+ *    wherever the clock actually is, rather than drifting or firing a stored
+ *    stale target repeatedly.
+ */
+export const msUntilNextLocalMidnight = (now: Date = new Date()): number => {
+  const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 0)
+  return nextMidnight.getTime() - now.getTime() + POST_MIDNIGHT_BUFFER_MS
+}
+
+/**
+ * Bumps publicChannels.dayTick shortly after every local midnight. That value
+ * isn't consumed for its content - it exists purely to bust the memoization on
+ * dailyGroupedCurrentChannelMessages (publicChannels.selectors.ts) so 'Today' /
+ * 'Yesterday' message-date labels update on their own, instead of staying
+ * frozen until a new message is sent or received.
+ *
+ * See https://github.com/TryQuiet/quiet/issues/2751 and #1661.
+ *
+ * Uses a self-rearming delay() (one wake per day) rather than a setInterval or
+ * per-minute poll, so it costs nothing while the channel view is otherwise
+ * idle. It is safe to run indefinitely: like the existing uptimeSaga
+ * (appConnection/uptime/uptime.saga.ts), it is `fork`-ed from a master saga and
+ * is cancelled along with it (see publicChannels.master.saga.ts), so there is
+ * no timer to manually clean up.
+ */
+export function* dayTickSaga(): Generator {
+  while (true) {
+    const waitMs = msUntilNextLocalMidnight()
+    yield* delay(waitMs)
+    logger.info('local day changed, bumping dayTick')
+    yield* put(publicChannelsActions.tickCurrentDay())
+  }
+}

--- a/packages/state-manager/src/sagas/publicChannels/dayTick/dayTickRehydration.test.ts
+++ b/packages/state-manager/src/sagas/publicChannels/dayTick/dayTickRehydration.test.ts
@@ -1,0 +1,50 @@
+import { publicChannelsSlice, publicChannelsActions, PublicChannelsState } from '../publicChannels.slice'
+
+/**
+ * Regression coverage for a redux-persist interaction in the #2751 fix.
+ *
+ * `publicChannels` IS persisted (see packages/desktop/src/renderer/store/reducers.ts,
+ * whitelist: [... StateManagerStoreKeys.PublicChannels ...]), and the rehydrate path runs
+ * PublicChannelsTransform's outbound handler -> sanitizePublicChannelsPersistenceState(),
+ * which returns `{ ...outboundState, <a few overrides> }`. It spreads the PERSISTED object
+ * and never calls `new PublicChannelsState()`, so the class-field default `dayTick = 0`
+ * does NOT apply to rehydrated state.
+ *
+ * For anyone upgrading from a build that predates `dayTick`, the rehydrated slice therefore
+ * has no `dayTick` key at all. An unguarded `state.dayTick += 1` then yields NaN, and NaN + 1
+ * stays NaN forever. Because reselect's default equality is `===` and `NaN === NaN` is false,
+ * `dailyGroupedCurrentChannelMessages` would cache-miss on EVERY call from then on —
+ * a permanent re-render cost in the message list (already flagged slow in #1116 / #648).
+ *
+ * These cases deliberately do NOT build state via `new PublicChannelsState()`: that
+ * constructor supplies the default and is precisely the path that cannot reproduce this.
+ */
+describe('#2751 dayTick: redux-persist rehydration', () => {
+  // Shaped like a pre-upgrade persisted slice: a present object, missing the new key.
+  const rehydratedWithoutDayTick = () => {
+    const { dayTick: _dropped, ...withoutDayTick } = new PublicChannelsState()
+    return withoutDayTick as unknown as PublicChannelsState
+  }
+
+  it('state rehydrated from a pre-upgrade build genuinely lacks dayTick', () => {
+    expect('dayTick' in rehydratedWithoutDayTick()).toBe(false)
+  })
+
+  it('produces a finite number, not NaN, on the first tick after rehydration', () => {
+    const next = publicChannelsSlice.reducer(rehydratedWithoutDayTick(), publicChannelsActions.tickCurrentDay())
+    expect(Number.isFinite(next.dayTick)).toBe(true)
+  })
+
+  it('keeps incrementing on subsequent days, so the selector cache-buster keeps changing', () => {
+    const first = publicChannelsSlice.reducer(rehydratedWithoutDayTick(), publicChannelsActions.tickCurrentDay())
+    const second = publicChannelsSlice.reducer(first, publicChannelsActions.tickCurrentDay())
+    expect(Number.isFinite(second.dayTick)).toBe(true)
+    expect(second.dayTick).not.toEqual(first.dayTick)
+  })
+
+  it('recovers even if an already-poisoned NaN was persisted by an intermediate build', () => {
+    const poisoned = { ...new PublicChannelsState(), dayTick: NaN } as PublicChannelsState
+    const next = publicChannelsSlice.reducer(poisoned, publicChannelsActions.tickCurrentDay())
+    expect(Number.isFinite(next.dayTick)).toBe(true)
+  })
+})

--- a/packages/state-manager/src/sagas/publicChannels/publicChannels.master.saga.ts
+++ b/packages/state-manager/src/sagas/publicChannels/publicChannels.master.saga.ts
@@ -1,5 +1,5 @@
 import { type Socket } from '../../types'
-import { all, takeEvery, cancelled } from 'typed-redux-saga'
+import { all, fork, takeEvery, cancelled } from 'typed-redux-saga'
 import { publicChannelsActions } from './publicChannels.slice'
 import { createChannelSaga } from './createChannel/createChannel.saga'
 import { deleteChannelSaga } from './deleteChannel/deleteChannel.saga'
@@ -11,6 +11,7 @@ import { channelDeletionResponseSaga } from './channelDeletionResponse/channelDe
 import { sendIntroductionMessageSaga } from './sendIntroductionMessage/sendIntroductionMessage.saga'
 import { createLogger } from '../../utils/logger'
 import { addMembersChannelSaga } from './addMembersChannel/addMembersChannel.saga'
+import { dayTickSaga } from './dayTick/dayTick.saga'
 
 const logger = createLogger('publicChannelsMasterSaga')
 
@@ -18,6 +19,7 @@ export function* publicChannelsMasterSaga(socket: Socket): Generator {
   logger.info('publicChannelsMasterSaga starting')
   try {
     yield all([
+      fork(dayTickSaga),
       takeEvery(publicChannelsActions.createChannel.type, createChannelSaga, socket),
       takeEvery(publicChannelsActions.deleteChannel.type, deleteChannelSaga, socket),
       takeEvery(publicChannelsActions.channelDeletionResponse.type, channelDeletionResponseSaga),

--- a/packages/state-manager/src/sagas/publicChannels/publicChannels.selectors.ts
+++ b/packages/state-manager/src/sagas/publicChannels/publicChannels.selectors.ts
@@ -220,23 +220,33 @@ export const currentChannelMessagesCount = createSelector(displayableCurrentChan
   return messages.length
 })
 
+// Selects PublicChannelsState.dayTick. Its value is never read below - it exists only to
+// invalidate this selector's memoized cache once per local day (see dayTickSaga), since
+// otherwise reselect keeps returning the same 'Today' / 'Yesterday' labels it computed the
+// first time, until the message list itself changes. See #2751 / #1661.
+const selectDayTick = createSelector(selectState, state => state?.dayTick)
+
 /**
  * Channel display messages grouped by day
  */
-export const dailyGroupedCurrentChannelMessages = createSelector(displayableCurrentChannelMessages, messages => {
-  const result: MessagesGroupsType = messages.reduce((groups: MessagesGroupsType, message: DisplayableMessage) => {
-    const date = formatMessageDisplayDate(message.createdAt)
+export const dailyGroupedCurrentChannelMessages = createSelector(
+  displayableCurrentChannelMessages,
+  selectDayTick,
+  (messages, _dayTick) => {
+    const result: MessagesGroupsType = messages.reduce((groups: MessagesGroupsType, message: DisplayableMessage) => {
+      const date = formatMessageDisplayDate(message.createdAt)
 
-    if (!groups[date]) {
-      groups[date] = []
-    }
+      if (!groups[date]) {
+        groups[date] = []
+      }
 
-    groups[date].push(message)
-    return groups
-  }, {})
+      groups[date].push(message)
+      return groups
+    }, {})
 
-  return result
-})
+    return result
+  }
+)
 
 /**
  * Channel messages grouped by day and then additionally by sender (if

--- a/packages/state-manager/src/sagas/publicChannels/publicChannels.slice.ts
+++ b/packages/state-manager/src/sagas/publicChannels/publicChannels.slice.ts
@@ -55,6 +55,13 @@ export class PublicChannelsState {
 
   public channelSpecificPermissions: EntityState<PrivateChannelPermissions> =
     channelSpecificPermissionsAdapter.getInitialState()
+
+  // Bumped once per local calendar day by dayTickSaga. Not read for its value -
+  // it exists only so selectors that memoize on it (e.g. dailyGroupedCurrentChannelMessages)
+  // are forced to recompute their 'Today' / 'Yesterday' message-date labels when the
+  // day rolls over, instead of only recomputing when a new message arrives.
+  // See https://github.com/TryQuiet/quiet/issues/2751 and #1661.
+  public dayTick: number = 0
 }
 
 export const publicChannelsSlice = createSlice({
@@ -170,6 +177,17 @@ export const publicChannelsSlice = createSlice({
       const { genericPermissions, channelSpecificPermissions } = action.payload
       state.genericChannelPermissions = genericPermissions
       channelSpecificPermissionsAdapter.setAll(state.channelSpecificPermissions, channelSpecificPermissions)
+    },
+    // Dispatched by dayTickSaga shortly after local midnight. See PublicChannelsState.dayTick.
+    // Guarded rather than a bare `+= 1`: this slice is persisted, and the rehydrate path
+    // (PublicChannelsTransform -> sanitizePublicChannelsPersistenceState) spreads the stored
+    // object instead of constructing a PublicChannelsState, so the class-field default above
+    // does NOT apply to state restored from a build that predates dayTick. An unguarded
+    // increment would yield NaN there, and since reselect compares with === (and NaN !== NaN)
+    // that would permanently defeat memoization of dailyGroupedCurrentChannelMessages.
+    // See dayTick/dayTickRehydration.test.ts.
+    tickCurrentDay: state => {
+      state.dayTick = Number.isFinite(state.dayTick) ? state.dayTick + 1 : 1
     },
     // Utility action for testing purposes
     test_message: (


### PR DESCRIPTION
Fixes #2751

## What

Saga-based day tick: a self-arming delay() to the next local midnight bumps a counter that busts reselect's memo on the message-date selector. Recomputed from the wall clock each iteration, so it is DST-correct and self-corrects after suspend. Fixes desktop and mobile in one place.

## Evidence

11/11 green across 3 suites. Store-level tests drive the REAL production selector chain, including one that primes the stale memo cache first to prove invalidation rather than first-computation. Reviewer added the rehydration guard + 4 tests after finding an undefined->NaN defect that would have permanently broken memoization for upgrading users; differential suite re-run shows 47 failures before and after (all pre-existing), passing 7->11.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Touches `packages/state-manager`: run `npm run build` there before running desktop/mobile suites.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2751.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
