### PR TITLE
Profile photos: error on oversized files and compress to the 200KB budget (#2953)

### DIFF
--- a/packages/backend/src/nest/storage/userProfile/userProfile.utils.ts
+++ b/packages/backend/src/nest/storage/userProfile/userProfile.utils.ts
@@ -1,4 +1,5 @@
 import { SetUserProfileResponse, UserProfile } from '@quiet/types'
+import { MAX_PROFILE_PHOTO_SIZE_BYTES } from '@quiet/common'
 import { createLogger } from '../../common/logger'
 
 const logger = createLogger('UserProfileStoreUtils')
@@ -83,8 +84,8 @@ export const validatePhoto = (photoString: string, pubKey: string): SetUserProfi
     }
 
     // Apply different size limits based on image format:
-    const MAX_SIZE_JPEG = 200 * 1024 // 200KB in bytes
-    const MAX_SIZE_PNG_GIF = 200 * 1024 // 200KB in bytes
+    const MAX_SIZE_JPEG = MAX_PROFILE_PHOTO_SIZE_BYTES
+    const MAX_SIZE_PNG_GIF = MAX_PROFILE_PHOTO_SIZE_BYTES
 
     if (photoString.startsWith('data:image/jpeg;base64,')) {
       if (photoBytes.length > MAX_SIZE_JPEG) {

--- a/packages/common/src/const.ts
+++ b/packages/common/src/const.ts
@@ -23,3 +23,20 @@ export enum InvalidInvitationLinkError {
   TITLE = 'Invalid invitation link',
   MESSAGE = 'Please check your invitation link and try again',
 }
+
+/**
+ * Maximum size, in bytes, of a user's profile photo.
+ *
+ * Profile photos are replicated to and auto-downloaded by every member of a
+ * community, so they are kept far smaller than ordinary attachments. This is the
+ * same 200KB budget that has always been enforced on the deprecated base64
+ * inline photos (see `validatePhoto` in the backend); attachment-based photos
+ * are held to it too so that the limit does not depend on how the photo happens
+ * to be transported.
+ */
+export const MAX_PROFILE_PHOTO_SIZE_BYTES = 200 * 1024
+
+/** User-facing message shown when the chosen profile photo exceeds the limit above. */
+export const PROFILE_PHOTO_TOO_LARGE_ERROR = `Photo is too large (max ${
+  MAX_PROFILE_PHOTO_SIZE_BYTES / 1024
+}KB). Please choose a smaller image.`

--- a/packages/desktop/src/main/main.test.ts
+++ b/packages/desktop/src/main/main.test.ts
@@ -6,6 +6,7 @@ import * as backendHelpers from './backendHelpers'
 import { autoUpdater } from 'electron-updater'
 import { BrowserWindow, app, ipcMain, Menu } from 'electron'
 import { waitFor } from '@testing-library/dom'
+import fs from 'fs'
 import path from 'path'
 import { composeInvitationDeepUrl, getValidInvitationUrlTestData, validInvitationCodeTestData } from '@quiet/common'
 import { InvitationData } from '@quiet/types'
@@ -366,5 +367,53 @@ describe('security: socketIOSecret exposure', () => {
     // Should NOT find the call with -scrt
     const secretCall = forkCalls.find((call: (string | string[])[]) => call[1] && call[1].includes('-scrt'))
     expect(secretCall).toBeUndefined()
+  })
+})
+
+describe('write-profile-photo-temp-file IPC handler', () => {
+  const getHandler = () => {
+    const call = (ipcMain.handle as jest.Mock).mock.calls.find(c => c[0] === 'write-profile-photo-temp-file')
+    expect(call).toBeDefined()
+    return call![1] as (event: unknown, arg: unknown) => Promise<{ path: string; name: string; ext: string }>
+  }
+
+  let mkdirSync: jest.SpyInstance
+  let writeFileSync: jest.SpyInstance
+
+  beforeEach(() => {
+    mkdirSync = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)
+    writeFileSync = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    mkdirSync.mockRestore()
+    writeFileSync.mockRestore()
+  })
+
+  it('writes the buffer to the temporary files directory and returns where it landed', async () => {
+    const fileBuffer = new Uint8Array([1, 2, 3, 4])
+
+    const result = await getHandler()(null, { fileName: 'profile-photo.jpg', ext: '.jpg', fileBuffer })
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true })
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const [writtenPath, writtenData] = writeFileSync.mock.calls[0]
+    expect(writtenData).toEqual(Buffer.from(fileBuffer))
+    // The extension is stripped from the returned name, matching writeTempFile,
+    // so that callers can rebuild `name + ext` without doubling it up.
+    expect(result).toEqual({ path: writtenPath, name: 'profile-photo', ext: '.jpg' })
+  })
+
+  it('keeps the whole file name when no extension is given', async () => {
+    const result = await getHandler()(null, { fileName: 'profile-photo', ext: '', fileBuffer: new Uint8Array([9]) })
+
+    expect(result.name).toBe('profile-photo')
+  })
+
+  it('rejects a request with no buffer instead of writing an empty file', async () => {
+    await expect(getHandler()(null, { fileName: 'profile-photo.jpg', ext: '.jpg' })).rejects.toThrow(
+      'write-profile-photo-temp-file requires a fileBuffer'
+    )
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 })

--- a/packages/desktop/src/main/main.ts
+++ b/packages/desktop/src/main/main.ts
@@ -877,6 +877,30 @@ app.on('ready', async () => {
     })
   })
 
