### PR TITLE
fix(mobile): collapse runs of blank lines in rendered messages (#1618)

### DIFF
--- a/packages/mobile/src/components/Message/Message.blankLines.test.tsx
+++ b/packages/mobile/src/components/Message/Message.blankLines.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { MessageType } from '@quiet/types'
+import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
+import { Message } from './Message.component'
+import { normalizeMessageWhitespace, toMarkdownSource } from './Message.utils'
+
+// https://github.com/TryQuiet/quiet/issues/1618 - a message padded with blank lines used to render
+// one line break per blank line, so it could take over the whole channel view.
+
+describe('normalizeMessageWhitespace', () => {
+  const cases: Array<[name: string, input: string, expected: string]> = [
+    ['collapses a run of blank lines to a single gap', 'a\n\n\n\n\nb', 'a\n\nb'],
+    ['keeps a single blank line', 'a\n\nb', 'a\n\nb'],
+    ['keeps a single newline', 'a\nb', 'a\nb'],
+    ['drops trailing blank lines', 'a\n\n\n\n', 'a'],
+    ['drops leading blank lines', '\n\na', 'a'],
+    ['drops leading and trailing blank lines at once', '\n\n\na\n\n\n', 'a'],
+    ['treats whitespace-only lines as blank', 'a\n   \n\t\n \nb', 'a\n\nb'],
+    ['leaves a message with no blank lines alone', 'a\nb\nc', 'a\nb\nc'],
+    ['empties a message that is nothing but blank lines', '\n\n\n   \n', ''],
+    ['normalizes Windows line endings', 'a\r\n\r\n\r\n\r\nb\r\n\r\n', 'a\n\nb'],
+    [
+      'preserves blank lines inside a fenced code block',
+      'a\n\n```\nx\n\n\n\ny\n```\n\n\nb',
+      'a\n\n```\nx\n\n\n\ny\n```\n\nb',
+    ],
+    ['preserves blank lines inside a tilde fence', '~~~\n\n\n~~~', '~~~\n\n\n~~~'],
+    ['preserves blank lines inside an unterminated fence', 'a\n\n```js\n\n\n', 'a\n\n```js\n\n\n'],
+    ['does not treat a longer inner run as a closing fence', '````\n\n\n```\n\n\n````', '````\n\n\n```\n\n\n````'],
+  ]
+
+  it.each(cases)('%s', (_name, input, expected) => {
+    expect(normalizeMessageWhitespace(input)).toEqual(expected)
+  })
+})
+
+describe('toMarkdownSource', () => {
+  it('keeps one blank line visible as a single <br>', () => {
+    expect(toMarkdownSource('a\n\n\n\n\nb')).toEqual('a\n<br>\nb')
+  })
+
+  it('emits no <br> for a message padded with blank lines', () => {
+    expect(toMarkdownSource('\n\n\nhello\n\n\n\n')).toEqual('hello')
+  })
+
+  it('never writes a <br> inside a fenced code block', () => {
+    expect(toMarkdownSource('a\n\n```\nx\n\ny\n```')).toEqual('a\n<br>\n```\nx\n\ny\n```')
+  })
+})
+
+// `@ronradtke/react-native-markdown-display` is mocked in setupTests.tsx to render
+// `<div>{props.children}</div>`, so the markdown source handed to it is readable straight off the
+// rendered tree.
+const markdownSourceOf = (node: any): string | null => {
+  if (!node || typeof node !== 'object') return null
+  if (node.type === 'div' && typeof node.children?.[0] === 'string') return node.children[0]
+  for (const child of node.children ?? []) {
+    const found = markdownSourceOf(child)
+    if (found !== null) return found
+  }
+  return null
+}
+
+const renderMessage = (message: string): string => {
+  const { toJSON } = renderComponent(
+    <Message
+      duplicatedUsernameHandleBack={() => {}}
+      unregisteredUsernameHandleBack={(_username: string) => {}}
+      data={[
+        {
+          id: 'id',
+          type: MessageType.Basic,
+          message,
+          createdAt: 0,
+          date: '1:30pm',
+          nickname: 'holmes',
+          isDuplicated: false,
+          isRegistered: true,
+          userId: 'test',
+        },
+      ]}
+      pendingMessages={{}}
+      openUrl={() => {}}
+      openImagePreview={() => {}}
+      downloadFile={() => {}}
+      cancelDownload={() => {}}
+    />
+  )
+  const source = markdownSourceOf(toJSON())
+  expect(source).not.toBeNull()
+  return source as string
+}
+
+describe('Message blank line rendering', () => {
+  it('renders no blank line for a message with ten trailing blank lines', () => {
+    const source = renderMessage('hello' + '\n'.repeat(10))
+    expect(source.match(/<br>/g) ?? []).toHaveLength(0)
+    expect(source).toEqual('hello')
+  })
+
+  it('renders no blank line for a message with ten leading blank lines', () => {
+    const source = renderMessage('\n'.repeat(10) + 'hello')
+    expect(source.match(/<br>/g) ?? []).toHaveLength(0)
+  })
+
+  it('collapses a run of blank lines in the middle of a message to a single gap', () => {
+    const source = renderMessage('a' + '\n'.repeat(6) + 'b')
+    expect(source.match(/<br>/g) ?? []).toHaveLength(1)
+  })
+
+  it('still shows a single blank line between two paragraphs', () => {
+    expect(renderMessage('a\n\nb')).toEqual('a\n<br>\nb')
+  })
+})

--- a/packages/mobile/src/components/Message/Message.component.tsx
+++ b/packages/mobile/src/components/Message/Message.component.tsx
@@ -15,6 +15,7 @@ import UserLabel from '../UserLabel/UserLabel.component'
 import { UserLabelType } from '../UserLabel/UserLabel.types'
 import { DateTime } from 'luxon'
 import { DEFAULT_AUTODOWNLOAD_SIZE_LIMIT } from '@quiet/state-manager'
+import { toMarkdownSource } from './Message.utils'
 
 const MessageProfilePhoto: React.FC<{ message: DisplayableMessage }> = ({ message }) => {
   const imgStyle = {
@@ -47,16 +48,6 @@ const MessageInner: FC<MessageProps & FileActionsProps> = ({
   duplicatedUsernameHandleBack,
   unregisteredUsernameHandleBack,
 }) => {
-  const pushBr = (str: string) => {
-    const afterSplit = str
-      .split('\n')
-      .map(e => {
-        if (e === '') return '<br>'
-        return e
-      })
-      .join('\n')
-    return afterSplit
-  }
   const renderMessage = (message: DisplayableMessage, pending: boolean) => {
     switch (message.type) {
       case 2: {
@@ -137,7 +128,7 @@ const MessageInner: FC<MessageProps & FileActionsProps> = ({
         }
         return (
           <Markdown markdownit={md} style={markdownStyle} rules={markdownRules}>
-            {pushBr(message.message)}
+            {toMarkdownSource(message.message)}
           </Markdown>
         )
       }

--- a/packages/mobile/src/components/Message/Message.stories.tsx
+++ b/packages/mobile/src/components/Message/Message.stories.tsx
@@ -143,3 +143,31 @@ storiesOf('TestMessage', module)
       />
     )
   })
+  .add('ManyBlankLines', () => {
+    // https://github.com/TryQuiet/quiet/issues/1618 - leading, middle and trailing blank lines
+    // should all collapse to at most a single gap, matching desktop.
+    return (
+      <Message
+        duplicatedUsernameHandleBack={function (): void {}}
+        unregisteredUsernameHandleBack={function (username: string): void {}}
+        data={[
+          {
+            id: '7',
+            type: MessageType.Basic,
+            message: '\n\n\n\nFour blank lines above me.\n\n\n\n\n\nSix blank lines above me.\n\n\n\n\n\n\n\n\n\n',
+            createdAt: 0,
+            date: '1:30pm',
+            nickname: 'holmes',
+            userId: 'test',
+            isDuplicated: false,
+            isRegistered: true,
+          },
+        ]}
+        maxAutodownloadSizeBytes={DEFAULT_AUTODOWNLOAD_SIZE_LIMIT}
+        openUrl={() => {}}
+        openImagePreview={() => {}}
+        downloadFile={() => {}}
+        cancelDownload={() => {}}
+      />
+    )
+  })

--- a/packages/mobile/src/components/Message/Message.utils.ts
+++ b/packages/mobile/src/components/Message/Message.utils.ts
@@ -1,0 +1,113 @@
+/**
+ * Helpers that turn a raw message body into the markdown source handed to
+ * `@ronradtke/react-native-markdown-display`.
+ *
+ * See https://github.com/TryQuiet/quiet/issues/1618
+ */
+
+/**
+ * An opening or closing fence of a fenced code block. markdown-it allows up to three leading
+ * spaces and a marker of three or more backticks or tildes, followed by an info string that only
+ * an opening fence may carry.
+ */
+const FENCE_LINE = /^ {0,3}(`{3,}|~{3,})(.*)$/
+
+const isBlank = (line: string): boolean => line.trim().length === 0
+
+interface MessageSegment {
+  /** True for the lines of a fenced code block, fence delimiters included. */
+  fenced: boolean
+  lines: string[]
+}
+
+/**
+ * Splits `lines` into alternating prose and fenced-code segments. Fenced segments are carried
+ * through every transformation untouched, so a code block keeps the exact blank lines its author
+ * typed. An unterminated fence swallows the rest of the message, which is how markdown-it reads it
+ * too.
+ */
+const splitFencedCode = (lines: string[]): MessageSegment[] => {
+  const segments: MessageSegment[] = []
+  let current: MessageSegment = { fenced: false, lines: [] }
+  let openingMarker: string | null = null
+
+  for (const line of lines) {
+    const fence = FENCE_LINE.exec(line)
+
+    if (openingMarker === null) {
+      if (fence) {
+        segments.push(current)
+        openingMarker = fence[1]
+        current = { fenced: true, lines: [line] }
+      } else {
+        current.lines.push(line)
+      }
+      continue
+    }
+
+    current.lines.push(line)
+    // A closing fence repeats the opening marker at least as many times and carries no info string.
+    const closesFence =
+      fence != null && fence[1][0] === openingMarker[0] && fence[1].length >= openingMarker.length && isBlank(fence[2])
+    if (closesFence) {
+      segments.push(current)
+      openingMarker = null
+      current = { fenced: false, lines: [] }
+    }
+  }
+
+  segments.push(current)
+  return segments.filter(segment => segment.lines.length > 0)
+}
+
+type Block = { kind: 'blank' } | { kind: 'text'; line: string } | { kind: 'fenced'; lines: string[] }
+
+/**
+ * Drops the blank lines that lead or trail a message and collapses every longer run of them into a
+ * single blank line, so a message padded with whitespace takes up no more room than the desktop
+ * renderer gives it. Whitespace-only lines count as blank, otherwise a client could pad a message
+ * with lines of spaces and get the same wall of empty space. Content inside a fenced code block is
+ * never touched.
+ */
+export const normalizeMessageWhitespace = (message: string): string => {
+  const blocks: Block[] = []
+  for (const segment of splitFencedCode(message.replace(/\r\n?/g, '\n').split('\n'))) {
+    if (segment.fenced) {
+      blocks.push({ kind: 'fenced', lines: segment.lines })
+    } else {
+      for (const line of segment.lines) {
+        blocks.push(isBlank(line) ? { kind: 'blank' } : { kind: 'text', line })
+      }
+    }
+  }
+
+  const kept: Block[] = []
+  for (const block of blocks) {
+    const previous = kept[kept.length - 1]
+    if (block.kind === 'blank' && (previous === undefined || previous.kind === 'blank')) continue
+    kept.push(block)
+  }
+  while (kept.length > 0 && kept[kept.length - 1].kind === 'blank') kept.pop()
+
+  return kept
+    .flatMap(block => {
+      if (block.kind === 'fenced') return block.lines
+      return block.kind === 'blank' ? [''] : [block.line]
+    })
+    .join('\n')
+}
+
+/**
+ * markdown-it turns any run of blank lines into a single paragraph break, and the mobile paragraph
+ * rule renders paragraphs with no margin, so a blank line the author typed would otherwise vanish.
+ * Replacing it with a literal `<br>` keeps the text around it inside one paragraph, where the soft
+ * breaks on either side of the `<br>` render as the blank line. Lines inside a fenced code block
+ * are left alone, because there the `<br>` would be shown verbatim as code.
+ */
+const pushBr = (message: string): string =>
+  splitFencedCode(message.split('\n'))
+    .flatMap(segment => (segment.fenced ? segment.lines : segment.lines.map(line => (line === '' ? '<br>' : line))))
+    .join('\n')
+
+/** The markdown source for a message body: blank lines normalised, then kept visible as `<br>`. */
+export const toMarkdownSource = (message: string): string => pushBr(normalizeMessageWhitespace(message))


### PR DESCRIPTION
Fixes #1618

## What

New pure Message.utils.ts normalises the body before pushBr: drops leading/trailing blank lines, collapses longer runs to one, treats whitespace-only lines as blank, and skips fenced code blocks. pushBr's intent (keep one typed blank line visible, PR #2980) preserved. Second defect found and fixed: pushBr wrote a literal '<br>' inside fenced code blocks. Mobile stays one blank line more generous than desktop — deliberate, pre-existing, flagged.

## Evidence

21 new assertions incl. a 14-case normalisation table; the 3 render assertions failed on unmodified code with 10/10/5 <br> tokens. ManyBlankLines story added for on-device review. Full mobile suite re-run by the lead: 54/54 suites, 168 tests.

### Screenshots

**blank-lines-current**

![1618-blank-lines-current.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1618/1618-blank-lines-current.png)

**code-fence-preserved**

![1618-code-fence-preserved.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1618/1618-code-fence-preserved.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1618-mobile.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
