### PR TITLE
Explain that a username cannot start with a hyphen

### DIFF
--- a/packages/desktop/src/renderer/components/CreateUsername/CreateUsername.test.tsx
+++ b/packages/desktop/src/renderer/components/CreateUsername/CreateUsername.test.tsx
@@ -41,4 +41,47 @@ describe('Create username', () => {
     const message = await screen.findByText(error)
     expect(message).toBeVisible()
   })
+
+  // https://github.com/TryQuiet/quiet/issues/1306 - a leading hyphen used to be accepted silently.
+  // ' holmes' is included because parseName turns the leading space into a hyphen too.
+  it.each([['-holmes'], ['-1'], ['--'], [' holmes']])(
+    'user inserting name starting with a hyphen "%s" cannot submit and sees an explanation',
+    async (name: string) => {
+      const registerUsername = jest.fn()
+
+      renderComponent(
+        <CreateUsernameComponent open={true} registerUsername={registerUsername} handleClose={() => {}} />
+      )
+
+      const input = screen.getByPlaceholderText('Enter a username')
+      const button = screen.getByText('Register')
+
+      await userEvent.type(input, name)
+      await userEvent.click(button)
+
+      await waitFor(() => expect(registerUsername).not.toBeCalled())
+
+      const message = await screen.findByText(UsernameErrors.LeadingHyphen)
+      expect(message).toBeVisible()
+    }
+  )
+
+  it.each([['holmes'], ['1-holmes'], ['holmes-']])(
+    'user inserting name "%s" without a leading hyphen can still submit',
+    async (name: string) => {
+      const registerUsername = jest.fn()
+
+      renderComponent(
+        <CreateUsernameComponent open={true} registerUsername={registerUsername} handleClose={() => {}} />
+      )
+
+      const input = screen.getByPlaceholderText('Enter a username')
+      const button = screen.getByText('Register')
+
+      await userEvent.type(input, name)
+      await userEvent.click(button)
+
+      await waitFor(() => expect(registerUsername).toBeCalledWith(name))
+    }
+  )
 })

--- a/packages/desktop/src/renderer/forms/fields/createUserFields.ts
+++ b/packages/desktop/src/renderer/forms/fields/createUserFields.ts
@@ -1,3 +1,5 @@
+import { parseName } from '@quiet/common'
+
 import { FieldErrors, UsernameErrors } from '../fieldsErrors'
 import { FieldData } from '../types'
 
@@ -18,6 +20,12 @@ export const userNameField = (name = 'userName'): FieldData => {
       pattern: {
         value: /^[-a-zA-Z0-9 ]+$/g,
         message: UsernameErrors.WrongCharacter,
+      },
+      validate: {
+        // The name that actually gets registered is parseName(value), which turns
+        // spaces and other special characters into hyphens. Check that parsed form,
+        // so " holmes" (registered as "-holmes") is caught as well as "-holmes".
+        leadingCharacter: (value: string) => !parseName(value).startsWith('-') || UsernameErrors.LeadingHyphen,
       },
     },
   }

--- a/packages/desktop/src/renderer/forms/fieldsErrors.ts
+++ b/packages/desktop/src/renderer/forms/fieldsErrors.ts
@@ -5,6 +5,7 @@ export enum FieldErrors {
 export enum UsernameErrors {
   NameTooLong = 'Username must have less than 20 characters',
   WrongCharacter = 'Username must be lowercase and cannot contain any special characters',
+  LeadingHyphen = 'Username must start with a letter or number',
 }
 
 export enum CommunityNameErrors {

--- a/packages/mobile/src/components/Registration/UsernameRegistration.component.tsx
+++ b/packages/mobile/src/components/Registration/UsernameRegistration.component.tsx
@@ -49,6 +49,13 @@ export const UsernameRegistration: FC<UsernameRegistrationProps> = ({
       setInputError('Username can not be empty')
       return
     }
+    // userName is already parseName(input), which turns spaces and other special
+    // characters into hyphens, so this also catches a leading space. See TryQuiet/quiet#1306.
+    if (userName.startsWith('-')) {
+      setLoading(false)
+      setInputError('Username must start with a letter or number')
+      return
+    }
     registerUsernameAction(userName)
   }
 

--- a/packages/mobile/src/components/Registration/UsernameRegistration.test.tsx
+++ b/packages/mobile/src/components/Registration/UsernameRegistration.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { screen, fireEvent } from '@testing-library/react-native'
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import { UsernameRegistration } from './UsernameRegistration.component'
 import { UsernameVariant } from './UsernameRegistration.types'
@@ -656,4 +657,49 @@ describe('UsernameRegistration', () => {
   //     </View>
   //   `)
   // })
+
+  // https://github.com/TryQuiet/quiet/issues/1306 - a leading hyphen used to be registered as-is.
+  // ' holmes' is included because parseName turns the leading space into a hyphen too.
+  it.each([['-holmes'], ['-1'], ['--'], [' holmes']])(
+    'user inserting name starting with a hyphen "%s" cannot submit and sees an explanation',
+    (name: string) => {
+      const registerUsernameAction = jest.fn()
+
+      renderComponent(
+        <UsernameRegistration
+          variant={UsernameVariant.NEW}
+          registerUsernameAction={registerUsernameAction}
+          usernameRegistered={false}
+          fetching={false}
+        />
+      )
+
+      fireEvent.changeText(screen.getByTestId('input'), name)
+      fireEvent.press(screen.getByTestId('button'))
+
+      expect(registerUsernameAction).not.toBeCalled()
+      expect(screen.getByText('Username must start with a letter or number')).toBeVisible()
+    }
+  )
+
+  it.each([['holmes'], ['1-holmes'], ['holmes-']])(
+    'user inserting name "%s" without a leading hyphen can still submit',
+    (name: string) => {
+      const registerUsernameAction = jest.fn()
+
+      renderComponent(
+        <UsernameRegistration
+          variant={UsernameVariant.NEW}
+          registerUsernameAction={registerUsernameAction}
+          usernameRegistered={false}
+          fetching={false}
+        />
+      )
+
+      fireEvent.changeText(screen.getByTestId('input'), name)
+      fireEvent.press(screen.getByTestId('button'))
+
+      expect(registerUsernameAction).toBeCalledWith(name)
+    }
+  )
 })


### PR DESCRIPTION
Fixes #1306

## What

Today '-holmes' registers permanently: the two react-hook-form rules in createUserFields.ts are the only username constraints in the whole repo (no saga, socket DTO or backend validation touches it; usernameTaken is a hard-coded false). Fix: a new UsernameErrors.LeadingHyphen + validate.leadingCharacter rule on desktop and a matching guard in mobile's onPress. Judgment call flagged for review: the rule tests parseName(value), so a leading SPACE is blocked too (parseName(' holmes') → '-holmes', which the form already previews as @-holmes); one-line edit to undo.

## Evidence

Cypress before/after of the desktop form with '-holmes' (before: no message, enabled Register; after: red field, explanation, disabled button). Desktop 268→275 tests, mobile 147→154, zero snapshots touched; lead re-ran 11/11 + 8/8. The /g flag on the existing pattern regex (stateful RegExp.test, plausible cause of #1215) is documented as an observation, not fixed.

### Screenshots

**after**

![1306-after.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1306/1306-after.png)

**before**

![1306-before.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1306/1306-before.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1306.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
