### PR TITLE
fix(common): decode percent-encoded file names for attachment previews

### DIFF
--- a/packages/common/src/fileData.test.ts
+++ b/packages/common/src/fileData.test.ts
@@ -1,4 +1,4 @@
-import { getFilesData } from './fileData'
+import { decodeFileName, getFilesData } from './fileData'
 
 describe('fileData ', () => {
   it('should return proper FilePreviewData', () => {
@@ -17,5 +17,63 @@ describe('fileData ', () => {
         ext: '.pdf',
       },
     ])
+  })
+
+  // https://github.com/TryQuiet/quiet/issues/1701
+  it('should percent-decode names derived from mobile picker URIs', () => {
+    const uri = 'file:///data/user/0/com.quiet.mobile/cache/My%20File.pdf'
+    const result = getFilesData([{ path: uri, isTmp: true }])
+    expect(Object.values(result)).toEqual([
+      {
+        // the raw URI is kept - sendFileMessageSaga decodes it before reading from disk
+        path: uri,
+        tmpPath: uri,
+        name: 'My File',
+        ext: '.pdf',
+      },
+    ])
+  })
+
+  it('should decode an encoded percent sign in a picker URI', () => {
+    const result = getFilesData([{ path: 'file:///cache/100%25%20off.txt' }])
+    expect(Object.values(result)[0]).toMatchObject({ name: '100% off', ext: '.txt' })
+  })
+
+  it('should leave a malformed percent sequence untouched', () => {
+    const result = getFilesData([{ path: 'file:///cache/%E0%A4%A.txt' }])
+    expect(Object.values(result)[0]).toMatchObject({ name: '%E0%A4%A', ext: '.txt' })
+  })
+
+  // Desktop hands us plain OS paths, never percent-encoded - they must survive untouched.
+  it('should not alter a desktop path whose name contains spaces', () => {
+    const filePath = '/home/user/Documents/My File.pdf'
+    const result = getFilesData([{ path: filePath }])
+    expect(Object.values(result)).toEqual([
+      {
+        path: filePath,
+        tmpPath: undefined,
+        name: 'My File',
+        ext: '.pdf',
+      },
+    ])
+  })
+
+  it('should not alter a desktop path whose name contains a literal percent sign', () => {
+    const result = getFilesData([{ path: '/home/user/Documents/100%.txt' }])
+    expect(Object.values(result)[0]).toMatchObject({ name: '100%', ext: '.txt' })
+  })
+})
+
+describe('decodeFileName', () => {
+  it.each([
+    ['My%20File.pdf', 'My File.pdf'],
+    ['100%25.txt', '100%.txt'],
+    ['%E0%A4%A', '%E0%A4%A'],
+    ['plain name.txt', 'plain name.txt'],
+    ['report.pdf', 'report.pdf'],
+    ['100%.txt', '100%.txt'],
+    ['', ''],
+  ])('decodes %p to %p', (input, expected) => {
+    expect(decodeFileName(input)).toEqual(expected)
   })
 })

--- a/packages/common/src/fileData.ts
+++ b/packages/common/src/fileData.ts
@@ -1,12 +1,35 @@
 import path from 'path'
 import { FileContent, FilePreviewData } from '@quiet/types'
 
+/**
+ * Percent-decode a file name, leaving it untouched if it is not valid encoding.
+ *
+ * Mobile file pickers hand us URIs (`file:///.../My%20File.pdf`), so a name taken
+ * straight from the path reaches the UI - and peers - as `My%20File` (#1701).
+ * `sendFileMessageSaga` already percent-decodes `path` before the file is read
+ * from disk, so decoding here keeps the displayed name in step with the file that
+ * is actually attached. Desktop supplies plain OS paths, which contain no `%` and
+ * so pass through unchanged. A name that genuinely contains `%` (`100%.txt`)
+ * arrives undecoded and would make `decodeURIComponent` throw, hence the fallback.
+ */
+export const decodeFileName = (name: string): string => {
+  try {
+    return decodeURIComponent(name)
+  } catch {
+    return name
+  }
+}
+
 export const getFileData = (filePath: string, isTmpPath = false): FilePreviewData => {
+  // basename() runs again below on the decoded name: decoding can reveal a path
+  // separator (`%2F`), and `name` must stay a bare file name - it is interpolated
+  // into a path when the backend copies the attachment into its uploads directory.
+  const fileName = decodeFileName(path.basename(filePath))
   const fileContent: FileContent = {
     path: filePath,
     tmpPath: isTmpPath ? filePath : undefined,
-    name: path.basename(filePath, path.extname(filePath)),
-    ext: path.extname(filePath).toLowerCase(),
+    name: path.basename(fileName, path.extname(fileName)),
+    ext: path.extname(fileName).toLowerCase(),
   }
   const id = `${Date.now()}_${Math.random().toString(36).substring(0, 20)}`
   return { [id]: fileContent }

--- a/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.test.tsx
+++ b/packages/mobile/src/components/FileAttachmentPreview/FileAttachmentPreview.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import FileAttachmentPreview from './FileAttachmentPreview.component'
 import { FilePreviewData } from '@quiet/types'
+import { getFilesData } from '@quiet/common'
 import { createLogger } from '../../utils/logger'
 
 const logger = createLogger('attachingPreview:test')
@@ -293,5 +294,25 @@ describe('FileAttachmentPreview component', () => {
         </View>
       </RCTScrollView>
     `)
+  })
+
+  // https://github.com/TryQuiet/quiet/issues/1701
+  it('shows spaces rather than %20 for a file picked through a document picker URI', () => {
+    // what react-native-document-picker hands back in `fileCopyUri` for "My File.pdf"
+    const pickedFiles = getFilesData([
+      { path: 'file:///data/user/0/com.quiet.mobile/cache/My%20File.pdf', isTmp: true },
+    ])
+
+    const { getByText, queryByText } = renderComponent(
+      <FileAttachmentPreview
+        filesData={pickedFiles}
+        removeFile={function (id: string): void {
+          logger.info(`removeFile ${id}`)
+        }}
+      />
+    )
+
+    expect(getByText('My File')).toBeTruthy()
+    expect(queryByText('My%20File')).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes #1701

## What

Decoded at the single shared derivation point (packages/common fileData): percent-decode the picked file's basename with a try/catch fallback for names that are not valid encoding, then basename() again so a decoded %2F can never smuggle a path separator into a name the backend interpolates into a path. The send saga already decodes the path, so the displayed name now matches the file actually attached. Not decoded at render time (old messages keep %20; avoids double-decoding).

## Evidence

common 13/13 (incl. 100%25.txt→100%.txt, malformed unchanged, desktop path with spaces unchanged, literal % unchanged) and mobile render test that reproduces the screenshot with My%20File; zero snapshots updated. Lead re-ran both. Known edge: a desktop file whose real name contains a valid escape like a%20b.txt would display as 'a b.txt' — accepted. packages/common must be rebuilt after checkout.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Touches `packages/common`: run `npm run build` there before running desktop/mobile suites.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1701.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
