### PR TITLE
Show channel list previews on a single line

### DIFF
--- a/packages/mobile/src/components/ChannelList/ChannelList.test.tsx
+++ b/packages/mobile/src/components/ChannelList/ChannelList.test.tsx
@@ -617,8 +617,10 @@ describe('ChannelList component', () => {
                           >
                             <Text
                               color="gray50"
+                              ellipsizeMode="tail"
                               fontSize={14}
                               horizontalTextAlign="left"
+                              numberOfLines={1}
                               style={
                                 [
                                   {
@@ -986,8 +988,10 @@ describe('ChannelList component', () => {
                           >
                             <Text
                               color="gray50"
+                              ellipsizeMode="tail"
                               fontSize={14}
                               horizontalTextAlign="left"
+                              numberOfLines={1}
                               style={
                                 [
                                   {
@@ -1355,8 +1359,10 @@ describe('ChannelList component', () => {
                           >
                             <Text
                               color="gray50"
+                              ellipsizeMode="tail"
                               fontSize={14}
                               horizontalTextAlign="left"
+                              numberOfLines={1}
                               style={
                                 [
                                   {
@@ -1758,8 +1764,10 @@ describe('ChannelList component', () => {
                           >
                             <Text
                               color="gray50"
+                              ellipsizeMode="tail"
                               fontSize={14}
                               horizontalTextAlign="left"
+                              numberOfLines={1}
                               style={
                                 [
                                   {
@@ -2109,8 +2117,10 @@ describe('ChannelList component', () => {
                           >
                             <Text
                               color="gray50"
+                              ellipsizeMode="tail"
                               fontSize={14}
                               horizontalTextAlign="left"
+                              numberOfLines={1}
                               style={
                                 [
                                   {

--- a/packages/mobile/src/components/ChannelTile/ChannelTile.component.tsx
+++ b/packages/mobile/src/components/ChannelTile/ChannelTile.component.tsx
@@ -36,6 +36,12 @@ export const ChannelTile: FC<ChannelTileProps> = ({ name, id, message, date, unr
     )
   }
 
+  // The conversation list gives every tile a single line of preview text. Collapse each run
+  // of whitespace (newlines, carriage returns, tabs) to one space before truncating: a raw
+  // newline would otherwise render verbatim and stretch the tile, and truncateWords splits on
+  // spaces alone, so 'one\ntwo' counts as one word and slips past the eleven-word limit.
+  const preview = message ? truncateWords(message.replace(/\s+/g, ' ').trim(), 11, 100) : ''
+
   return (
     <GestureHandlerRootView>
       {/* <Swipeable friction={4} renderLeftActions={leftSwipe}> */}
@@ -91,11 +97,11 @@ export const ChannelTile: FC<ChannelTileProps> = ({ name, id, message, date, unr
               </View>
               <View style={{ flexDirection: 'row', paddingTop: 3 }}>
                 <View style={{ flex: 10 }}>
-                  {message && (
-                    <Typography fontSize={14} color={'gray50'}>
-                      {truncateWords(message, 11, 100)}
+                  {preview ? (
+                    <Typography fontSize={14} color={'gray50'} numberOfLines={1} ellipsizeMode={'tail'}>
+                      {preview}
                     </Typography>
-                  )}
+                  ) : null}
                 </View>
                 <View style={{ flex: 2, alignItems: 'flex-end' }}>
                   {unread && (

--- a/packages/mobile/src/components/ChannelTile/ChannelTile.stories.tsx
+++ b/packages/mobile/src/components/ChannelTile/ChannelTile.stories.tsx
@@ -53,3 +53,16 @@ storiesOf('ChannelTile', module)
       }}
     />
   ))
+  .add('Multi-line message', () => (
+    <ChannelTile
+      name={'general'}
+      id={'general'}
+      message={'line one\nline two\n\nline three, which carries on for long enough to need an ellipsis at the end'}
+      date={'1:55pm'}
+      unread={false}
+      isPublic={true}
+      redirect={(id: string) => {
+        logger.info(`Clicked ${id}`)
+      }}
+    />
+  ))

--- a/packages/mobile/src/components/ChannelTile/ChannelTile.test.tsx
+++ b/packages/mobile/src/components/ChannelTile/ChannelTile.test.tsx
@@ -3,6 +3,17 @@ import React from 'react'
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import { ChannelTile } from './ChannelTile.component'
 
+type RenderedNode = string | { children?: RenderedNode[] | null } | null
+
+// Collects every rendered string in the tree, so a preview can be asserted on as
+// text rather than by matching against the component's internal structure.
+const renderedStrings = (node: RenderedNode | RenderedNode[]): string[] => {
+  if (node === null || node === undefined) return []
+  if (typeof node === 'string') return [node]
+  if (Array.isArray(node)) return node.flatMap(renderedStrings)
+  return renderedStrings(node.children ?? [])
+}
+
 describe('ChannelList component', () => {
   it('should match inline snapshot', () => {
     const { toJSON } = renderComponent(
@@ -343,8 +354,10 @@ describe('ChannelList component', () => {
                   >
                     <Text
                       color="gray50"
+                      ellipsizeMode="tail"
                       fontSize={14}
                       horizontalTextAlign="left"
+                      numberOfLines={1}
                       style={
                         [
                           {
@@ -717,8 +730,10 @@ describe('ChannelList component', () => {
                   >
                     <Text
                       color="gray50"
+                      ellipsizeMode="tail"
                       fontSize={14}
                       horizontalTextAlign="left"
+                      numberOfLines={1}
                       style={
                         [
                           {
@@ -1107,8 +1122,10 @@ describe('ChannelList component', () => {
                   >
                     <Text
                       color="gray50"
+                      ellipsizeMode="tail"
                       fontSize={14}
                       horizontalTextAlign="left"
+                      numberOfLines={1}
                       style={
                         [
                           {
@@ -1140,5 +1157,45 @@ describe('ChannelList component', () => {
         </View>
       </View>
     `)
+  })
+  it('collapses a multi-line message into a single-line preview', () => {
+    const { getByText, toJSON } = renderComponent(
+      <ChannelTile
+        name={'general'}
+        id={'general'}
+        message={'line one\nline two\n\nline three'}
+        date={'1:55pm'}
+        unread={false}
+        isPublic={true}
+        redirect={jest.fn()}
+      />
+    )
+
+    const preview = renderedStrings(toJSON() as RenderedNode).find(text => text.includes('line one'))
+
+    expect(preview).toEqual('line one line two line three')
+    expect(preview).not.toMatch(/[\n\r\t]/)
+
+    // The tile reserves one line for the preview, so an unusually long single-line
+    // message is ellipsised rather than pushing the rest of the list around.
+    const previewNode = getByText('line one line two line three')
+    expect(previewNode.props.numberOfLines).toEqual(1)
+    expect(previewNode.props.ellipsizeMode).toEqual('tail')
+  })
+
+  it('keeps a preview of a whitespace-only message off the tile', () => {
+    const { toJSON } = renderComponent(
+      <ChannelTile
+        name={'general'}
+        id={'general'}
+        message={'\n\n   \t'}
+        date={'1:55pm'}
+        unread={false}
+        isPublic={true}
+        redirect={jest.fn()}
+      />
+    )
+
+    expect(renderedStrings(toJSON() as RenderedNode)).toEqual(['G', 'general', '1:55pm'])
   })
 })


### PR DESCRIPTION
Fixes #1266

## What

ChannelTile collapses all whitespace runs to one space and trims before truncateWords (which splits on spaces only, so a newline-joined message counted as one 'word' and slipped past both limits), and caps the preview at numberOfLines=1 with tail ellipsis. Shaped in the tile, not the shared channelsStatusSorted selector.

## Evidence

2 new tests red on unmodified code; 4 inline snapshots updated (pure insertion of the two new props). Full mobile suite re-run by the lead after the env fix: 53/53 suites, 149 tests, 44/44 snapshots.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1266.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
