### PR TITLE
Copy a message to the clipboard on long press (mobile)

### DIFF
--- a/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -901,9 +901,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        deathhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhstarrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrdeathstartttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-17"
+                      >
+                        <div>
+                          deathhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhstarrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrdeathstartttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1128,9 +1161,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        We cannot grant you the rank of messager
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-16"
+                      >
+                        <div>
+                          We cannot grant you the rank of messager
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1355,9 +1421,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        The more messages the better
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-15"
+                      >
+                        <div>
+                          The more messages the better
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1568,9 +1667,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Yeah!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-14"
+                      >
+                        <div>
+                          Yeah!
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -1781,9 +1913,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Wrough!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-13"
+                      >
+                        <div>
+                          Wrough!
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2008,9 +2173,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        I Agree
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-11"
+                      >
+                        <div>
+                          I Agree
+                        </div>
+                      </View>
                     </View>
                     <View
                       style={
@@ -2019,9 +2217,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Of course, I Agree
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-12"
+                      >
+                        <div>
+                          Of course, I Agree
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2232,9 +2463,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Messages more there should be
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-9"
+                      >
+                        <div>
+                          Messages more there should be
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2445,9 +2709,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Why?
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-8"
+                      >
+                        <div>
+                          Why?
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2658,9 +2955,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Uhuhu!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-7"
+                      >
+                        <div>
+                          Uhuhu!
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>
@@ -2885,9 +3215,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Luck, I am your father!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-4"
+                      >
+                        <div>
+                          Luck, I am your father!
+                        </div>
+                      </View>
                     </View>
                     <View
                       style={
@@ -2896,9 +3259,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        That's impossible!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-5"
+                      >
+                        <div>
+                          That's impossible!
+                        </div>
+                      </View>
                     </View>
                     <View
                       style={
@@ -2907,9 +3303,42 @@ exports[`Chat component renders component 1`] = `
                         }
                       }
                     >
-                      <div>
-                        Nooo!
-                      </div>
+                      <View
+                        accessibilityState={
+                          {
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
+                          }
+                        }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={true}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="message-copy-6"
+                      >
+                        <div>
+                          Nooo!
+                        </div>
+                      </View>
                     </View>
                   </View>
                 </View>

--- a/packages/mobile/src/components/Message/Message.component.tsx
+++ b/packages/mobile/src/components/Message/Message.component.tsx
@@ -1,5 +1,6 @@
-import React, { type FC, type ReactNode } from 'react'
-import { View, Text, Image, StyleSheet } from 'react-native'
+import React, { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { View, Text, Image, StyleSheet, Pressable } from 'react-native'
+import Clipboard from '@react-native-clipboard/clipboard'
 import { Typography } from '../Typography/Typography.component'
 import type { MessageProps } from './Message.types'
 import { Jdenticon } from '../Jdenticon/Jdenticon.component'
@@ -15,6 +16,14 @@ import UserLabel from '../UserLabel/UserLabel.component'
 import { UserLabelType } from '../UserLabel/UserLabel.types'
 import { DateTime } from 'luxon'
 import { DEFAULT_AUTODOWNLOAD_SIZE_LIMIT } from '@quiet/state-manager'
+
+// How long the "Copied" confirmation stays on screen after a long press.
+const COPIED_INDICATOR_DURATION = 1500
+
+// Only user-written text messages can be copied. Image and file messages hold a filename rather
+// than author-written text and keep their existing tap-to-preview behaviour, and Info messages are
+// written by the app itself.
+const isCopyable = (message: DisplayableMessage): boolean => message.type === MessageType.Basic
 
 const MessageProfilePhoto: React.FC<{ message: DisplayableMessage }> = ({ message }) => {
   const imgStyle = {
@@ -47,6 +56,24 @@ const MessageInner: FC<MessageProps & FileActionsProps> = ({
   duplicatedUsernameHandleBack,
   unregisteredUsernameHandleBack,
 }) => {
+  const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null)
+  const copiedResetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (copiedResetTimeout.current) clearTimeout(copiedResetTimeout.current)
+    },
+    []
+  )
+
+  // Copies the message exactly as its author wrote it (markdown source), not the rendered text.
+  const copyMessage = useCallback((message: DisplayableMessage) => {
+    Clipboard.setString(message.message)
+    if (copiedResetTimeout.current) clearTimeout(copiedResetTimeout.current)
+    setCopiedMessageId(message.id)
+    copiedResetTimeout.current = setTimeout(() => setCopiedMessageId(null), COPIED_INDICATOR_DURATION)
+  }, [])
+
   const pushBr = (str: string) => {
     const afterSplit = str
       .split('\n')
@@ -106,7 +133,14 @@ const MessageInner: FC<MessageProps & FileActionsProps> = ({
             </Text>
           ),
           link: (node: ASTNode, children: ReactNode[], parent: ASTNode[], styles: any) => (
-            <Text key={node.key} style={styles.link} onPress={() => openUrl(node.attributes.href)}>
+            // A link claims the touch responder, so without its own onLongPress a long press
+            // starting on a link would open the url instead of copying the message.
+            <Text
+              key={node.key}
+              style={styles.link}
+              onPress={() => openUrl(node.attributes.href)}
+              onLongPress={isCopyable(message) ? () => copyMessage(message) : undefined}
+            >
               {children}
             </Text>
           ),
@@ -228,9 +262,29 @@ const MessageInner: FC<MessageProps & FileActionsProps> = ({
           <View style={{ flexShrink: 1 }}>
             {data.map((message: DisplayableMessage, index: number) => {
               const outerDivStyle = index > 0 ? classes.nextMessage : classes.firstMessage
+              const rendered = renderMessage(message, pending)
               return (
                 <View style={outerDivStyle} key={index}>
-                  {renderMessage(message, pending)}
+                  {isCopyable(message) ? (
+                    // No pressed-state styling on purpose: a press-in highlight flickers when a
+                    // scroll gesture starts on a message. The "Copied" badge is the feedback.
+                    <Pressable onLongPress={() => copyMessage(message)} testID={`message-copy-${message.id}`}>
+                      {rendered}
+                      {copiedMessageId === message.id && (
+                        <View
+                          style={classes.copiedIndicator}
+                          pointerEvents='none'
+                          testID={`message-copied-${message.id}`}
+                        >
+                          <Typography fontSize={12} color={'white'}>
+                            Copied
+                          </Typography>
+                        </View>
+                      )}
+                    </Pressable>
+                  ) : (
+                    rendered
+                  )}
                 </View>
               )
             })}
@@ -247,6 +301,17 @@ const classes = StyleSheet.create({
   },
   nextMessage: {
     paddingTop: 4,
+  },
+  // Absolutely positioned so showing it never changes the message height, which would make the
+  // inverted message list jump.
+  copiedIndicator: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+    backgroundColor: defaultTheme.palette.background.gray70,
   },
 })
 

--- a/packages/mobile/src/components/Message/Message.stories.tsx
+++ b/packages/mobile/src/components/Message/Message.stories.tsx
@@ -91,6 +91,34 @@ storiesOf('TestMessage', module)
       />
     )
   })
+  // Long-press anywhere on this message (including on the link) to copy its markdown source.
+  // The existing 'Link' story is a MessageType.Info message, which is deliberately not copyable.
+  .add('CopyOnLongPress', () => {
+    return (
+      <Message
+        duplicatedUsernameHandleBack={function (): void {}}
+        unregisteredUsernameHandleBack={function (username: string): void {}}
+        data={[
+          {
+            id: '7',
+            type: MessageType.Basic,
+            message: 'Long press to copy this **markdown** message, link included: https://tryquiet.org',
+            createdAt: 0,
+            date: '1:30pm',
+            nickname: 'holmes',
+            userId: 'test',
+            isDuplicated: false,
+            isRegistered: true,
+          },
+        ]}
+        maxAutodownloadSizeBytes={DEFAULT_AUTODOWNLOAD_SIZE_LIMIT}
+        openUrl={url => logger.info(`opened url ${url}`)}
+        openImagePreview={() => {}}
+        downloadFile={() => {}}
+        cancelDownload={() => {}}
+      />
+    )
+  })
   .add('ValidInlineLatexExpression', () => {
     return (
       <Message

--- a/packages/mobile/src/components/Message/Message.test.tsx
+++ b/packages/mobile/src/components/Message/Message.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { act, fireEvent, screen } from '@testing-library/react-native'
+import Clipboard from '@react-native-clipboard/clipboard'
+import { DisplayableMessage, MessageType } from '@quiet/types'
+import { DEFAULT_AUTODOWNLOAD_SIZE_LIMIT } from '@quiet/state-manager'
+
+import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
+import { Message } from './Message.component'
+
+const LINK_HREF = 'https://tryquiet.org'
+
+// src/setupTests.tsx replaces the markdown renderer with `<div>{children}</div>`, which never
+// calls the `rules` the component passes it. That would leave the `link` rule - the one place
+// where a long press has to beat an existing onPress - completely uncovered. This stand-in
+// keeps the setupTests behaviour and additionally renders what the component's own `link` rule
+// returns, so the real rule is exercised.
+jest.mock('@ronradtke/react-native-markdown-display', () => {
+  const react = require('react')
+  const href = 'https://tryquiet.org'
+  return {
+    __esModule: true,
+    default: ({ children, rules }: any) =>
+      react.createElement(
+        'div',
+        null,
+        children,
+        // Stands in for linkify: when the markdown source contains the url, render whatever the
+        // component's own `link` rule returns for it.
+        typeof children === 'string' && children.includes(href)
+          ? rules.link({ key: 'link', attributes: { href } }, [href], [], { link: {} })
+          : null
+      ),
+    MarkdownIt: jest.fn(),
+    hasParents: jest.fn(),
+  }
+})
+
+// Clipboard itself is mocked globally in src/setupTests.tsx, next to the other native modules.
+const setString = Clipboard.setString as jest.Mock
+
+const basicMessage: DisplayableMessage = {
+  id: 'message-id',
+  type: MessageType.Basic,
+  // Deliberately markdown: we copy the source the author typed, not the rendered text.
+  message: `Hello **world**, see ${LINK_HREF}`,
+  createdAt: 1698483600,
+  date: '28 Oct, 10:00',
+  nickname: 'alice',
+  userId: 'aliceUserId',
+  isDuplicated: false,
+  isRegistered: true,
+}
+
+const imageMessage: DisplayableMessage = {
+  ...basicMessage,
+  id: 'image-message-id',
+  type: MessageType.Image,
+  message: 'image.png',
+  media: {
+    cid: 'cid',
+    path: '/mnt/storage/image.png',
+    name: 'image',
+    ext: '.png',
+    message: { id: 'image-message-id', channelId: 'channel-id' },
+    width: 100,
+    height: 100,
+    size: 1024,
+  },
+}
+
+const renderMessage = (data: DisplayableMessage[], openUrl: jest.Mock = jest.fn()) => {
+  renderComponent(
+    <Message
+      data={data}
+      maxAutodownloadSizeBytes={DEFAULT_AUTODOWNLOAD_SIZE_LIMIT}
+      openUrl={openUrl}
+      openImagePreview={jest.fn()}
+      downloadFile={jest.fn()}
+      cancelDownload={jest.fn()}
+      duplicatedUsernameHandleBack={jest.fn()}
+      unregisteredUsernameHandleBack={jest.fn()}
+    />
+  )
+  return { openUrl }
+}
+
+describe('Message component - copy on long press', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    setString.mockClear()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('copies the raw message text to the clipboard on long press', () => {
+    renderMessage([basicMessage])
+
+    fireEvent(screen.getByTestId(`message-copy-${basicMessage.id}`), 'longPress')
+
+    expect(setString).toHaveBeenCalledTimes(1)
+    expect(setString).toHaveBeenCalledWith(`Hello **world**, see ${LINK_HREF}`)
+  })
+
+  it('shows a "Copied" indicator that disappears on its own', () => {
+    renderMessage([basicMessage])
+
+    expect(screen.queryByTestId(`message-copied-${basicMessage.id}`)).toBeNull()
+
+    fireEvent(screen.getByTestId(`message-copy-${basicMessage.id}`), 'longPress')
+    expect(screen.getByTestId(`message-copied-${basicMessage.id}`)).toBeTruthy()
+
+    act(() => {
+      jest.advanceTimersByTime(1500)
+    })
+    expect(screen.queryByTestId(`message-copied-${basicMessage.id}`)).toBeNull()
+  })
+
+  it('does not copy on a normal press', () => {
+    renderMessage([basicMessage])
+
+    fireEvent.press(screen.getByTestId(`message-copy-${basicMessage.id}`))
+
+    expect(setString).not.toHaveBeenCalled()
+    expect(screen.queryByTestId(`message-copied-${basicMessage.id}`)).toBeNull()
+  })
+
+  it('copies only the long-pressed message out of a grouped set', () => {
+    const second: DisplayableMessage = { ...basicMessage, id: 'second-id', message: 'second message' }
+    renderMessage([basicMessage, second])
+
+    fireEvent(screen.getByTestId(`message-copy-${second.id}`), 'longPress')
+
+    expect(setString).toHaveBeenCalledTimes(1)
+    expect(setString).toHaveBeenCalledWith('second message')
+    expect(screen.getByTestId(`message-copied-${second.id}`)).toBeTruthy()
+    expect(screen.queryByTestId(`message-copied-${basicMessage.id}`)).toBeNull()
+  })
+
+  it('still opens a link when the link is tapped', () => {
+    const { openUrl } = renderMessage([basicMessage])
+
+    fireEvent.press(screen.getByText(LINK_HREF))
+
+    expect(openUrl).toHaveBeenCalledWith(LINK_HREF)
+    expect(setString).not.toHaveBeenCalled()
+  })
+
+  it('copies instead of opening a link when the long press starts on the link', () => {
+    const { openUrl } = renderMessage([basicMessage])
+
+    fireEvent(screen.getByText(LINK_HREF), 'longPress')
+
+    expect(setString).toHaveBeenCalledWith(`Hello **world**, see ${LINK_HREF}`)
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('does not make image messages copyable', () => {
+    renderMessage([imageMessage])
+
+    expect(screen.queryByTestId(`message-copy-${imageMessage.id}`)).toBeNull()
+  })
+})

--- a/packages/mobile/src/setupTests.tsx
+++ b/packages/mobile/src/setupTests.tsx
@@ -198,6 +198,18 @@ jest.mock('react-native-zip-archive', () => ({
 
 jest.mock('react-native-share', () => ({ default: { open: jest.fn() } }))
 
+// Mocked because of:
+//
+// "Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'RNCClipboard' could not be found.
+// Verify that a module by this name is registered in the native binary."
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  __esModule: true,
+  default: {
+    setString: jest.fn(),
+    getString: jest.fn(),
+  },
+}))
+
 export const ioMock = io as jest.Mock
 
 jest.resetAllMocks()


### PR DESCRIPTION
Fixes #1086

## What

Long-press on a text message copies its markdown source to the clipboard and flashes an absolutely-positioned 'Copied' badge on that row for 1.5 s (no layout shift in the inverted list). Deliberately no pressed-state styling so a scroll starting on a message never flickers. Links get their own onLongPress because a link Text claims the responder. Text messages only; image/file/Info untouched. Rejected: routing through the app-wide ConfirmationBox toast (needs redux in Message, breaks stories/tests, says less).

## Evidence

7 new RNTL tests (5 red on unmodified code; 2 are must-not-change guards), incl. two for the previously untestable markdown link rule via a file-local renderer stand-in. One Chat snapshot updated (each basic message gains the Pressable wrapper). Full mobile 54/54 suites, 154 tests. Lead re-ran Message + Chat: 8/8. Pre-existing bug spotted, not fixed: InvitationContextMenu returns early on Android 13+ before Clipboard.setString, so invite links are never copied there.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1086.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
