### PR TITLE
fix(mobile): let the message entry field scale back down

### DIFF
--- a/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/packages/mobile/src/components/Chat/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -3036,7 +3036,7 @@ exports[`Chat component renders component 1`] = `
                       style={
                         [
                           {
-                            "height": 54,
+                            "minHeight": 40,
                             "paddingBottom": 0,
                             "paddingTop": 12,
                             "textAlignVertical": "center",

--- a/packages/mobile/src/components/Input/Input.styles.ts
+++ b/packages/mobile/src/components/Input/Input.styles.ts
@@ -8,7 +8,21 @@ export const StyledTextInput = styled(TextInput)<{
 }>`
   ${({ height, multiline }) => css`
     text-align-vertical: center;
-    height: ${Math.max(40, height)}px;
+    /*
+     * A multiline input must keep an auto height. Its own box is what React Native measures to
+     * produce onContentSizeChange, so pinning that box to the last reported height freezes the
+     * measurement: on Android a definite height stops Yoga consulting
+     * ReactTextInputShadowNode.measure(), the view is never re-laid-out, ReactEditText.onLayout()
+     * never runs and ReactContentSizeWatcher never dispatches a smaller size. The field could then
+     * only ever grow. See TryQuiet/quiet#2655.
+     */
+    ${multiline
+      ? css`
+          min-height: 40px;
+        `
+      : css`
+          height: ${Math.max(40, height)}px;
+        `}
     ${Platform.select({
       ios: {
         paddingTop: 12,

--- a/packages/mobile/src/components/Input/Input.test.tsx
+++ b/packages/mobile/src/components/Input/Input.test.tsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import { StyleSheet, ViewStyle } from 'react-native'
+import { fireEvent, screen } from '@testing-library/react-native'
+import type { ReactTestInstance } from 'react-test-renderer'
 
 import { renderComponent } from '../../utils/functions/renderComponent/renderComponent'
 import { Input } from './Input.component'
@@ -85,5 +88,78 @@ describe('MessageInput component', () => {
         </View>
       </View>
     `)
+  })
+})
+
+/**
+ * Regression coverage for TryQuiet/quiet#2655 — "Message entry field doesn't scale back down".
+ *
+ * A multiline TextInput may not pin its own `height`, because the height it reports through
+ * `onContentSizeChange` is produced by the very box we would be pinning:
+ *
+ *  - Android: a definite height on the Yoga node means `ReactTextInputShadowNode.measure()`
+ *    (react-native/ReactAndroid/.../textinput/ReactTextInputShadowNode.java) is never consulted,
+ *    so the view keeps the frame JS wrote and is never re-laid-out. `ReactEditText.onLayout()`
+ *    (ReactEditText.java:252) is what drives `ReactContentSizeWatcher.onLayout()`
+ *    (ReactTextInputManager.java:1191), and that watcher only dispatches when the measured size
+ *    differs from the size it last dispatched (ReactTextInputManager.java:1227). Pin the height
+ *    and no smaller size is ever reported, so the field ratchets up and never comes back down.
+ *  - iOS measures the text in the shadow view with an unbounded height
+ *    (RCTBaseTextInputShadowView.mm:84-111), which is why the report is Android-only.
+ *
+ * Jest has no native layout, so `nativeReportsContentHeight` below models that Android rule:
+ * a smaller content size is only delivered while the input's own height is free.
+ */
+describe('multiline Input auto-sizing (#2655)', () => {
+  const BASE_WRAPPER_HEIGHT = 54
+
+  const inputStyle = (): ViewStyle => StyleSheet.flatten(screen.getByTestId('input').props.style) ?? {}
+
+  // The pressable wrapper carries no testID, so walk up to the nearest host element.
+  const wrapperHeight = (): number | undefined => {
+    let node: ReactTestInstance | null = screen.getByTestId('input').parent
+    while (node && typeof node.type !== 'string') {
+      node = node.parent
+    }
+    return (StyleSheet.flatten(node?.props.style) as ViewStyle | undefined)?.height as number | undefined
+  }
+
+  const nativeReportsContentHeight = (height: number) => {
+    const pinned = inputStyle().height
+    if (typeof pinned === 'number' && height < pinned) {
+      // The native view cannot shrink below the height we pinned, so no event is dispatched.
+      return
+    }
+    fireEvent(screen.getByTestId('input'), 'contentSizeChange', {
+      nativeEvent: { contentSize: { height, width: 300 } },
+    })
+  }
+
+  it('leaves the multiline input free to re-measure itself', () => {
+    renderComponent(<Input multiline onChangeText={() => {}} placeholder={'Message #general'} />)
+
+    nativeReportsContentHeight(200)
+
+    expect(inputStyle().height).toBeUndefined()
+    expect(inputStyle().minHeight).toBe(40)
+  })
+
+  it('scales the wrapper back down once the message is sent', () => {
+    renderComponent(<Input multiline onChangeText={() => {}} placeholder={'Message #general'} />)
+
+    // A long message grows the field.
+    nativeReportsContentHeight(200)
+    expect(wrapperHeight()).toBe(220)
+
+    // The chat screen clears the input after send and the field reflows to one line.
+    nativeReportsContentHeight(24)
+    expect(wrapperHeight()).toBe(BASE_WRAPPER_HEIGHT)
+  })
+
+  it('keeps pinning the height of single-line inputs', () => {
+    renderComponent(<Input onChangeText={() => {}} placeholder={'Username'} />)
+
+    expect(inputStyle().height).toBe(54)
+    expect(inputStyle().minHeight).toBeUndefined()
   })
 })


### PR DESCRIPTION
Fixes #2655

## What

Root cause: Input fed onContentSizeChange's height straight back into the same TextInput's style height. On Android (old architecture) a definite height makes Yoga skip the text measure function, the view is never re-laid-out, and the content-size watcher's height falls back to the frame JS pinned — so no smaller size can ever be reported. Fix: multiline inputs get min-height instead of height; wrapper maths (54 floor, height+20) unchanged; single-line inputs byte-identical; iOS unaffected because it measures with unbounded height.

## Evidence

Second agent verified the mechanism against RN 0.77.3 sources (Yoga CalculateLayout.cpp:301, ReactEditText.java:246/1346, ReactTextInputManager.java:1211, RCTBaseTextInputShadowView.mm:84) and flagged one incomplete clause in the commit message (onLayout is not the only driver; the frame fallback is the sharper reason) — conclusion unaffected. Reverting Input.styles.ts fails 2 of 3 new tests ('Expected: 54, Received: 220'). Full mobile 53/53, 150 tests; one Chat snapshot line changed. Pre-existing and untouched: no maxHeight on the composer, so it can still grow unbounded upward.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2655.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
