### PR TITLE
Keep the desktop app resident while the backend is running

### DIFF
--- a/packages/desktop/src/main/main.test.ts
+++ b/packages/desktop/src/main/main.test.ts
@@ -4,7 +4,7 @@ import * as main from './main'
 import * as backendHelpers from './backendHelpers'
 
 import { autoUpdater } from 'electron-updater'
-import { BrowserWindow, app, ipcMain, Menu } from 'electron'
+import { BrowserWindow, app, ipcMain, Menu, powerSaveBlocker } from 'electron'
 import { waitFor } from '@testing-library/dom'
 import path from 'path'
 import { composeInvitationDeepUrl, getValidInvitationUrlTestData, validInvitationCodeTestData } from '@quiet/common'
@@ -65,6 +65,9 @@ jest.mock('child_process', () => {
 })
 
 jest.mock('electron', () => {
+  // Faithful little fake: real Electron hands back an id and tracks whether that id is still active.
+  const startedPowerSaveBlockers = new Set<number>()
+  let nextPowerSaveBlockerId = 1
   return {
     ...jest.requireActual('electron'),
     app: {
@@ -117,6 +120,17 @@ jest.mock('electron', () => {
       once: jest.fn(),
       handle: jest.fn(),
       removeListener: jest.fn(),
+    },
+    powerSaveBlocker: {
+      start: jest.fn(() => {
+        const id = nextPowerSaveBlockerId++
+        startedPowerSaveBlockers.add(id)
+        return id
+      }),
+      stop: jest.fn((id: number) => {
+        startedPowerSaveBlockers.delete(id)
+      }),
+      isStarted: jest.fn((id: number) => startedPowerSaveBlockers.has(id)),
     },
   }
 })
@@ -231,6 +245,39 @@ describe('electron app ready event', () => {
     expect(mockWindowWebContentsSend).toHaveBeenCalledWith('newUpdateAvailable')
   })
 })
+
+// Issue #53: a suspended machine stops answering as a peer, which breaks registration for everyone
+// else. These run before the quit-flow tests below, while `quitting` is still false.
+describe('power save blocker', () => {
+  const powerSaveBlockerStart = powerSaveBlocker.start as jest.Mock<any, any>
+  const powerSaveBlockerStop = powerSaveBlocker.stop as jest.Mock<any, any>
+
+  it('starts one prevent-app-suspension blocker once the backend is running', () => {
+    expect(powerSaveBlockerStart).toHaveBeenCalledTimes(1)
+    expect(powerSaveBlockerStart).toHaveBeenCalledWith('prevent-app-suspension')
+  })
+
+  it('does not start a second blocker while one is already running', () => {
+    main.startPowerSaveBlocker()
+    expect(powerSaveBlockerStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops the blocker it started when the app quits', () => {
+    const startedId = powerSaveBlockerStart.mock.results[0].value
+    const beforeQuitHandler = mockAppOnCalls.find(c => c[0] === 'before-quit')[1]
+
+    beforeQuitHandler({ preventDefault: jest.fn() })
+
+    expect(powerSaveBlockerStop).toHaveBeenCalledTimes(1)
+    expect(powerSaveBlockerStop).toHaveBeenCalledWith(startedId)
+  })
+
+  it('stopping when no blocker is running is a no-op', () => {
+    main.stopPowerSaveBlocker()
+    expect(powerSaveBlockerStop).toHaveBeenCalledTimes(1)
+  })
+})
+
 // --- EXTRA QUIT-FLOW TESTS ---
 describe('additional quit flow scenarios', () => {
   const forkMock = require('child_process').fork as jest.Mock

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -1,5 +1,5 @@
 import './loadMainEnvs' // Needs to be at the top of imports
-import { app, BrowserWindow, BrowserView, Menu, ipcMain, session, dialog } from 'electron'
+import { app, BrowserWindow, BrowserView, Menu, ipcMain, session, dialog, powerSaveBlocker } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { autoUpdater } from 'electron-updater'
@@ -516,6 +516,37 @@ const setupUpdater = async () => {
 
 let ports: ApplicationPorts
 let backendProcess: ChildProcess | null = null
+let powerSaveBlockerId: number | null = null
+
+/**
+ * Ask the OS not to idle-suspend us while the backend is running.
+ *
+ * A suspended machine stops answering as a peer, which is what breaks registration for everyone else
+ * (issue #53). We use 'prevent-app-suspension' and deliberately not 'prevent-display-sleep': we need
+ * the process to keep running, not the screen to stay lit. This blocks *idle* suspension only - an
+ * explicit user sleep (closing the lid, choosing Sleep) still wins on every platform.
+ */
+export const startPowerSaveBlocker = () => {
+  if (powerSaveBlockerId !== null && powerSaveBlocker.isStarted(powerSaveBlockerId)) {
+    logger.trace('Power save blocker already running, id:', powerSaveBlockerId)
+    return
+  }
+  powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension')
+  logger.info('Started power save blocker (prevent-app-suspension), id:', powerSaveBlockerId)
+}
+
+export const stopPowerSaveBlocker = () => {
+  if (powerSaveBlockerId === null) {
+    logger.trace('No power save blocker to stop')
+    return
+  }
+  const id = powerSaveBlockerId
+  powerSaveBlockerId = null
+  if (powerSaveBlocker.isStarted(id)) {
+    powerSaveBlocker.stop(id)
+    logger.info('Stopped power save blocker, id:', id)
+  }
+}
 
 app.on('ready', async () => {
   logger.info('Event: app.ready')
@@ -617,6 +648,9 @@ app.on('ready', async () => {
     },
   })
   logger.info('Forked backend, PID:', backendProcess.pid)
+
+  // The backend is what keeps us reachable, so hold the blocker for exactly as long as it lives.
+  startPowerSaveBlocker()
 
   const solveCaptcha = async (siteKey?: string) => {
     const resolvedSiteKey = siteKey ?? process.env.HCAPTCHA_SITEKEY
@@ -972,6 +1006,7 @@ app.on('activate', async () => {
 
 app.on('before-quit', e => {
   quitting = true
+  stopPowerSaveBlocker()
   if (backendProcess !== null) {
     logger.info('App before-quit intercepted waiting for backend to exit', e)
     if (!updating) {


### PR DESCRIPTION
Fixes #53

## What

Holds one `powerSaveBlocker('prevent-app-suspension')` for exactly the backend's lifetime: started right after the fork, released first thing in before-quit; both helpers idempotent because before-quit fires twice on the wait-for-backend path. Explicit user sleep (lid close) still wins — cited from Apple IOPMLib and Microsoft SetThreadExecutionState docs, since Electron's page is silent on it. No opt-out shipped: battery trade-off stated.

## Evidence

4 new main-process tests, all red on unmodified main.ts, green after; suite 268→272 passing with the same single pre-existing failure. Lead verified placement and re-ran main.test.ts (20/20).

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-53.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
