### PR TITLE
fix(mobile): stop list rows dimming while the list is being dragged

### DIFF
--- a/packages/mobile/src/components/ChannelList/ChannelList.stories.tsx
+++ b/packages/mobile/src/components/ChannelList/ChannelList.stories.tsx
@@ -78,6 +78,28 @@ storiesOf('ChannelList', module)
       ]}
     />
   ))
+  // Issue #1495: a list long enough to scroll, so the tap highlight can be
+  // checked against a drag. Flick through it - no tile should dim - then tap
+  // one and the dim should appear and clear with the tap.
+  .add('Long list (scroll to check tap feedback)', () => (
+    <ChannelList
+      // @ts-ignore
+      community={{
+        name: 'Quiet',
+      }}
+      tiles={Array.from({ length: 30 }, (_, index) => ({
+        name: `channel-${index + 1}`,
+        id: `channel-${index + 1}`,
+        message: 'Text from latest chat message. Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        date: '1:55pm',
+        unread: index % 4 === 0,
+        isPublic: index % 5 !== 0,
+        redirect: (id: string) => {
+          logger.info(`Clicked ${id}`)
+        },
+      }))}
+    />
+  ))
   .add('Empty', () => (
     <ChannelList
       // @ts-ignore

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.stories.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembership.stories.tsx
@@ -1,3 +1,4 @@
+import { UserProfile } from '@quiet/types'
 import { storiesOf } from '@storybook/react-native'
 import React from 'react'
 
@@ -7,16 +8,39 @@ import { createLogger } from '../../../utils/logger'
 
 const logger = createLogger('channelMembership:stories')
 
-storiesOf('UpdateChannelMembership', module).add('Default', () => (
-  <UpdateChannelMembership
-    channelName={'private-channel'}
-    channelId={'abc123'}
-    userProfiles={{}}
-    updateChannelMembership={(memberIds: string[]) => {
-      logger.info('updating channel membership')
-    }}
-    handleBackButton={() => {
-      logger.info('going back')
-    }}
-  />
-))
+// Issue #1495: enough members that the list scrolls, so the tap highlight can
+// be checked against a drag.
+const manyMembers: Record<string, UserProfile> = Object.fromEntries(
+  Array.from({ length: 30 }, (_, index) => {
+    const userId = `member-${index + 1}`
+    return [userId, { userId, nickname: `member-${index + 1}` }]
+  })
+)
+
+storiesOf('UpdateChannelMembership', module)
+  .add('Default', () => (
+    <UpdateChannelMembership
+      channelName={'private-channel'}
+      channelId={'abc123'}
+      userProfiles={{}}
+      updateChannelMembership={(memberIds: string[]) => {
+        logger.info('updating channel membership')
+      }}
+      handleBackButton={() => {
+        logger.info('going back')
+      }}
+    />
+  ))
+  .add('Many members (scroll to check tap feedback)', () => (
+    <UpdateChannelMembership
+      channelName={'private-channel'}
+      channelId={'abc123'}
+      userProfiles={manyMembers}
+      updateChannelMembership={(memberIds: string[]) => {
+        logger.info('updating channel membership')
+      }}
+      handleBackButton={() => {
+        logger.info('going back')
+      }}
+    />
+  ))

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.component.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.component.tsx
@@ -9,6 +9,7 @@ import { SelectableListOption, UpdateChannelMembershipListProps } from './Update
 import { Spinner } from '../../Spinner/Spinner.component'
 import { createLogger } from '../../../utils/logger'
 import { uniqueId } from 'lodash'
+import { TAP_FEEDBACK_DELAY_MS } from '../../../utils/const/tapFeedback'
 
 const logger = createLogger('UpdateChannelMembershipList')
 
@@ -55,7 +56,7 @@ export const UpdateChannelMembershipList: React.FC<UpdateChannelMembershipListPr
       : defaultTheme.palette.background.gray06
     const checkedColor = item.mutable ? defaultTheme.palette.background.gray70 : defaultTheme.palette.background.gray06
     const label = (
-      <TouchableOpacity onPress={() => updateOptionsOnCheck(item)}>
+      <TouchableOpacity onPress={() => updateOptionsOnCheck(item)} delayPressIn={TAP_FEEDBACK_DELAY_MS}>
         <View
           style={{
             display: 'flex',

--- a/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.test.tsx
+++ b/packages/mobile/src/components/ChannelMembership/UpdateChannelMembership/UpdateChannelMembershipList.test.tsx
@@ -1,0 +1,48 @@
+import { UserProfile } from '@quiet/types'
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+
+import { TAP_FEEDBACK_DELAY_MS } from '../../../utils/const/tapFeedback'
+import { renderComponent } from '../../../utils/functions/renderComponent/renderComponent'
+
+import { UpdateChannelMembershipList } from './UpdateChannelMembershipList.component'
+import { SelectableListOption } from './UpdateChannelMembershipList.types'
+
+// Issue #1495: rows inside a scrollable list must not dim while the list is
+// being dragged, and the dim must not outlive the tap. Both requirements are
+// expressed entirely through Pressability's two delay knobs, so pinning the
+// props pins the motion -- see utils/const/tapFeedback.ts for the state-machine
+// argument. The `delayPressIn` assertion is the one that fails on develop; the
+// `delayPressOut` assertion guards behaviour that is already correct.
+describe('UpdateChannelMembershipList tap feedback (#1495)', () => {
+  const options: SelectableListOption[] = [
+    { id: 'alice', label: 'alice', selected: false, index: 0, mutable: true, hide: false },
+    { id: 'bob', label: 'bob', selected: true, index: 1, mutable: true, hide: false },
+  ]
+
+  const userProfiles: Record<string, UserProfile> = {
+    alice: { userId: 'alice', nickname: 'alice' },
+    bob: { userId: 'bob', nickname: 'bob' },
+  }
+
+  const rows = () =>
+    renderComponent(
+      <UpdateChannelMembershipList
+        options={options}
+        setOptions={jest.fn()}
+        visibleOptionsIndices={new Set([0, 1])}
+        userProfiles={userProfiles}
+        channelId={'abc123'}
+      />
+    ).UNSAFE_getAllByType(TouchableOpacity)
+
+  it('delays the press so dragging the member list never dims a row', () => {
+    const members = rows()
+    expect(members).toHaveLength(options.length)
+    members.forEach(row => expect(row.props.delayPressIn).toBe(TAP_FEEDBACK_DELAY_MS))
+  })
+
+  it('keeps delayPressOut unset so the dim clears as soon as the tap ends', () => {
+    rows().forEach(row => expect(row.props.delayPressOut).toBeUndefined())
+  })
+})

--- a/packages/mobile/src/components/ChannelTile/ChannelTile.component.tsx
+++ b/packages/mobile/src/components/ChannelTile/ChannelTile.component.tsx
@@ -5,6 +5,7 @@ import { defaultTheme } from '../../styles/themes/default.theme'
 import { truncateWords } from '../../utils/functions/truncateWords/truncateWords'
 import { Typography } from '../Typography/Typography.component'
 import { ChannelTileProps } from './ChannelTile.types'
+import { TAP_FEEDBACK_DELAY_MS } from '../../utils/const/tapFeedback'
 import LockIcon from '../../assets/icons/svg/lock'
 import PublicChannelIcon from '../../assets/icons/svg/public-channel'
 
@@ -41,6 +42,7 @@ export const ChannelTile: FC<ChannelTileProps> = ({ name, id, message, date, unr
       {/* <Swipeable friction={4} renderLeftActions={leftSwipe}> */}
       <TouchableOpacity
         testID={`channel_tile_${name}`}
+        delayPressIn={TAP_FEEDBACK_DELAY_MS}
         onPress={() => {
           redirect(id)
         }}

--- a/packages/mobile/src/components/ChannelTile/ChannelTile.test.tsx
+++ b/packages/mobile/src/components/ChannelTile/ChannelTile.test.tsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import { TouchableOpacity } from 'react-native'
+
+import { TAP_FEEDBACK_DELAY_MS } from '../../utils/const/tapFeedback'
 
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import { ChannelTile } from './ChannelTile.component'
@@ -1140,5 +1143,34 @@ describe('ChannelList component', () => {
         </View>
       </View>
     `)
+  })
+})
+
+// Issue #1495: rows inside a scrollable list must not dim while the list is
+// being dragged, and the dim must not outlive the tap. Both requirements are
+// expressed entirely through Pressability's two delay knobs, so pinning the
+// props pins the motion -- see utils/const/tapFeedback.ts for the state-machine
+// argument. The `delayPressIn` assertion is the one that fails on develop; the
+// `delayPressOut` assertion guards behaviour that is already correct.
+describe('ChannelTile tap feedback (#1495)', () => {
+  const tile = () =>
+    renderComponent(
+      <ChannelTile
+        name={'general'}
+        id={'general'}
+        message={'Text from latest chat message.'}
+        date={'1:55pm'}
+        unread={false}
+        isPublic={true}
+        redirect={jest.fn()}
+      />
+    ).UNSAFE_getByType(TouchableOpacity)
+
+  it('delays the press so dragging the channel list never dims a tile', () => {
+    expect(tile().props.delayPressIn).toBe(TAP_FEEDBACK_DELAY_MS)
+  })
+
+  it('keeps delayPressOut unset so the dim clears as soon as the tap ends', () => {
+    expect(tile().props.delayPressOut).toBeUndefined()
   })
 })

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.component.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.component.tsx
@@ -6,6 +6,7 @@ import { defaultPalette } from '../../styles/palettes/default.palette'
 import { icons } from '../../assets'
 import { createLogger } from '../../utils/logger'
 import { defaultTheme } from '../../styles/themes/default.theme'
+import { TAP_FEEDBACK_DELAY_MS } from '../../utils/const/tapFeedback'
 
 const logger = createLogger('contextMenu:component')
 
@@ -190,7 +191,7 @@ export const ContextMenuItem: FC<ContextMenuItemProps> = ({ title, subtitle, suf
   const paddingVertical = 11
   const minHeight = 48
   return (
-    <TouchableOpacity onPress={action} testID={title}>
+    <TouchableOpacity onPress={action} testID={title} delayPressIn={TAP_FEEDBACK_DELAY_MS}>
       <View
         style={{
           display: 'flex',

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -107,6 +107,25 @@ storiesOf('ContextMenu', module)
       />
     )
   })
+  // Issue #1495: enough items that the sheet's list scrolls, so the tap
+  // highlight can be checked against a drag.
+  .add('Many items (scroll to check tap feedback)', () => {
+    return (
+      <ContextMenu
+        title={'Rockets'}
+        items={Array.from({ length: 15 }, (_, index) => ({
+          title: `Menu item ${index + 1}`,
+          action: () => {
+            logger.info(`clicked on menu item ${index + 1}`)
+          },
+        }))}
+        visible={true}
+        handleClose={() => {
+          logger.info('closing menu')
+        }}
+      />
+    )
+  })
   .add('Invitation', () => {
     return (
       <ContextMenu

--- a/packages/mobile/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/mobile/src/components/ContextMenu/ContextMenu.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import { TouchableOpacity } from 'react-native'
+
+import { TAP_FEEDBACK_DELAY_MS } from '../../utils/const/tapFeedback'
 
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 
-import { ContextMenu } from './ContextMenu.component'
+import { ContextMenu, ContextMenuItem } from './ContextMenu.component'
 
 import { ContextMenuItemProps } from './ContextMenu.types'
 
@@ -1435,5 +1438,24 @@ describe('ContextMenu component', () => {
         </View>
       </View>
     `)
+  })
+})
+
+// Issue #1495: rows inside a scrollable list must not dim while the list is
+// being dragged, and the dim must not outlive the tap. Both requirements are
+// expressed entirely through Pressability's two delay knobs, so pinning the
+// props pins the motion -- see utils/const/tapFeedback.ts for the state-machine
+// argument. The `delayPressIn` assertion is the one that fails on develop; the
+// `delayPressOut` assertion guards behaviour that is already correct.
+describe('ContextMenuItem tap feedback (#1495)', () => {
+  const item = () =>
+    renderComponent(<ContextMenuItem title={'Create channel'} action={jest.fn()} />).UNSAFE_getByType(TouchableOpacity)
+
+  it('delays the press so dragging the action sheet never dims a menu item', () => {
+    expect(item().props.delayPressIn).toBe(TAP_FEEDBACK_DELAY_MS)
+  })
+
+  it('keeps delayPressOut unset so the dim clears as soon as the tap ends', () => {
+    expect(item().props.delayPressOut).toBeUndefined()
   })
 })

--- a/packages/mobile/src/utils/const/tapFeedback.ts
+++ b/packages/mobile/src/utils/const/tapFeedback.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared tap-feedback tuning for touchable rows that live inside a scrollable
+ * list. See https://github.com/TryQuiet/quiet/issues/1495.
+ *
+ * The value is passed as `delayPressIn` to `TouchableOpacity`. React Native's
+ * default is 0, which means `Pressability` emits its `DELAY` signal
+ * synchronously from `onResponderGrant`: the row moves straight to
+ * `RESPONDER_ACTIVE_PRESS_IN` and dims on touch-down, before the gesture is
+ * known to be a tap. Dragging or flicking the list therefore dims whichever row
+ * the finger landed on, which is the non-standard behaviour reported on #1495.
+ *
+ * With a non-zero delay the `DELAY` signal is scheduled on a timer instead. If
+ * the enclosing FlatList/ScrollView claims the touch first, the row receives
+ * `RESPONDER_TERMINATED` while still in `RESPONDER_INACTIVE_PRESS_IN`, which is
+ * not an active state, so `onPressIn` is never called and no opacity change is
+ * ever shown. A tap that ends before the delay elapses still flashes, because
+ * `Pressability` special-cases `RESPONDER_RELEASE` from an inactive press-in
+ * state and fires activate + deactivate back to back.
+ *
+ * 150 ms is the value the issue reporter asked for in
+ * https://github.com/TryQuiet/quiet/issues/1495#issuecomment-1625261531.
+ *
+ * Deliberately paired with no `delayPressOut`, so the highlight lasts only as
+ * long as the tap (the issue's second requirement). `TouchableOpacity` sets
+ * `minPressDuration: 0`, so nothing holds the dim open after release.
+ */
+export const TAP_FEEDBACK_DELAY_MS = 150


### PR DESCRIPTION
Fixes #1495

## What

Tap feedback itself already shipped in PR #1584; what remained were the maintainer's two follow-ups. Fix: `delayPressIn={150}` (the reporter's own number, one shared documented constant) on the three touchables that live inside FlatLists — channel tile, action-sheet menu item, member row — so a drag/flick claims the responder before the row ever dims. The second requirement (highlight lasts only for the tap) needs no code: nothing sets delayPressOut and TouchableOpacity has minPressDuration 0; tests pin that absence. Agent dropped the inherited activeOpacity restyle as scope creep (issue #1063 plans to delete the effect).

## Evidence

3 prop-pinning tests fail on unmodified code (Received: undefined); zero snapshots change because delayPressIn never reaches the host view. Full mobile 54/54, 153 tests. Lead re-ran 26/26. MOTION: three scrollable stories added (ChannelList, ContextMenu, UpdateChannelMembership) for the on-device check; report contains the Pressability state-machine argument. Flagged, not fixed: Button still uses TouchableWithoutFeedback (no feedback at all); taps under 150 ms dim less.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1495.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