+  /**
+   * Writes a compressed profile photo to a temp file and returns where it landed.
+   *
+   * Deliberately a separate channel from `writeTempFile` above: that one answers
+   * with a broadcast `writeTempFileReply`, and the channel view listens to it
+   * permanently and appends every reply to the message composer's pending
+   * attachments. Reusing it would make the user's profile photo appear as an
+   * unsent chat attachment. `handle`/`invoke` answers only the caller.
+   */
+  ipcMain.handle('write-profile-photo-temp-file', async (_event, arg) => {
+    logger.info('ipcMain: write-profile-photo-temp-file')
+    if (!arg?.fileBuffer) {
+      throw new Error('write-profile-photo-temp-file requires a fileBuffer')
+    }
+    const temporaryFilesDirectory = path.join(appDataPath, 'temporaryFiles')
+    fs.mkdirSync(temporaryFilesDirectory, { recursive: true })
+    const id = `${Date.now()}_${Math.random().toString(36).substring(0, 20)}`
+    const name = arg.ext ? arg.fileName.split(arg.ext)[0] : arg.fileName
+    const filePath = `${path.join(temporaryFilesDirectory, `${name}_${id}${arg.ext}`)}`
+    fs.writeFileSync(filePath, Buffer.from(arg.fileBuffer))
+
+    return { path: filePath, name, ext: arg.ext }
+  })
+
   ipcMain.on('openUploadFileDialog', async e => {
     logger.info('ipcMain: openUploadFileDialog')
     let filesDialogResult: Electron.OpenDialogReturnValue

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileContextMenu.container.tsx
@@ -12,7 +12,7 @@ import { ContextMenu, ContextMenuItemList } from '../ContextMenu.component'
 import { MenuName } from '../../../../const/MenuNames.enum'
 import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 import { createLogger } from '../../../logger'
-import { webUtils } from 'electron'
+import { prepareProfilePhotoForUpload } from './profilePhoto/prepareProfilePhoto'
 
 const logger = createLogger('userProfileContextMenu:container')
 
@@ -249,13 +249,21 @@ export const UserProfileMenuProfileView: FC<UserProfileMenuProfileViewProps> = (
  * A button that shows a file input dialog for attaching a profile
  * photo and passes the chosen file to a callback.
  */
-export const EditPhotoButton: FC<{ onChange: (photo?: File) => void }> = ({ onChange }) => {
+export const EditPhotoButton: FC<{ onChange: (photo?: File) => void; busy?: boolean }> = ({
+  onChange,
+  busy = false,
+}) => {
   const fileInput = React.useRef<HTMLInputElement>(null)
 
   return (
-    <button className={classes.editPhotoButton} onClick={evt => fileInput.current?.click()}>
+    <button
+      className={classes.editPhotoButton}
+      disabled={busy}
+      data-testid='user-profile-edit-photo-button'
+      onClick={evt => fileInput.current?.click()}
+    >
       <Typography variant='body2' style={{ lineHeight: '20px' }}>
-        Edit photo
+        {busy ? 'Resizing photo…' : 'Edit photo'}
       </Typography>
       <input
         ref={fileInput}
@@ -284,11 +292,14 @@ export const UserProfileMenuEditComponent: FC<{ setRoute: (route: string) => voi
   const userId = userProfile?.userId || ''
   const contextMenu = useContextMenu(MenuName.UserProfile)
   const saveUserProfileError = useSelector(users.selectors.saveUserProfileError)
-  const onSaveUserProfile = ({ photo }: { photo: File }) => {
-    // since on electron 32+ .path is undefined on File, we need to set the path property before sneding the profile pic to the backend
-    // @ts-ignore
-    photo.path = webUtils.getPathForFile(photo)
-    dispatch(users.actions.saveUserProfile({ photo }))
+  const onSaveUserProfile = async ({ photo }: { photo: File }) => {
+    // Oversized photos are re-encoded down to MAX_PROFILE_PHOTO_SIZE_BYTES here
+    // rather than refused. The result already carries the on-disk `path` the
+    // upload saga reads (since Electron 32+, File.path is gone and the path has
+    // to be resolved explicitly). A photo that already fits, or one that cannot
+    // be compressed, comes back untouched.
+    const preparedPhoto = await prepareProfilePhotoForUpload(photo)
+    dispatch(users.actions.saveUserProfile({ photo: preparedPhoto }))
   }
 
   React.useEffect(() => {
@@ -320,7 +331,7 @@ export interface UserProfileMenuEditViewProps {
     handleClose: () => any
   }
   setRoute: (route: string) => void
-  onSaveUserProfile: ({ photo }: { photo: File }) => void
+  onSaveUserProfile: ({ photo }: { photo: File }) => void | Promise<void>
   errorBanner?: string | null
 }
 
@@ -336,6 +347,9 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
   const [contentRef, setContentRef] = useState<HTMLDivElement | null>(null)
   const scrollbarRef = useRef(null)
   const [offset, setOffset] = useState(0)
+  // Re-encoding a multi-megabyte photo takes a moment; keep the button from
+  // being clicked twice while it happens.
+  const [preparingPhoto, setPreparingPhoto] = useState(false)
 
   const theme = useTheme()
 
@@ -358,7 +372,12 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
       return
     }
 
-    onSaveUserProfile({ photo })
+    setPreparingPhoto(true)
+    try {
+      await onSaveUserProfile({ photo })
+    } finally {
+      setPreparingPhoto(false)
+    }
   }
 
   React.useEffect(() => {
@@ -416,7 +435,7 @@ export const UserProfileMenuEditView: FC<UserProfileMenuEditViewProps> = ({
                         className={classes.profilePhoto}
                         size={96}
                       />
-                      <EditPhotoButton onChange={onChange} />
+                      <EditPhotoButton onChange={onChange} busy={preparingPhoto} />
                     </Grid>
                     <label htmlFor='username' className={classes.editUsernameFieldLabel}>
                       Username

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileMenuEditView.photoCompression.cy.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileMenuEditView.photoCompression.cy.tsx
@@ -1,0 +1,221 @@
+import React from 'react'
+import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles'
+import { mount } from 'cypress/react18'
+import { it, cy, describe, expect, beforeEach, Cypress } from 'local-cypress'
+
+import { MAX_PROFILE_PHOTO_SIZE_BYTES } from '@quiet/common'
+
+import { UserProfileMenuEditView } from './UserProfileContextMenu.container'
+import { compressProfilePhoto } from './profilePhoto/compressProfilePhoto'
+import {
+  prepareProfilePhotoForUpload,
+  type UploadableProfilePhoto,
+  type WriteProfilePhotoTempFileRequest,
+} from './profilePhoto/prepareProfilePhoto'
+import { lightTheme } from '../../../theme'
+
+const contextMenu = {
+  visible: true,
+  handleOpen: () => {},
+  handleClose: () => {},
+}
+
+const ORIGINAL_PHOTO_PATH = '/home/me/Pictures/original.png'
+const TEMP_PHOTO_PATH = '/appData/temporaryFiles/profile-photo_cypress.jpg'
+
+/**
+ * A 2000x2000 field of random pixels. Noise does not compress, so the PNG comes
+ * out far over the profile photo budget - this is the "photo straight off a
+ * phone" case that #2953 is about.
+ */
+const makeNoisyPng = (edge: number): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = edge
+    canvas.height = edge
+    const context = canvas.getContext('2d')
+    if (!context) {
+      reject(new Error('no 2d context'))
+      return
+    }
+    const image = context.createImageData(edge, edge)
+    const data = image.data
+    for (let i = 0; i < data.length; i += 4) {
+      const rgb = (Math.random() * 0xffffff) | 0
+      data[i] = rgb & 0xff
+      data[i + 1] = (rgb >> 8) & 0xff
+      data[i + 2] = (rgb >> 16) & 0xff
+      data[i + 3] = 255
+    }
+    context.putImageData(image, 0, 0)
+    canvas.toBlob(blob => {
+      if (!blob) {
+        reject(new Error('toBlob returned nothing'))
+        return
+      }
+      blob.arrayBuffer().then(buffer => resolve(new Uint8Array(buffer)), reject)
+    }, 'image/png')
+  })
+
+/** A 16x16 solid square: a perfectly ordinary, already-small profile photo. */
+const makeSmallPng = (): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 16
+    canvas.height = 16
+    const context = canvas.getContext('2d')
+    if (!context) {
+      reject(new Error('no 2d context'))
+      return
+    }
+    context.fillStyle = '#1c7bd4'
+    context.fillRect(0, 0, 16, 16)
+    canvas.toBlob(blob => {
+      if (!blob) {
+        reject(new Error('toBlob returned nothing'))
+        return
+      }
+      blob.arrayBuffer().then(buffer => resolve(new Uint8Array(buffer)), reject)
+    }, 'image/png')
+  })
+
+describe('Edit profile view: oversized photos are compressed, not refused', () => {
+  // Everything the real container does, except the hop into the main process.
+  let writeTempFileCalls: WriteProfilePhotoTempFileRequest[]
+  let dispatched: UploadableProfilePhoto[]
+
+  const onSaveUserProfile = async ({ photo }: { photo: File }) => {
+    const prepared = await prepareProfilePhotoForUpload(photo, {
+      compress: compressProfilePhoto,
+      writeTempFile: async request => {
+        writeTempFileCalls.push(request)
+        return { path: TEMP_PHOTO_PATH, name: 'profile-photo', ext: '.jpg' }
+      },
+      getPathForFile: () => ORIGINAL_PHOTO_PATH,
+    })
+    dispatched.push(prepared)
+  }
+
+  const mountEditView = (handler: ({ photo }: { photo: File }) => void | Promise<void> = onSaveUserProfile) => {
+    mount(
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={lightTheme}>
+          <CssBaseline />
+          <UserProfileMenuEditView
+            username='nick'
+            userId='userId'
+            contextMenu={contextMenu}
+            setRoute={() => {}}
+            onSaveUserProfile={handler}
+            errorBanner={null}
+          />
+        </ThemeProvider>
+      </StyledEngineProvider>
+    )
+  }
+
+  const choosePhoto = (bytes: Uint8Array, fileName: string, mimeType: string) => {
+    cy.get('[data-testid="user-profile-edit-photo-input"]').selectFile(
+      { contents: Cypress.Buffer.from(bytes), fileName, mimeType },
+      { force: true }
+    )
+  }
+
+  beforeEach(() => {
+    writeTempFileCalls = []
+    dispatched = []
+    cy.viewport(600, 560)
+  })
+
+  it('re-encodes a multi-megabyte photo down to the 200KB budget', () => {
+    cy.then(() => makeNoisyPng(2000)).then((bytes: Uint8Array) => {
+      // Sanity check on the fixture itself: it really is over the budget.
+      expect(bytes.byteLength).to.be.greaterThan(1024 * 1024)
+      expect(bytes.byteLength).to.be.greaterThan(MAX_PROFILE_PHOTO_SIZE_BYTES)
+
+      mountEditView()
+      choosePhoto(bytes, 'huge.png', 'image/png')
+    })
+
+    cy.wrap(writeTempFileCalls, { timeout: 30000 }).should('have.length', 1)
+
+    cy.then(() => {
+      const written = writeTempFileCalls[0]
+      expect(written.fileName).to.equal('profile-photo.jpg')
+      expect(written.ext).to.equal('.jpg')
+      expect(written.fileBuffer.byteLength).to.be.at.most(MAX_PROFILE_PHOTO_SIZE_BYTES)
+      // JPEG SOI marker: the bytes handed to the main process really are a JPEG.
+      expect(written.fileBuffer[0]).to.equal(0xff)
+      expect(written.fileBuffer[1]).to.equal(0xd8)
+
+      // The saga uploads from disk, so the dispatched photo must point at the
+      // temp file, not at the user's original.
+      expect(dispatched).to.have.length(1)
+      expect(dispatched[0].path).to.equal(TEMP_PHOTO_PATH)
+      expect(dispatched[0].name).to.equal('profile-photo.jpg')
+      expect(dispatched[0].size).to.be.at.most(MAX_PROFILE_PHOTO_SIZE_BYTES)
+    })
+
+    // No banner: the photo was accepted, which is the whole point of the change.
+    cy.contains('Photo is too large').should('not.exist')
+    cy.contains('Edit photo').should('be.visible')
+    cy.screenshot('2953-compress-accepted-light', { overwrite: true, capture: 'viewport' })
+  })
+
+  it('leaves a photo that already fits completely untouched', () => {
+    cy.then(() => makeSmallPng()).then((bytes: Uint8Array) => {
+      expect(bytes.byteLength).to.be.lessThan(MAX_PROFILE_PHOTO_SIZE_BYTES)
+
+      mountEditView()
+      choosePhoto(bytes, 'small.png', 'image/png')
+    })
+
+    cy.wrap(dispatched, { timeout: 30000 }).should('have.length', 1)
+
+    cy.then(() => {
+      // Not re-encoded: no temp file, and the upload still reads the user's own
+      // file off disk exactly as it did before this change.
+      expect(writeTempFileCalls).to.have.length(0)
+      expect(dispatched[0].path).to.equal(ORIGINAL_PHOTO_PATH)
+      expect(dispatched[0].name).to.equal('small.png')
+      expect(dispatched[0].type).to.equal('image/png')
+    })
+
+    cy.contains('Photo is too large').should('not.exist')
+  })
+
+  it('disables the Edit photo button while the photo is being resized', () => {
+    // A multi-megabyte photo takes a moment to re-encode; hold the button so it
+    // cannot be clicked a second time mid-flight. A handler that never settles
+    // makes that window observable.
+    mountEditView(() => new Promise<void>(() => {}))
+
+    cy.get('[data-testid="user-profile-edit-photo-button"]').should('not.be.disabled')
+    cy.contains('Edit photo').should('be.visible')
+
+    choosePhoto(new TextEncoder().encode('anything'), 'any.png', 'image/png')
+
+    cy.get('[data-testid="user-profile-edit-photo-button"]').should('be.disabled')
+    cy.contains('Resizing photo').should('be.visible')
+    cy.screenshot('2953-compress-resizing-light', { overwrite: true, capture: 'viewport' })
+  })
+
+  it('falls back to the original file when the chosen file is not a decodable image', () => {
+    const notAnImage = new TextEncoder().encode('this is not a png, whatever the extension says')
+
+    mountEditView()
+    choosePhoto(notAnImage, 'lies.png', 'image/png')
+
+    cy.wrap(dispatched, { timeout: 30000 }).should('have.length', 1)
+
+    cy.then(() => {
+      // Compression could not rescue it, so the user's file goes through
+      // unchanged and the size guard in saveUserProfileSaga stays the backstop
+      // that produces the too-large banner.
+      expect(writeTempFileCalls).to.have.length(0)
+      expect(dispatched[0].path).to.equal(ORIGINAL_PHOTO_PATH)
+      expect(dispatched[0].name).to.equal('lies.png')
+    })
+  })
+})

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileMenuEditView.photoSize.cy.tsx
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/UserProfileMenuEditView.photoSize.cy.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles'
+import { mount } from 'cypress/react18'
+import { it, cy, describe } from 'local-cypress'
+
+import { PROFILE_PHOTO_TOO_LARGE_ERROR } from '@quiet/common'
+
+import { UserProfileMenuEditView } from './UserProfileContextMenu.container'
+import { lightTheme, darkTheme } from '../../../theme'
+
+const contextMenu = {
+  visible: true,
+  handleOpen: () => {},
+  handleClose: () => {},
+}
+
+const mountEditView = (theme: typeof lightTheme, errorBanner?: string | null) => {
+  mount(
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <UserProfileMenuEditView
+          username='nick'
+          userId='userId'
+          contextMenu={contextMenu}
+          setRoute={() => {}}
+          onSaveUserProfile={() => {}}
+          errorBanner={errorBanner}
+        />
+      </ThemeProvider>
+    </StyledEngineProvider>
+  )
+}
+
+describe('Edit profile view: oversized photo error banner', () => {
+  it('shows no banner when there is no error (behaviour on develop)', () => {
+    cy.viewport(600, 560)
+    mountEditView(lightTheme, null)
+
+    cy.contains('Edit profile').should('be.visible')
+    cy.contains(PROFILE_PHOTO_TOO_LARGE_ERROR).should('not.exist')
+    cy.screenshot('2953-before-no-banner-light', { overwrite: true, capture: 'viewport' })
+  })
+
+  it('renders the too-large error from @quiet/common in the banner (light)', () => {
+    cy.viewport(600, 560)
+    mountEditView(lightTheme, PROFILE_PHOTO_TOO_LARGE_ERROR)
+
+    cy.contains(PROFILE_PHOTO_TOO_LARGE_ERROR).should('be.visible')
+    cy.screenshot('2953-after-banner-light', { overwrite: true, capture: 'viewport' })
+  })
+
+  it('renders the too-large error from @quiet/common in the banner (dark)', () => {
+    cy.viewport(600, 560)
+    mountEditView(darkTheme, PROFILE_PHOTO_TOO_LARGE_ERROR)
+
+    cy.contains(PROFILE_PHOTO_TOO_LARGE_ERROR).should('be.visible')
+    cy.screenshot('2953-after-banner-dark', { overwrite: true, capture: 'viewport' })
+  })
+})

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/compressProfilePhoto.test.ts
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/compressProfilePhoto.test.ts
@@ -1,0 +1,167 @@
+import { MAX_PROFILE_PHOTO_SIZE_BYTES } from '@quiet/common'
+
+import {
+  COMPRESSED_PROFILE_PHOTO_EXT,
+  COMPRESSED_PROFILE_PHOTO_NAME,
+  MAX_PROFILE_PHOTO_EDGE_PX,
+  PROFILE_PHOTO_QUALITY_MAX,
+  compressProfilePhoto,
+  scaleToFit,
+  type DecodedProfilePhoto,
+  type ProfilePhotoCodec,
+} from './compressProfilePhoto'
+
+/**
+ * jsdom has no canvas and no image decoder, so the codec is injected. What is
+ * under test is the policy around it: when to re-encode at all, what size to
+ * draw at, and which quality to stop on.
+ */
+const fakeFile = (name: string, type: string, size: number): File => ({ name, type, size }) as File
+
+const fakeBlob = (size: number): Blob => ({ size }) as Blob
+
+const decoded = (width: number, height: number): DecodedProfilePhoto => ({
+  width,
+  height,
+  source: {} as CanvasImageSource,
+})
+
+/** A codec whose JPEG size is a plain function of the pixel count and quality. */
+const makeCodec = (
+  width: number,
+  height: number,
+  sizeFor: (w: number, h: number, quality: number) => number
+): ProfilePhotoCodec & { encodeCalls: Array<{ width: number; height: number; quality: number }> } => {
+  const encodeCalls: Array<{ width: number; height: number; quality: number }> = []
+  return {
+    encodeCalls,
+    decode: jest.fn(async () => decoded(width, height)),
+    encode: jest.fn(async (_d, w, h, quality) => {
+      encodeCalls.push({ width: w, height: h, quality })
+      return fakeBlob(sizeFor(w, h, quality))
+    }),
+  }
+}
+
+const OVER = MAX_PROFILE_PHOTO_SIZE_BYTES + 1
+
+describe('scaleToFit', () => {
+  it('leaves an image that already fits alone', () => {
+    expect(scaleToFit(300, 200, 512)).toEqual({ width: 300, height: 200 })
+  })
+
+  it('scales the long edge down and keeps the aspect ratio', () => {
+    expect(scaleToFit(2000, 1000, 512)).toEqual({ width: 512, height: 256 })
+    expect(scaleToFit(1000, 2000, 512)).toEqual({ width: 256, height: 512 })
+  })
+
+  it('never produces a zero-width image', () => {
+    expect(scaleToFit(10000, 1, 512)).toEqual({ width: 512, height: 1 })
+  })
+})
+
+describe('compressProfilePhoto', () => {
+  it('passes an image that already fits through untouched, without decoding it', async () => {
+    const file = fakeFile('small.png', 'image/png', MAX_PROFILE_PHOTO_SIZE_BYTES)
+    const codec = makeCodec(100, 100, () => 10)
+
+    const result = await compressProfilePhoto(file, codec)
+
+    expect(result).toEqual({ compressed: false, file })
+    expect(codec.decode).not.toHaveBeenCalled()
+    expect(codec.encode).not.toHaveBeenCalled()
+  })
+
+  it('re-encodes an oversized image at the target long edge', async () => {
+    const file = fakeFile('huge.png', 'image/png', 8 * 1024 * 1024)
+    const codec = makeCodec(2000, 1500, () => 1000)
+
+    const result = await compressProfilePhoto(file, codec)
+
+    expect(result).toMatchObject({
+      compressed: true,
+      photo: {
+        name: COMPRESSED_PROFILE_PHOTO_NAME,
+        ext: COMPRESSED_PROFILE_PHOTO_EXT,
+        width: MAX_PROFILE_PHOTO_EDGE_PX,
+        height: 384,
+        quality: PROFILE_PHOTO_QUALITY_MAX,
+      },
+    })
+    expect(codec.encodeCalls).toHaveLength(1)
+  })
+
+  it('steps the quality down and stops on the first encode that fits', async () => {
+    const file = fakeFile('huge.jpg', 'image/jpeg', 8 * 1024 * 1024)
+    // Only quality <= 0.76 (the third rung) comes in under budget.
+    const codec = makeCodec(2000, 2000, (_w, _h, quality) => (quality <= 0.76 ? MAX_PROFILE_PHOTO_SIZE_BYTES : OVER))
+
+    const result = await compressProfilePhoto(file, codec)
+
+    expect(result).toMatchObject({ compressed: true, photo: { quality: 0.76, width: 512, height: 512 } })
+    expect(codec.encodeCalls.map(c => c.quality)).toEqual([0.92, 0.84, 0.76])
+  })
+
+  it('halves the long edge once when the whole quality ladder is over budget', async () => {
+    const file = fakeFile('huge.jpg', 'image/jpeg', 20 * 1024 * 1024)
+    const halved = Math.round(MAX_PROFILE_PHOTO_EDGE_PX / 2)
+    const codec = makeCodec(4000, 4000, w => (w <= halved ? 1000 : OVER))
+
+    const result = await compressProfilePhoto(file, codec)
+
+    expect(result).toMatchObject({ compressed: true, photo: { width: halved, height: halved, quality: 0.92 } })
+    // Full ladder at 512, then the first rung at 256.
+    expect(codec.encodeCalls.filter(c => c.width === MAX_PROFILE_PHOTO_EDGE_PX)).toHaveLength(6)
+    expect(codec.encodeCalls[codec.encodeCalls.length - 1]).toEqual({ width: halved, height: halved, quality: 0.92 })
+  })
+
+  it('gives up when even the halved image is over budget', async () => {
+    const file = fakeFile('huge.jpg', 'image/jpeg', 200 * 1024 * 1024)
+    const codec = makeCodec(4000, 4000, () => OVER)
+
+    expect(await compressProfilePhoto(file, codec)).toBeNull()
+  })
+
+  it('returns null when the file cannot be decoded', async () => {
+    const file = fakeFile('broken.png', 'image/png', 5 * 1024 * 1024)
+    const codec: ProfilePhotoCodec = {
+      decode: jest.fn(async () => {
+        throw new Error('not an image')
+      }),
+      encode: jest.fn(async () => fakeBlob(10)),
+    }
+
+    expect(await compressProfilePhoto(file, codec)).toBeNull()
+    expect(codec.encode).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the decoder reports a zero-sized image', async () => {
+    const file = fakeFile('empty.png', 'image/png', 5 * 1024 * 1024)
+    const codec = makeCodec(0, 0, () => 10)
+
+    expect(await compressProfilePhoto(file, codec)).toBeNull()
+  })
+
+  it('does not pass a small non-image through; it tries to decode it and fails', async () => {
+    const file = fakeFile('notreally.jpg', 'text/plain', 1024)
+    const codec: ProfilePhotoCodec = {
+      decode: jest.fn(async () => {
+        throw new Error('not an image')
+      }),
+      encode: jest.fn(async () => fakeBlob(10)),
+    }
+
+    expect(await compressProfilePhoto(file, codec)).toBeNull()
+    expect(codec.decode).toHaveBeenCalled()
+  })
+
+  it('returns null when the encoder yields no blob', async () => {
+    const file = fakeFile('huge.png', 'image/png', 5 * 1024 * 1024)
+    const codec: ProfilePhotoCodec = {
+      decode: jest.fn(async () => decoded(1000, 1000)),
+      encode: jest.fn(async () => null),
+    }
+
+    expect(await compressProfilePhoto(file, codec)).toBeNull()
+  })
+})

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/compressProfilePhoto.ts
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/compressProfilePhoto.ts
@@ -1,0 +1,173 @@
+/**
+ * Shrinks an oversized profile photo so that it fits the community-wide profile
+ * photo budget instead of being refused outright.
+ *
+ * Profile photos are force-replicated to and auto-downloaded by every member of
+ * a community, so `MAX_PROFILE_PHOTO_SIZE_BYTES` is a hard budget rather than a
+ * nicety. Refusing a 4MB phone photo is technically correct but useless to the
+ * user, who has no way to resize it inside Quiet; re-encoding it is.
+ *
+ * Only oversized photos are touched. A photo that already fits is passed
+ * through byte for byte, so nothing about today's behaviour changes for the
+ * common case, and PNG/GIF transparency and animation survive.
+ */
+import { MAX_PROFILE_PHOTO_SIZE_BYTES } from '@quiet/common'
+
+/**
+ * Longest edge, in CSS pixels, of a re-encoded profile photo.
+ *
+ * The photo is never rendered larger than 96 CSS px anywhere in the app (see the
+ * `size` prop of `ProfilePhoto`), so 512 leaves better than 5x headroom for
+ * high-DPI displays and for the photo being shown larger in future, while still
+ * being small enough that the quality loop below almost always lands on its
+ * first iteration.
+ */
+export const MAX_PROFILE_PHOTO_EDGE_PX = 512
+
+/** JPEG quality tried first, then stepped down until the photo fits. */
+export const PROFILE_PHOTO_QUALITY_MAX = 0.92
+/** Lowest JPEG quality we are willing to ship. Below this, artefacts dominate. */
+export const PROFILE_PHOTO_QUALITY_MIN = 0.5
+export const PROFILE_PHOTO_QUALITY_STEP = 0.08
+
+export const COMPRESSED_PROFILE_PHOTO_EXT = '.jpg'
+export const COMPRESSED_PROFILE_PHOTO_MIME = 'image/jpeg'
+export const COMPRESSED_PROFILE_PHOTO_NAME = `profile-photo${COMPRESSED_PROFILE_PHOTO_EXT}`
+
+/** A decoded still image, ready to be drawn onto a canvas. */
+export interface DecodedProfilePhoto {
+  width: number
+  height: number
+  source: CanvasImageSource
+}
+
+/**
+ * The seams that need a real browser. Injected so that the scaling and quality
+ * policy below can be unit tested under jsdom, which has no canvas.
+ */
+export interface ProfilePhotoCodec {
+  decode: (file: File) => Promise<DecodedProfilePhoto>
+  encode: (decoded: DecodedProfilePhoto, width: number, height: number, quality: number) => Promise<Blob | null>
+}
+
+export interface CompressedProfilePhoto {
+  blob: Blob
+  name: string
+  ext: string
+  width: number
+  height: number
+  quality: number
+}
+
+export type ProfilePhotoCompressionResult =
+  /** The photo already fits; upload the user's file untouched. */
+  | { compressed: false; file: File }
+  /** The photo was re-encoded as a JPEG that fits the budget. */
+  | { compressed: true; photo: CompressedProfilePhoto }
+
+const isImage = (file: File): boolean => (file.type || '').startsWith('image/')
+
+/** Scales `width` x `height` down so that its longest edge is at most `maxEdge`. */
+export const scaleToFit = (width: number, height: number, maxEdge: number): { width: number; height: number } => {
+  const longEdge = Math.max(width, height)
+  if (longEdge <= maxEdge) return { width, height }
+  const ratio = maxEdge / longEdge
+  return {
+    width: Math.max(1, Math.round(width * ratio)),
+    height: Math.max(1, Math.round(height * ratio)),
+  }
+}
+
+const defaultDecode = async (file: File): Promise<DecodedProfilePhoto> => {
+  const bitmap = await createImageBitmap(file)
+  return { width: bitmap.width, height: bitmap.height, source: bitmap }
+}
+
+const defaultEncode = async (
+  decoded: DecodedProfilePhoto,
+  width: number,
+  height: number,
+  quality: number
+): Promise<Blob | null> => {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const context = canvas.getContext('2d')
+  if (!context) return null
+  // JPEG has no alpha channel. Painting white first keeps a transparent PNG from
+  // coming out with a black background.
+  context.fillStyle = '#ffffff'
+  context.fillRect(0, 0, width, height)
+  context.drawImage(decoded.source, 0, 0, width, height)
+  return await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, COMPRESSED_PROFILE_PHOTO_MIME, quality))
+}
+
+export const defaultProfilePhotoCodec: ProfilePhotoCodec = {
+  decode: defaultDecode,
+  encode: defaultEncode,
+}
+
+/** JPEG qualities to try, highest first. */
+const qualityLadder = (): number[] => {
+  const qualities: number[] = []
+  // Guard against float drift making the loop overshoot PROFILE_PHOTO_QUALITY_MIN.
+  for (let q = PROFILE_PHOTO_QUALITY_MAX; q >= PROFILE_PHOTO_QUALITY_MIN - 1e-9; q -= PROFILE_PHOTO_QUALITY_STEP) {
+    qualities.push(Math.round(q * 100) / 100)
+  }
+  return qualities
+}
+
+/**
+ * Returns the photo to upload, or `null` when the file cannot be rescued.
+ *
+ * `null` means "I could not make this into an image that fits": a non-image, a
+ * corrupt file, or something so large that even 256px at quality 0.5 is over
+ * budget. Callers fall back to uploading the user's original file, which the
+ * size guard in `saveUserProfileSaga` then turns into the too-large banner.
+ */
+export const compressProfilePhoto = async (
+  file: File,
+  codec: ProfilePhotoCodec = defaultProfilePhotoCodec
+): Promise<ProfilePhotoCompressionResult | null> => {
+  if (isImage(file) && file.size <= MAX_PROFILE_PHOTO_SIZE_BYTES) {
+    return { compressed: false, file }
+  }
+
+  let decoded: DecodedProfilePhoto
+  try {
+    decoded = await codec.decode(file)
+  } catch {
+    return null
+  }
+  if (!decoded?.width || !decoded?.height) return null
+
+  // One pass at the target edge; if even the lowest quality is still over
+  // budget, halve the edge and try the ladder once more.
+  for (const maxEdge of [MAX_PROFILE_PHOTO_EDGE_PX, Math.round(MAX_PROFILE_PHOTO_EDGE_PX / 2)]) {
+    const { width, height } = scaleToFit(decoded.width, decoded.height, maxEdge)
+    for (const quality of qualityLadder()) {
+      let blob: Blob | null
+      try {
+        blob = await codec.encode(decoded, width, height, quality)
+      } catch {
+        return null
+      }
+      if (!blob) return null
+      if (blob.size <= MAX_PROFILE_PHOTO_SIZE_BYTES) {
+        return {
+          compressed: true,
+          photo: {
+            blob,
+            name: COMPRESSED_PROFILE_PHOTO_NAME,
+            ext: COMPRESSED_PROFILE_PHOTO_EXT,
+            width,
+            height,
+            quality,
+          },
+        }
+      }
+    }
+  }
+
+  return null
+}

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/prepareProfilePhoto.test.ts
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/prepareProfilePhoto.test.ts
@@ -1,0 +1,117 @@
+import { prepareProfilePhotoForUpload, type PrepareProfilePhotoDeps } from './prepareProfilePhoto'
+import { COMPRESSED_PROFILE_PHOTO_EXT, COMPRESSED_PROFILE_PHOTO_NAME } from './compressProfilePhoto'
+
+const makeBlob = (bytes: number): Blob => {
+  const data = new Uint8Array(bytes)
+  const blob = new Blob([data])
+  // jsdom's Blob predates Blob.arrayBuffer.
+  if (typeof (blob as unknown as { arrayBuffer?: unknown }).arrayBuffer !== 'function') {
+    Object.defineProperty(blob, 'arrayBuffer', { value: async () => data.buffer })
+  }
+  return blob
+}
+
+const originalFile = (): File => ({ name: 'me.png', type: 'image/png', size: 4 }) as File
+
+const makeDeps = (overrides: Partial<PrepareProfilePhotoDeps> = {}): PrepareProfilePhotoDeps => ({
+  compress: jest.fn(async () => null),
+  writeTempFile: jest.fn(async () => ({
+    path: '/data/temporaryFiles/profile-photo_1.jpg',
+    name: 'profile-photo',
+    ext: '.jpg',
+  })),
+  getPathForFile: jest.fn(() => '/home/me/Pictures/me.png'),
+  ...overrides,
+})
+
+describe('prepareProfilePhotoForUpload', () => {
+  it('writes the compressed photo to a temp file and points the upload at it', async () => {
+    const file = originalFile()
+    const blob = makeBlob(1234)
+    const deps = makeDeps({
+      compress: jest.fn(async () => ({
+        compressed: true as const,
+        photo: {
+          blob,
+          name: COMPRESSED_PROFILE_PHOTO_NAME,
+          ext: COMPRESSED_PROFILE_PHOTO_EXT,
+          width: 512,
+          height: 512,
+          quality: 0.92,
+        },
+      })),
+    })
+
+    const prepared = await prepareProfilePhotoForUpload(file, deps)
+
+    expect(deps.writeTempFile).toHaveBeenCalledWith({
+      fileName: COMPRESSED_PROFILE_PHOTO_NAME,
+      ext: COMPRESSED_PROFILE_PHOTO_EXT,
+      fileBuffer: expect.any(Uint8Array),
+    })
+    expect(prepared.path).toBe('/data/temporaryFiles/profile-photo_1.jpg')
+    // The saga derives the attachment extension from the name, so it has to keep one.
+    expect(prepared.name).toBe('profile-photo.jpg')
+    expect(prepared.size).toBe(1234)
+    // The on-disk path of the user's original file is never asked for.
+    expect(deps.getPathForFile).not.toHaveBeenCalled()
+  })
+
+  it('uploads the original file from disk when the photo already fits', async () => {
+    const file = originalFile()
+    const deps = makeDeps({ compress: jest.fn(async () => ({ compressed: false as const, file })) })
+
+    const prepared = await prepareProfilePhotoForUpload(file, deps)
+
+    expect(prepared).toBe(file)
+    expect(prepared.path).toBe('/home/me/Pictures/me.png')
+    expect(deps.writeTempFile).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the original file when the photo cannot be compressed', async () => {
+    const file = originalFile()
+    const deps = makeDeps({ compress: jest.fn(async () => null) })
+
+    const prepared = await prepareProfilePhotoForUpload(file, deps)
+
+    expect(prepared).toBe(file)
+    expect(prepared.path).toBe('/home/me/Pictures/me.png')
+    expect(deps.writeTempFile).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the original file when writing the temp file fails', async () => {
+    const file = originalFile()
+    const deps = makeDeps({
+      compress: jest.fn(async () => ({
+        compressed: true as const,
+        photo: {
+          blob: makeBlob(10),
+          name: COMPRESSED_PROFILE_PHOTO_NAME,
+          ext: COMPRESSED_PROFILE_PHOTO_EXT,
+          width: 512,
+          height: 512,
+          quality: 0.92,
+        },
+      })),
+      writeTempFile: jest.fn(async () => {
+        throw new Error('ipc unavailable')
+      }),
+    })
+
+    const prepared = await prepareProfilePhotoForUpload(file, deps)
+
+    expect(prepared).toBe(file)
+    expect(prepared.path).toBe('/home/me/Pictures/me.png')
+  })
+
+  it('falls back to the original file when compression itself throws', async () => {
+    const file = originalFile()
+    const deps = makeDeps({
+      compress: jest.fn(async () => {
+        throw new Error('boom')
+      }),
+    })
+
+    expect(await prepareProfilePhotoForUpload(file, deps)).toBe(file)
+  })
+})

--- a/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/prepareProfilePhoto.ts
+++ b/packages/desktop/src/renderer/components/ContextMenu/menus/profilePhoto/prepareProfilePhoto.ts
@@ -1,0 +1,100 @@
+/**
+ * Turns the file the user picked in the Edit profile view into the file the
+ * upload saga should send.
+ *
+ * `saveUserProfileSaga` uploads a profile photo from disk (it puts `photo.path`
+ * into an ATTACH_FILE payload), not from the File's bytes, so a compressed
+ * photo has to exist on disk before the action is dispatched. The renderer
+ * cannot write files itself, hence the trip through the main process.
+ */
+import { ipcRenderer, webUtils } from 'electron'
+
+import {
+  COMPRESSED_PROFILE_PHOTO_MIME,
+  compressProfilePhoto,
+  type ProfilePhotoCompressionResult,
+} from './compressProfilePhoto'
+
+/**
+ * Dedicated IPC channel for writing the compressed photo to a temp file.
+ *
+ * Deliberately NOT the existing `writeTempFile` channel: `Channel.tsx` keeps a
+ * permanent `ipcRenderer.on('writeTempFileReply', ...)` listener that adds every
+ * reply it sees to the message composer's pending attachments, so reusing that
+ * channel would make the profile photo show up as an unsent chat attachment.
+ * A request/response `invoke` channel has no such broadcast.
+ */
+export const WRITE_PROFILE_PHOTO_TEMP_FILE_CHANNEL = 'write-profile-photo-temp-file'
+
+export interface WriteProfilePhotoTempFileRequest {
+  fileName: string
+  ext: string
+  fileBuffer: Uint8Array
+}
+
+export interface WriteProfilePhotoTempFileResponse {
+  path: string
+  name: string
+  ext: string
+}
+
+export interface PrepareProfilePhotoDeps {
+  compress: (file: File) => Promise<ProfilePhotoCompressionResult | null>
+  writeTempFile: (request: WriteProfilePhotoTempFileRequest) => Promise<WriteProfilePhotoTempFileResponse>
+  getPathForFile: (file: File) => string
+}
+
+export const defaultPrepareProfilePhotoDeps: PrepareProfilePhotoDeps = {
+  compress: compressProfilePhoto,
+  writeTempFile: async request => await ipcRenderer.invoke(WRITE_PROFILE_PHOTO_TEMP_FILE_CHANNEL, request),
+  // Since Electron 32 `File.path` is gone and the on-disk path has to be asked
+  // for explicitly.
+  getPathForFile: file => webUtils.getPathForFile(file),
+}
+
+/** A File whose on-disk location the upload saga can read. */
+export type UploadableProfilePhoto = File & { path: string }
+
+const withPath = (file: File, path: string): UploadableProfilePhoto => {
+  // `path` is not a standard File property; the saga reads it off the payload.
+  // It has to be defined rather than assigned: Chromium below Electron 32 still
+  // declares `File.prototype.path` as a getter, and a plain assignment to it
+  // throws in strict mode.
+  Object.defineProperty(file, 'path', { value: path, writable: true, configurable: true, enumerable: true })
+  return file as UploadableProfilePhoto
+}
+
+/**
+ * Always returns something dispatchable.
+ *
+ * When the photo cannot be compressed - a non-image, a corrupt file, an IPC
+ * failure, or an image too big to rescue - the user's original file is returned
+ * unchanged, which is exactly what this code did before compression existed.
+ * The size guard in `saveUserProfileSaga` stays the backstop that turns an
+ * unrescuable oversized photo into the too-large banner.
+ */
+export const prepareProfilePhotoForUpload = async (
+  photo: File,
+  deps: PrepareProfilePhotoDeps = defaultPrepareProfilePhotoDeps
+): Promise<UploadableProfilePhoto> => {
+  const original = () => withPath(photo, deps.getPathForFile(photo))
+
+  let result: ProfilePhotoCompressionResult | null
+  try {
+    result = await deps.compress(photo)
+  } catch {
+    return original()
+  }
+
+  if (!result || !result.compressed) return original()
+
+  const { blob, name, ext } = result.photo
+  try {
+    const buffer = new Uint8Array(await blob.arrayBuffer())
+    const written = await deps.writeTempFile({ fileName: name, ext, fileBuffer: buffer })
+    const compressedFile = new File([blob], `${written.name}${written.ext}`, { type: COMPRESSED_PROFILE_PHOTO_MIME })
+    return withPath(compressedFile, written.path)
+  } catch {
+    return original()
+  }
+}

--- a/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.test.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.test.ts
@@ -25,6 +25,7 @@ import {
   SocketActions,
 } from '@quiet/types'
 import { type Socket } from '../../../types'
+import { MAX_PROFILE_PHOTO_SIZE_BYTES, PROFILE_PHOTO_TOO_LARGE_ERROR } from '@quiet/common'
 
 describe('saveUserProfileSaga', () => {
   let store: Store
@@ -50,6 +51,10 @@ describe('saveUserProfileSaga', () => {
 
   const makeFile = (name: string, path: string): File => {
     return Object.assign(new Blob([]), { name, path }) as any as File
+  }
+
+  const makeFileOfSize = (name: string, path: string, bytes: number): File => {
+    return Object.assign(new Blob([new Uint8Array(bytes)]), { name, path }) as any as File
   }
 
   const makeUploadStatusAction = (mid: string, downloadState: DownloadState) =>
@@ -310,6 +315,74 @@ describe('saveUserProfileSaga', () => {
           },
         ],
       })
+      .run()
+  })
+
+  test('rejects an oversized profile photo with an error and never starts the upload', async () => {
+    const photo = makeFileOfSize('huge.jpg', '/tmp/huge.jpg', MAX_PROFILE_PHOTO_SIZE_BYTES + 1)
+
+    await expectSaga(
+      saveUserProfileSaga,
+      socket as unknown as Socket,
+      // @ts-ignore
+      usersActions.saveUserProfile({ photo, nickname: userProfile.nickname, bio: userProfile.bio })
+    )
+      .withReducer(combineReducers(testReducers))
+      .withState(store.getState())
+      .put(usersActions.setSaveUserProfileError(PROFILE_PHOTO_TOO_LARGE_ERROR))
+      // The upload must never start: no message id, no ATTACH_FILE, no Attaching status.
+      .not.call.fn(generateMessageId)
+      .not.call.like({ context: socket, fn: socket.emit })
+      .not.put.like({ action: { type: filesActions.updateDownloadStatus.type } })
+      // And the profile must not be saved.
+      .not.call.like({ context: socket, fn: socket.emitWithAck })
+      .not.put.like({ action: { type: usersActions.setUserProfile.type } })
+      .run()
+  })
+
+  test('accepts a profile photo exactly at the size limit', async () => {
+    const fixedId = 'fixed-at-limit-id'
+    const profilePhotoMessageId = `profile-photo-${identity.userId}-${fixedId}`
+
+    const uploadedMetadata: FileMetadata = {
+      name: `profile-photo-${identity.userId}`,
+      ext: '.jpg',
+      path: '/tmp/at-limit.jpg',
+      cid: 'bafy-at-limit-cid',
+      message: {
+        id: profilePhotoMessageId,
+        channelId: PROFILE_PHOTO_CHANNEL_ID,
+      },
+    }
+
+    let takeCalls = 0
+    const provideTake = () => ({
+      take(effect: any, next: any) {
+        takeCalls += 1
+        if (takeCalls === 1) {
+          return makeUploadStatusAction(profilePhotoMessageId, DownloadState.Hosted)
+        }
+        return next()
+      },
+    })
+
+    const photo = makeFileOfSize('at-limit.jpg', '/tmp/at-limit.jpg', MAX_PROFILE_PHOTO_SIZE_BYTES)
+
+    await expectSaga(
+      saveUserProfileSaga,
+      socket as unknown as Socket,
+      // @ts-ignore
+      usersActions.saveUserProfile({ photo, nickname: userProfile.nickname, bio: userProfile.bio })
+    )
+      .withReducer(combineReducers(testReducers))
+      .withState(store.getState())
+      .provide([
+        [call.fn(generateMessageId), fixedId],
+        [select(filesSelectors.profilePhotos), { [profilePhotoMessageId]: uploadedMetadata }],
+        { take: provideTake().take },
+      ])
+      .call.like({ context: socket, fn: socket.emit })
+      .put.like({ action: { type: usersActions.setSaveUserProfileError.type, payload: null } })
       .run()
   })
 })

--- a/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.ts
+++ b/packages/state-manager/src/sagas/users/userProfile/saveUserProfile.saga.ts
@@ -11,6 +11,7 @@ import {
   DownloadStatus,
   PROFILE_PHOTO_CHANNEL_ID,
 } from '@quiet/types'
+import { MAX_PROFILE_PHOTO_SIZE_BYTES, PROFILE_PHOTO_TOO_LARGE_ERROR } from '@quiet/common'
 
 import { identitySelectors } from '../../identity/identity.selectors'
 import { type Socket, applyEmitParams } from '../../../types'
@@ -35,6 +36,17 @@ export function* saveUserProfileSaga(socket: Socket, action: PayloadAction<SaveU
   let profilePhotoMetadata: FileMetadata | undefined = undefined
 
   if (action.payload.photo) {
+    // Reject oversized photos before the upload starts. Nothing downstream
+    // bounds the size of an attachment-based profile photo, so without this the
+    // user gets no feedback at all and every peer ends up replicating the file.
+    if (action.payload.photo.size > MAX_PROFILE_PHOTO_SIZE_BYTES) {
+      logger.error(
+        `Profile photo is too large: ${action.payload.photo.size} bytes, max ${MAX_PROFILE_PHOTO_SIZE_BYTES} bytes`
+      )
+      yield* put(usersActions.setSaveUserProfileError(PROFILE_PHOTO_TOO_LARGE_ERROR))
+      return
+    }
+
     if (!profilePhotoMetadata) {
       logger.info('No profile photo metadata found, starting upload process')
       const file = action.payload.photo!


### PR DESCRIPTION
Fixes #2953

## What

Issue premise is stale (photos moved to IPFS attachments in efcb0d4f9, base64 socket-crash path is dead code) but the bug is real in a new form: an oversized photo is now silently ACCEPTED and replicated to every peer with no bound. Fix: size guard in the shared saveUserProfile saga (single choke point, already owns setSaveUserProfileError), limit hoisted to @quiet/common as MAX_PROFILE_PHOTO_SIZE_BYTES = 200KB (the project's own existing base64 budget; backend's two duplicate literals now point at it). MAINTAINER DECISION: 200KB confirmed, and photos are now COMPRESSED to it (2nd commit 4f52a6383) rather than refused — decode → canvas scaled to ≤512px long edge → JPEG quality ladder 0.92→0.5, one halving fallback; photos already under budget pass through byte-for-byte; the saga guard stays as backstop. Written to disk via a new invoke/handle IPC because the existing writeTempFile broadcast reply would have dropped the photo into the composer as a pending attachment. Also found: downloadProfilePhotosSaga ignores the autodownload size limit (flagged, not fixed).

## Evidence

Measured: 4000×3000 41MB PNG → 512×384 152KB @0.92; 2000×2000 13.7MB → 512×512 202KB; 600×600 54KB JPEG → untouched. Cypress in real Chromium 7/7 (compression spec 4 + banner spec 3, re-run by the lead), jest 48/50 (2 skipped) incl. injected-codec unit tests and the new IPC handler; desktop 97/98 suites with the same pre-existing failure; zero snapshots. Caught a real bug on the way: Electron <32 declares File.prototype.path as a getter, so the old plain assignment throws in strict mode — now Object.defineProperty. Caveat: over-budget PNG/GIF lose transparency/animation (flattened to JPEG); under-budget ones are untouched. Earlier finding stands: downloadProfilePhotosSaga ignores the autodownload limit.

### Screenshots

**after-banner-dark**

![2953-after-banner-dark.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-after-banner-dark.png)

**after-banner-light**

![2953-after-banner-light.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-after-banner-light.png)

**before-no-banner-light**

![2953-before-no-banner-light.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-before-no-banner-light.png)

**compress-after-accepted**

![2953-compress-after-accepted.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-compress-after-accepted.png)

**compress-before-banner**

![2953-compress-before-banner.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-compress-before-banner.png)

**compress-resizing**

![2953-compress-resizing.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2953/2953-compress-resizing.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 2 commits; rebase before merge.
- Touches `packages/common`: run `npm run build` there before running desktop/mobile suites.
- Touches `packages/state-manager`: run `npm run build` there before running desktop/mobile suites.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2953.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
