### PR TITLE
fix(desktop): persist and restore the main window size (#2103)

### DIFF
--- a/packages/desktop/src/main/main.test.ts
+++ b/packages/desktop/src/main/main.test.ts
@@ -25,6 +25,11 @@ const mockWindowClose = jest.fn()
 const mockSetMovable = jest.fn()
 const mockSetAlwaysOnTop = jest.fn()
 const mockIsDestroyed = jest.fn()
+const mockIsMaximized = jest.fn()
+const mockIsFullScreen = jest.fn()
+const mockGetPrimaryDisplay = jest.fn()
+const mockStoreGet = jest.fn()
+const mockStoreSet = jest.fn()
 
 const spyCreateWindow = jest.spyOn(main, 'createWindow')
 const spyGetPorts = jest.spyOn(backendHelpers, 'getPorts')
@@ -33,9 +38,16 @@ jest.spyOn(main, 'isBrowserWindow').mockReturnValue(true)
 jest.spyOn(path, 'join').mockReturnValue('path')
 
 jest.mock('electron-store', () => {
-  return {
-    initRenderer: jest.fn(),
-  }
+  // main.ts uses electron-store both as a namespace (initRenderer) and as a
+  // constructor (the persisted window size), so the mock has to be both.
+  const ElectronStoreMock: any = jest.fn().mockImplementation(() => {
+    return {
+      get: mockStoreGet,
+      set: mockStoreSet,
+    }
+  })
+  ElectronStoreMock.initRenderer = jest.fn()
+  return ElectronStoreMock
 })
 
 jest.mock('@electron/remote/main', () => {
@@ -98,6 +110,8 @@ jest.mock('electron', () => {
         getPosition: jest.fn().mockImplementation(() => [600, 800]),
         setSize: jest.fn(),
         setPosition: jest.fn(),
+        isMaximized: mockIsMaximized,
+        isFullScreen: mockIsFullScreen,
         isMinimized: jest.fn(),
         restore: jest.fn(),
         focus: jest.fn(),
@@ -111,6 +125,11 @@ jest.mock('electron', () => {
     }),
     Menu: {
       setApplicationMenu: jest.fn(),
+    },
+    screen: {
+      // Wrapped so the mock fn is looked up lazily - jest.mock factories run
+      // before the const declarations above are initialised.
+      getPrimaryDisplay: () => mockGetPrimaryDisplay(),
     },
     ipcMain: {
       on: jest.fn(),
@@ -366,5 +385,132 @@ describe('security: socketIOSecret exposure', () => {
     // Should NOT find the call with -scrt
     const secretCall = forkCalls.find((call: (string | string[])[]) => call[1] && call[1].includes('-scrt'))
     expect(secretCall).toBeUndefined()
+  })
+})
+
+describe('window size persistence', () => {
+  const BrowserWindowMock = BrowserWindow as unknown as jest.Mock
+
+  // createWindow() builds the main window first and the splash window second.
+  const optionsOfLastWindows = () => {
+    const calls = BrowserWindowMock.mock.calls
+    return { mainWindow: calls[calls.length - 2][0], splash: calls[calls.length - 1][0] }
+  }
+
+  // 'resize' is registered on every createWindow() call, so take the latest one.
+  const lastHandlerFor = (event: string) =>
+    mockWindowOn.mock.calls.filter(call => call[0] === event).pop()![1] as (...args: any[]) => void
+
+  // 'close' is registered once, during startup, not on every createWindow() call.
+  // Capture it before the per-test mockClear() wipes the record of it.
+  let onStartupClose: (e: any) => void
+
+  beforeAll(() => {
+    onStartupClose = mockWindowOn.mock.calls.find(call => call[0] === 'close')![1]
+  })
+
+  beforeEach(() => {
+    BrowserWindowMock.mockClear()
+    mockWindowOn.mockClear()
+    mockStoreGet.mockReset()
+    mockStoreSet.mockReset()
+    mockIsMaximized.mockReturnValue(false)
+    mockIsFullScreen.mockReturnValue(false)
+    mockGetPrimaryDisplay.mockReturnValue({ workAreaSize: { width: 2560, height: 1440 } })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('uses the built-in default size when nothing has been persisted', async () => {
+    mockStoreGet.mockReturnValue(undefined)
+
+    await main.createWindow()
+
+    expect(optionsOfLastWindows().mainWindow).toEqual(expect.objectContaining({ width: 800, height: 540 }))
+  })
+
+  it('restores a persisted size that fits on the current display', async () => {
+    mockStoreGet.mockReturnValue({ width: 1200, height: 900 })
+
+    await main.createWindow()
+
+    const { mainWindow, splash } = optionsOfLastWindows()
+    expect(mainWindow).toEqual(expect.objectContaining({ width: 1200, height: 900 }))
+    // The splash window has always matched the main window, so it still does.
+    expect(splash).toEqual(expect.objectContaining({ width: 1200, height: 900 }))
+  })
+
+  it('clamps a persisted size that no longer fits the display work area', async () => {
+    mockGetPrimaryDisplay.mockReturnValue({ workAreaSize: { width: 1366, height: 768 } })
+    mockStoreGet.mockReturnValue({ width: 3840, height: 2160 })
+
+    await main.createWindow()
+
+    expect(optionsOfLastWindows().mainWindow).toEqual(expect.objectContaining({ width: 1366, height: 768 }))
+  })
+
+  it('falls back to the default size when the persisted value is malformed', async () => {
+    mockStoreGet.mockReturnValue({ width: 'wide', height: -1 })
+
+    await main.createWindow()
+
+    expect(optionsOfLastWindows().mainWindow).toEqual(expect.objectContaining({ width: 800, height: 540 }))
+  })
+
+  it('falls back to the default size when reading the store throws', async () => {
+    mockStoreGet.mockImplementation(() => {
+      throw new Error('corrupted window-state.json')
+    })
+
+    await main.createWindow()
+
+    expect(optionsOfLastWindows().mainWindow).toEqual(expect.objectContaining({ width: 800, height: 540 }))
+  })
+
+  it('persists the new size once resizing settles', async () => {
+    jest.useFakeTimers()
+    await main.createWindow()
+    const onResize = lastHandlerFor('resize')
+
+    onResize()
+    onResize()
+    onResize()
+    expect(mockStoreSet).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(1000)
+
+    // Debounced: a burst of resize events results in a single write.
+    expect(mockStoreSet).toHaveBeenCalledTimes(1)
+    expect(mockStoreSet).toHaveBeenCalledWith('windowSize', { width: 600, height: 800 })
+  })
+
+  it('does not persist the size of a maximised window', async () => {
+    jest.useFakeTimers()
+    await main.createWindow()
+    mockIsMaximized.mockReturnValue(true)
+
+    lastHandlerFor('resize')()
+    jest.advanceTimersByTime(1000)
+
+    expect(mockStoreSet).not.toHaveBeenCalled()
+  })
+
+  it('flushes a pending save when the window is closed', async () => {
+    jest.useFakeTimers()
+    await main.createWindow()
+
+    lastHandlerFor('resize')()
+    expect(mockStoreSet).not.toHaveBeenCalled()
+
+    onStartupClose({ preventDefault: jest.fn() })
+
+    expect(mockStoreSet).toHaveBeenCalledWith('windowSize', { width: 600, height: 800 })
+
+    // …and the pending debounce was cancelled rather than firing a second write.
+    mockStoreSet.mockClear()
+    jest.advanceTimersByTime(1000)
+    expect(mockStoreSet).not.toHaveBeenCalled()
   })
 })

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -1,5 +1,5 @@
 import './loadMainEnvs' // Needs to be at the top of imports
-import { app, BrowserWindow, BrowserView, Menu, ipcMain, session, dialog } from 'electron'
+import { app, BrowserWindow, BrowserView, Menu, ipcMain, session, dialog, screen } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { autoUpdater } from 'electron-updater'
@@ -12,6 +12,7 @@ import { fork, ChildProcess } from 'child_process'
 import { getFilesData } from '@quiet/common'
 import { type BackendLeaveCommunityMessage } from '@quiet/types'
 import { updateDesktopFile, processInvitationCode } from './invitation'
+import type ElectronStoreType from 'electron-store'
 const ElectronStore = require('electron-store')
 const contextMenu = require('electron-context-menu')
 import sodium from 'libsodium-wrappers-sumo'
@@ -90,9 +91,104 @@ interface IWindowSize {
 
 logger.info('electron main')
 
-const windowSize: IWindowSize = {
+// Used on first launch, and whenever the persisted size is missing or unusable.
+const defaultWindowSize: IWindowSize = {
   width: 800,
   height: 540,
+}
+
+// Mirrors mainWindow.setMinimumSize() in createWindow. Electron would enforce this
+// anyway, so there is no point restoring anything smaller.
+const minimumWindowSize: IWindowSize = {
+  width: 600,
+  height: 400,
+}
+
+// Kept in its own file so it can never interfere with the redux-persist store the
+// renderer process keeps in the same data directory.
+const WINDOW_STATE_STORE_NAME = 'window-state'
+const WINDOW_SIZE_STORE_KEY = 'windowSize'
+// 'resize' fires continuously while the user drags; only write once they stop.
+const WINDOW_SIZE_SAVE_DEBOUNCE_MS = 500
+
+type WindowStateStore = ElectronStoreType<{ windowSize?: IWindowSize }>
+
+let windowStateStore: WindowStateStore | null = null
+let windowSizeSaveTimeout: ReturnType<typeof setTimeout> | null = null
+
+const getWindowStateStore = (): WindowStateStore => {
+  // Created lazily: at module load time the app data directory may not exist yet.
+  if (windowStateStore === null) {
+    const store: WindowStateStore = new ElectronStore({ name: WINDOW_STATE_STORE_NAME, cwd: newUserDataPath })
+    windowStateStore = store
+    return store
+  }
+  return windowStateStore
+}
+
+const isUsableDimension = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+// max can legitimately be smaller than min on a very small display, in which case
+// the minimum wins - Electron enforces it through setMinimumSize regardless.
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), Math.max(min, max))
+
+/**
+ * Reconciles a persisted size with the display the window will actually open on, so
+ * a size saved while a bigger (possibly since disconnected) monitor was attached can
+ * never produce a window larger than the current work area. Anything missing or
+ * malformed falls back to the default.
+ */
+const resolveWindowSize = (stored: unknown, workAreaSize: IWindowSize): IWindowSize => {
+  if (typeof stored !== 'object' || stored === null) return { ...defaultWindowSize }
+  const { width, height } = stored as Partial<IWindowSize>
+  if (!isUsableDimension(width) || !isUsableDimension(height)) return { ...defaultWindowSize }
+  return {
+    width: clamp(Math.round(width), minimumWindowSize.width, workAreaSize.width),
+    height: clamp(Math.round(height), minimumWindowSize.height, workAreaSize.height),
+  }
+}
+
+const loadWindowSize = (): IWindowSize => {
+  try {
+    // screen is only usable after the 'ready' event, which is why this is called
+    // from createWindow rather than at module scope.
+    return resolveWindowSize(getWindowStateStore().get(WINDOW_SIZE_STORE_KEY), screen.getPrimaryDisplay().workAreaSize)
+  } catch (e) {
+    logger.warn('Could not read persisted window size, using the default', e)
+    return { ...defaultWindowSize }
+  }
+}
+
+const saveWindowSize = (): void => {
+  const window = mainWindow
+  if (window === null) return
+  try {
+    // A maximised or full-screen window reports the size of the screen; persisting
+    // that would reopen the app un-maximised but screen-sized.
+    if (window.isDestroyed() || window.isMaximized() || window.isFullScreen()) return
+    const [width, height] = window.getSize()
+    if (!isUsableDimension(width) || !isUsableDimension(height)) return
+    getWindowStateStore().set(WINDOW_SIZE_STORE_KEY, { width, height })
+  } catch (e) {
+    logger.warn('Could not persist window size', e)
+  }
+}
+
+const scheduleWindowSizeSave = (): void => {
+  if (windowSizeSaveTimeout !== null) clearTimeout(windowSizeSaveTimeout)
+  windowSizeSaveTimeout = setTimeout(() => {
+    windowSizeSaveTimeout = null
+    saveWindowSize()
+  }, WINDOW_SIZE_SAVE_DEBOUNCE_MS)
+}
+
+const flushWindowSizeSave = (): void => {
+  if (windowSizeSaveTimeout !== null) {
+    clearTimeout(windowSizeSaveTimeout)
+    windowSizeSaveTimeout = null
+  }
+  saveWindowSize()
 }
 
 const crypto = require('crypto').webcrypto
@@ -174,18 +270,16 @@ app.on('open-url', (event, url) => {
   }
 })
 
-let browserWidth: number
-let browserHeight: number
-
 // Default title bar must be hidden for macos because we have custom styles for it
 const titleBarStyle = process.platform === 'darwin' ? 'hidden' : 'default'
 export const createWindow = async () => {
   logger.trace('Creating splash and main windows')
+  const startupWindowSize = loadWindowSize()
   logger.trace('Creating main window')
   logger.time('Created mainWindow')
   mainWindow = new BrowserWindow({
-    width: windowSize.width,
-    height: windowSize.height,
+    width: startupWindowSize.width,
+    height: startupWindowSize.height,
     show: false,
     titleBarStyle,
     webPreferences: {
@@ -200,8 +294,10 @@ export const createWindow = async () => {
   logger.trace('Creating splash window')
   logger.time('Created splash')
   splash = new BrowserWindow({
-    width: windowSize.width,
-    height: windowSize.height,
+    // The splash window has always matched the main window so the hand-over is
+    // seamless; it follows the restored size for the same reason.
+    width: startupWindowSize.width,
+    height: startupWindowSize.height,
     show: false,
     titleBarStyle,
     webPreferences: {
@@ -257,13 +353,8 @@ export const createWindow = async () => {
     rendererReady = false
     mainWindow = null
   })
-  mainWindow.on('resize', () => {
-    if (isBrowserWindow(mainWindow)) {
-      const [width, height] = mainWindow.getSize()
-      browserHeight = height
-      browserWidth = width
-    }
-  })
+  // Remember the size the user chose so the window comes back the same next boot.
+  mainWindow.on('resize', scheduleWindowSizeSave)
   electronLocalshortcut.register(mainWindow, 'CommandOrControl+L', () => {
     if (isBrowserWindow(mainWindow)) {
       mainWindow.webContents.send('openLogs')
@@ -720,6 +811,10 @@ app.on('ready', async () => {
   mainWindow.on('close', e => {
     logger.info('Main window close event received')
     if (resetting) return
+
+    // The debounced save from 'resize' may still be pending; write it out now,
+    // while the window is still alive and can report its size.
+    flushWindowSizeSave()
 
     // --- macOS: hide instead of destroying the renderer ---
     if (process.platform === 'darwin' && !updating && backendProcess !== null) {


### PR DESCRIPTION
Fixes #2103

## What

Size saved to its own electron-store file (window-state.json) from a debounced resize handler and flushed on close; restored in createWindow and clamped to the current display's work area (600x400 floor mirrors setMinimumSize). Skips maximised/fullscreen sizes; malformed data → defaults. Position deliberately not persisted.

## Evidence

8 new tests written first (4 red on unmodified code), all green after; full desktop suite 276/284 with the same single pre-existing failure. Lead verified flush runs inside the 'close' handler before hide/destroy and re-ran main.test.ts (24/24).

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2103.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
