### PR TITLE
test(desktop): guard message wrapping around long links (#372)

### DIFF
--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.wrap.cy.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.wrap.cy.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import CssBaseline from '@mui/material/CssBaseline'
+import { composeStories, setGlobalConfig } from '@storybook/testing-react'
+import { it, beforeEach, cy, Cypress, describe, expect } from 'local-cypress'
+
+import * as stories from '../../Channel/Channel.stories'
+import { withTheme } from '../../../storybook/decorators'
+import { mount } from 'cypress/react18'
+
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+Cypress.on('uncaught:exception', err => {
+  /* returning false here prevents Cypress from failing the test */
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false
+  }
+})
+
+// @ts-expect-error
+setGlobalConfig(withTheme)
+
+const { SendingMessagesWithScroll } = composeStories(stories)
+
+// Regression guard for https://github.com/TryQuiet/quiet/issues/372.
+// A run that is too long for one line must start on a line of its own; the ordinary
+// words before it must stay together on the preceding line. `overflow-wrap: anywhere`
+// on `.TextMessagemessage` only permits a mid-word break when the line has no other
+// acceptable break point, so the space before the long run has to win.
+const LINK =
+  'http://linksfahfalskjfhalskjfhlaksjfhalkshfalksdfhaslkdjfhsldkfaskhfaslkdjfhaslkdjfhaslkdfjhasldkfahslkdfjhasldfkjahsldfkjhasdfkjhjfad.com'
+const LONG_WORD = 'z'.repeat(130)
+
+/** Bounding rect of `text` within the message span's first text node. */
+const rectOf = (span: HTMLElement, text: string): DOMRect => {
+  const walker = document.createTreeWalker(span, NodeFilter.SHOW_TEXT)
+  let node: Node | null
+  while ((node = walker.nextNode())) {
+    const idx = (node.textContent || '').indexOf(text)
+    if (idx === -1) continue
+    const range = document.createRange()
+    range.setStart(node, idx)
+    range.setEnd(node, idx + text.length)
+    return range.getBoundingClientRect()
+  }
+  throw new Error(`"${text}" not found in message`)
+}
+
+const send = (message: string) => {
+  cy.get('[data-testid="messageInput"]')
+    .focus()
+    .type(message, { delay: 0, parseSpecialCharSequences: false })
+    .type('{enter}')
+  cy.contains('new word')
+}
+
+/**
+ * `first` and `second` must share a line, and `longRun` must begin below them at the
+ * left edge of the message column. Assertions are all relative, so they hold for any
+ * font the test machine happens to resolve.
+ */
+const assertLongRunStartsItsOwnLine = (getLongRunRect: (span: HTMLElement) => DOMRect) =>
+  cy
+    .get('span[data-testid^="messagesGroupContent-"]')
+    .last()
+    .then($el => {
+      const span = $el[0]
+      const first = rectOf(span, 'new')
+      const second = rectOf(span, 'word')
+      const longRun = getLongRunRect(span)
+      const columnLeft = Math.round(span.getBoundingClientRect().left)
+
+      expect(Math.round(second.top), '"word" shares a line with "new"').to.equal(Math.round(first.top))
+      expect(Math.round(longRun.top), 'long run starts below "new word"').to.be.greaterThan(Math.round(first.top))
+      expect(Math.round(longRun.left), 'long run starts at the left edge of the message column').to.equal(columnLeft)
+    })
+
+describe('Long runs wrap onto their own line (issue #372)', () => {
+  beforeEach(() => {
+    cy.viewport(600, 700)
+    mount(
+      <React.Fragment>
+        <CssBaseline>
+          <SendingMessagesWithScroll />
+        </CssBaseline>
+      </React.Fragment>
+    )
+    cy.wait(0)
+  })
+
+  it('keeps "new word" together and starts an autolinked URL on the next line', () => {
+    send(`new word ${LINK}`)
+    assertLongRunStartsItsOwnLine(span => {
+      const anchor = span.querySelector('a')
+      if (!anchor) throw new Error('URL was not autolinked')
+      return anchor.getClientRects()[0] as DOMRect
+    })
+  })
+
+  it('keeps "new word" together and starts a long unbroken word on the next line', () => {
+    send(`new word ${LONG_WORD}`)
+    assertLongRunStartsItsOwnLine(span => rectOf(span, LONG_WORD.slice(0, 3)))
+  })
+})


### PR DESCRIPTION
Refs #372

## What

Does not reproduce on origin/develop: 'new word' sits alone on line 1 and the URL starts on line 2 at every column width from 312 to 824px; a 130-char non-URL word behaves the same. Quiet's CSS never changed — overflowWrap:'anywhere' predates the issue by five weeks — the engine did (Electron 17 → 23 in 2023, → 31/32 in March 2026, all before 9.0). Close as completed.

## Evidence

8 screenshots incl. negative controls: adding word-break:break-all reproduces the 2022 complaint and fails the new Cypress guard, so the guard is not vacuous. One test-only commit (optional to land); no production change. Cypress 25/25 across 4 specs, desktop jest unchanged 95/96. Closure comment queued for the user.

### Screenshots

**breakall-link-600**

![372-breakall-link-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-breakall-link-600.png)

**breakall-longword-600**

![372-breakall-longword-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-breakall-longword-600.png)

**code-600**

![372-code-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-code-600.png)

**link-420**

![372-link-420.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-link-420.png)

**link-600**

![372-link-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-link-600.png)

**link-900**

![372-link-900.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-link-900.png)

**longword-600**

![372-longword-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-longword-600.png)

**prose-600**

![372-prose-600.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/372/372-prose-600.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-372.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
