### PR TITLE
Link #channel mentions to the channel they name (desktop)

### DIFF
--- a/packages/desktop/src/renderer/components/Channel/Channel.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { shell, ipcRenderer, webUtils } from 'electron'
 
@@ -7,6 +7,7 @@ import { users, messages, publicChannels, communities, files, network, settings 
 import { FileMetadata, CancelDownload, FileContent, FilePreviewData } from '@quiet/types'
 
 import ChannelComponent, { ChannelComponentProps } from './ChannelComponent'
+import { ChannelLinkNavigation } from '../widgets/channels/TextMessage'
 
 import { useModal } from '../../containers/hooks'
 import { ModalName } from '../../sagas/modals/modals.types'
@@ -27,6 +28,10 @@ const Channel = () => {
   const currentChannelName = useSelector(publicChannels.selectors.currentChannelName)
   const currentChannel = useSelector(publicChannels.selectors.currentChannel)
   const currentChannelSubscribed = useSelector(publicChannels.selectors.currentChannelSubscribed)
+
+  // The channels the user can actually see - the same list the sidebar renders. Channels the user
+  // has no access to are not in the store, so mentions of them stay plain text.
+  const visibleChannels = useSelector(publicChannels.selectors.publicChannels)
 
   const currentChannelMessagesCount = useSelector(publicChannels.selectors.currentChannelMessagesCount)
 
@@ -165,6 +170,16 @@ const Channel = () => {
     shell.openExternal(url)
   }, [])
 
+  const channelLinks = useMemo<ChannelLinkNavigation>(
+    () => ({
+      channels: new Map(visibleChannels.map(channel => [channel.name.toLowerCase(), channel.id])),
+      onChannelLinkClick: (channelId: string) => {
+        dispatch(publicChannels.actions.setCurrentChannel({ channelId }))
+      },
+    }),
+    [visibleChannels, dispatch]
+  )
+
   const openContainingFolder = useCallback((path: string) => {
     shell.showItemInFolder(path)
   }, [])
@@ -210,6 +225,7 @@ const Channel = () => {
     onInputChange: onInputChange,
     onInputEnter: onInputEnter,
     openUrl: openUrl,
+    channelLinks: channelLinks,
     handleFileDrop: handleFileDrop,
     openFilesDialog: openFilesDialog,
     isCommunityInitialized: isCommunityInitialized,

--- a/packages/desktop/src/renderer/components/Channel/ChannelComponent.tsx
+++ b/packages/desktop/src/renderer/components/Channel/ChannelComponent.tsx
@@ -8,6 +8,7 @@ import PageHeader from '../ui/Page/PageHeader'
 
 import ChannelHeaderComponent from '../widgets/channels/ChannelHeader'
 import ChannelMessagesComponent from '../widgets/channels/ChannelMessages'
+import { ChannelLinkNavigation } from '../widgets/channels/TextMessage'
 import ChannelInputComponent from '../widgets/channels/ChannelInput'
 
 import { INPUT_STATE } from '../widgets/channels/ChannelInput/InputState.enum'
@@ -50,6 +51,7 @@ export interface ChannelComponentProps {
   onInputChange: (value: string) => void
   onInputEnter: (message: string) => void
   openUrl: (url: string) => void
+  channelLinks?: ChannelLinkNavigation
   openFilesDialog: () => void
   handleFileDrop: (arg: any) => void
   isCommunityInitialized: boolean
@@ -85,6 +87,7 @@ export const ChannelComponent: React.FC<ChannelComponentProps & UploadFilesPrevi
   onInputChange,
   onInputEnter,
   openUrl,
+  channelLinks,
   removeFile,
   handleFileDrop,
   filesData,
@@ -240,6 +243,7 @@ export const ChannelComponent: React.FC<ChannelComponentProps & UploadFilesPrevi
             onScroll={onScroll}
             uploadedFileModal={uploadedFileModal}
             openUrl={openUrl}
+            channelLinks={channelLinks}
             openContainingFolder={openContainingFolder}
             downloadFile={downloadFile}
             cancelDownload={cancelDownload}

--- a/packages/desktop/src/renderer/components/MathMessage/MathMessageComponent.tsx
+++ b/packages/desktop/src/renderer/components/MathMessage/MathMessageComponent.tsx
@@ -49,6 +49,7 @@ const MathComponent: React.FC<UseMathProps & TextMessageComponentProps> = ({
   messageId,
   pending,
   openUrl,
+  channelLinks,
   index,
 }) => {
   const [renderedHTML, setRenderedHTML] = React.useState<string | null>(null)
@@ -95,6 +96,7 @@ const MathComponent: React.FC<UseMathProps & TextMessageComponentProps> = ({
       messageId={`${messageId}-${index}`}
       pending={pending}
       openUrl={openUrl}
+      channelLinks={channelLinks}
       key={`${messageId}-${index}`}
     />
   )
@@ -110,6 +112,7 @@ export const MathMessageComponent: React.FC<TextMessageComponentProps & MathMess
   messageId,
   pending,
   openUrl,
+  channelLinks,
   display = false,
   onMathMessageRendered,
 }) => {
@@ -119,7 +122,15 @@ export const MathMessageComponent: React.FC<TextMessageComponentProps & MathMess
     texMessageSplit = splitByTex(String.raw`${message}`, displayMathRegex)
   } catch (e) {
     logger.error('Error extracting tex from message', e)
-    return <TextMessageComponent message={message} messageId={messageId} pending={pending} openUrl={openUrl} />
+    return (
+      <TextMessageComponent
+        message={message}
+        messageId={messageId}
+        pending={pending}
+        openUrl={openUrl}
+        channelLinks={channelLinks}
+      />
+    )
   }
 
   return (
@@ -132,6 +143,7 @@ export const MathMessageComponent: React.FC<TextMessageComponentProps & MathMess
           messageId={messageId}
           pending={pending}
           openUrl={openUrl}
+          channelLinks={channelLinks}
           index={index}
           key={`${messageId}-${index}`}
         />

--- a/packages/desktop/src/renderer/components/widgets/channels/BasicMessage.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/BasicMessage.tsx
@@ -14,6 +14,7 @@ import ProfilePhoto from '../../ProfilePhoto/ProfilePhoto'
 import type { DisplayableMessage, DownloadStatus, MessageSendingStatus } from '@quiet/types'
 
 import { NestedMessageContent } from './NestedMessageContent'
+import { ChannelLinkNavigation } from './TextMessage'
 
 import type { FileActionsProps } from '../../Channel/File/FileComponent/FileComponent'
 
@@ -162,6 +163,7 @@ export interface BasicMessageProps {
   messages: DisplayableMessage[]
   pendingMessages?: Dictionary<MessageSendingStatus>
   openUrl: (url: string) => void
+  channelLinks?: ChannelLinkNavigation
   downloadStatuses?: Dictionary<DownloadStatus>
   maxAutodownloadSizeBytes: number
   uploadedFileModal?: UseModalType<{
@@ -180,6 +182,7 @@ export const BasicMessageComponent: React.FC<BasicMessageProps & FileActionsProp
   uploadedFileModal,
   onMathMessageRendered,
   openUrl,
+  channelLinks,
   openContainingFolder,
   downloadFile,
   cancelDownload,
@@ -278,6 +281,7 @@ export const BasicMessageComponent: React.FC<BasicMessageProps & FileActionsProp
                       maxAutodownloadSizeBytes={maxAutodownloadSizeBytes}
                       uploadedFileModal={uploadedFileModal}
                       openUrl={openUrl}
+                      channelLinks={channelLinks}
                       openContainingFolder={openContainingFolder}
                       downloadFile={downloadFile}
                       cancelDownload={cancelDownload}

--- a/packages/desktop/src/renderer/components/widgets/channels/ChannelMessages.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/ChannelMessages.tsx
@@ -6,6 +6,7 @@ import { styled } from '@mui/material/styles'
 import FloatingDate from './FloatingDate'
 import DateDivider from '../DateDivider'
 import BasicMessageComponent from './BasicMessage'
+import { ChannelLinkNavigation } from './TextMessage'
 import SpinnerLoader from '../../ui/Spinner/SpinnerLoader'
 
 import { CancelDownload, DownloadStatus, FileMetadata, MessagesDailyGroups, MessageSendingStatus } from '@quiet/types'
@@ -71,6 +72,7 @@ interface Props {
   scrollbarRef: React.RefObject<HTMLDivElement>
   onScroll: () => void
   openUrl: (url: string) => void
+  channelLinks?: ChannelLinkNavigation
   openContainingFolder?: (path: string) => void
   downloadFile?: (media: FileMetadata) => void
   cancelDownload?: (cancelDownload: CancelDownload) => void
@@ -90,6 +92,7 @@ export const ChannelMessagesComponent: React.FC<Props> = ({
   onScroll,
   uploadedFileModal,
   openUrl,
+  channelLinks,
   openContainingFolder,
   downloadFile,
   cancelDownload,
@@ -248,6 +251,7 @@ export const ChannelMessagesComponent: React.FC<Props> = ({
                   maxAutodownloadSizeBytes={maxAutodownloadSizeBytes}
                   uploadedFileModal={uploadedFileModal}
                   openUrl={openUrl}
+                  channelLinks={channelLinks}
                   openContainingFolder={openContainingFolder}
                   downloadFile={downloadFile}
                   cancelDownload={cancelDownload}

--- a/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/NestedMessageContent.tsx
@@ -6,7 +6,7 @@ import { Grid, useTheme } from '@mui/material'
 import ImageAttachment from '../../Channel/File/ImageAttachment/ImageAttachment'
 import FileComponent, { FileActionsProps } from '../../Channel/File/FileComponent/FileComponent'
 import { displayMathRegex } from '../../../../utils/functions/splitByTex'
-import { TextMessageComponent } from './TextMessage'
+import { ChannelLinkNavigation, TextMessageComponent } from './TextMessage'
 import { MathMessageComponent } from '../../MathMessage/MathMessageComponent'
 import { UseModalType } from '../../../containers/hooks'
 import { DisplayableMessage, DownloadState, DownloadStatus } from '@quiet/types'
@@ -42,6 +42,7 @@ export interface NestedMessageContentProps {
   downloadStatus?: DownloadStatus
   maxAutodownloadSizeBytes: number
   openUrl: (url: string) => void
+  channelLinks?: ChannelLinkNavigation
   uploadedFileModal?: UseModalType<{
     src: string
   }>
@@ -56,6 +57,7 @@ export const NestedMessageContent: React.FC<NestedMessageContentProps & FileActi
   uploadedFileModal,
   onMathMessageRendered,
   openUrl,
+  channelLinks,
   openContainingFolder,
   downloadFile,
   cancelDownload,
@@ -126,6 +128,7 @@ export const NestedMessageContent: React.FC<NestedMessageContentProps & FileActi
               messageId={message.id}
               pending={pending}
               openUrl={openUrl}
+              channelLinks={channelLinks}
             />
           )
         }
@@ -136,6 +139,7 @@ export const NestedMessageContent: React.FC<NestedMessageContentProps & FileActi
             messageId={message.id}
             pending={pending}
             openUrl={openUrl}
+            channelLinks={channelLinks}
             onMathMessageRendered={onMathMessageRendered}
           />
         )

--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.test.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import userEvent from '@testing-library/user-event'
+import { renderComponent } from '../../../testUtils'
+import { ChannelLinkNavigation, TextMessageComponent } from './TextMessage'
+import { channelLinkHref } from './remarkChannelLinks'
+
+const GENERAL_ID = 'general-channel-id'
+const DESIGN_ID = 'design-channel-id'
+
+const channelLinks = (onChannelLinkClick = jest.fn()): ChannelLinkNavigation => ({
+  channels: new Map([
+    ['general', GENERAL_ID],
+    ['design', DESIGN_ID],
+    ['design-review', 'design-review-channel-id'],
+  ]),
+  onChannelLinkClick,
+})
+
+const renderMessage = (message: string, navigation?: ChannelLinkNavigation, openUrl = jest.fn()) => ({
+  openUrl,
+  ...renderComponent(
+    <TextMessageComponent
+      message={message}
+      messageId='message-id'
+      pending={false}
+      openUrl={openUrl}
+      channelLinks={navigation}
+    />
+  ),
+})
+
+describe('TextMessage channel mentions', () => {
+  it('turns a mention of an existing channel into a link to that channel', () => {
+    const { baseElement } = renderMessage('see #general for details', channelLinks())
+
+    const link = baseElement.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link).toHaveTextContent('#general')
+    expect(link).toHaveAttribute('href', channelLinkHref(GENERAL_ID))
+    expect(baseElement).toHaveTextContent('see #general for details')
+  })
+
+  it('calls onChannelLinkClick with the channel id when the link is clicked', async () => {
+    const onChannelLinkClick = jest.fn()
+    const { baseElement, openUrl } = renderMessage('see #general for details', channelLinks(onChannelLinkClick))
+
+    await userEvent.click(baseElement.querySelector('a') as HTMLAnchorElement)
+
+    expect(onChannelLinkClick).toHaveBeenCalledTimes(1)
+    expect(onChannelLinkClick).toHaveBeenCalledWith(GENERAL_ID)
+    // A channel link navigates inside the app; it must never reach the external browser.
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('prefers the longest matching channel name', () => {
+    const { baseElement } = renderMessage('see #design-review please', channelLinks())
+
+    expect(baseElement.querySelector('a')).toHaveTextContent('#design-review')
+  })
+
+  it('leaves trailing sentence punctuation outside the link', () => {
+    const { baseElement } = renderMessage('go to #general.', channelLinks())
+
+    expect(baseElement.querySelector('a')).toHaveTextContent('#general')
+    expect(baseElement).toHaveTextContent('go to #general.')
+  })
+
+  it('links every mention in a message', () => {
+    const { baseElement } = renderMessage('#general and #design', channelLinks())
+
+    const links = Array.from(baseElement.querySelectorAll('a'))
+    expect(links.map(link => link.getAttribute('href'))).toEqual([
+      channelLinkHref(GENERAL_ID),
+      channelLinkHref(DESIGN_ID),
+    ])
+  })
+
+  describe('does not link', () => {
+    it.each([
+      ['an unknown channel name', 'try #nope for details'],
+      ['a name that only starts with a channel name', 'that is #generalize really'],
+      ['a mention glued to a preceding word', 'not a mention: foo#general'],
+      ['a mention inside inline code', 'inline code: `#general` stays code'],
+      ['a fragment inside an autolinked url', 'see https://example.com/#general'],
+      ['a doubled hash', 'see ##general'],
+    ])('%s', (_label: string, message: string) => {
+      const { baseElement } = renderMessage(message, channelLinks())
+
+      expect(baseElement.querySelectorAll('[data-testid="channelLink"]')).toHaveLength(0)
+      expect(baseElement).toHaveTextContent(message.replace(/`/g, ''))
+    })
+
+    it('a mention inside a fenced code block', () => {
+      const { baseElement } = renderMessage('```\nping #general\n```', channelLinks())
+
+      expect(baseElement.querySelectorAll('[data-testid="channelLink"]')).toHaveLength(0)
+      expect(baseElement.querySelector('code')).toHaveTextContent('ping #general')
+    })
+  })
+
+  it('keeps the url of an autolinked address intact', () => {
+    const { baseElement } = renderMessage('see https://example.com/#general', channelLinks())
+
+    expect(baseElement.querySelector('a')).toHaveAttribute('href', 'https://example.com/#general')
+  })
+
+  it('still opens a real url in the browser', async () => {
+    const { baseElement, openUrl } = renderMessage('see https://example.com/ now', channelLinks())
+
+    await userEvent.click(baseElement.querySelector('a') as HTMLAnchorElement)
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/')
+  })
+
+  it('renders mentions as plain text when no channel list is supplied', () => {
+    const { baseElement } = renderMessage('see #general for details')
+
+    expect(baseElement.querySelectorAll('a')).toHaveLength(0)
+    expect(baseElement).toHaveTextContent('see #general for details')
+  })
+
+  it('ignores a hand-written link to a channel the user cannot see', async () => {
+    const onChannelLinkClick = jest.fn()
+    const { baseElement, openUrl } = renderMessage(
+      `[click me](${channelLinkHref('secret-channel-id')})`,
+      channelLinks(onChannelLinkClick)
+    )
+
+    await userEvent.click(baseElement.querySelector('a') as HTMLAnchorElement)
+
+    expect(onChannelLinkClick).not.toHaveBeenCalled()
+    // Nor may it fall through to the browser - `#channel/…` is not a url anyone should visit.
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+})

--- a/packages/desktop/src/renderer/components/widgets/channels/TextMessage.tsx
+++ b/packages/desktop/src/renderer/components/widgets/channels/TextMessage.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames'
 import React, { ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import type { PluggableList } from 'unified'
 import { isAllEmoji } from '../../../../../../common/src/emojis'
+import { parseChannelLinkHref, remarkChannelLinks } from './remarkChannelLinks'
 
 const PREFIX = 'TextMessage'
 
@@ -105,14 +107,41 @@ const StyledTypography = styled(Typography)(({ theme }) => ({
   },
 })) as typeof Typography
 
+/**
+ * Everything TextMessage needs to turn `#some-channel` into a link the user can click.
+ * Optional throughout the message tree so stories, tests and any other caller can leave it out and
+ * keep the previous plain-text behaviour.
+ */
+export interface ChannelLinkNavigation {
+  /** lowercased channel name -> channel id, for every channel the user can currently see */
+  channels: Map<string, string>
+  onChannelLinkClick: (channelId: string) => void
+}
+
 export interface TextMessageComponentProps {
   message: string
   messageId: string
   pending: boolean
   openUrl: (url: string) => void
+  channelLinks?: ChannelLinkNavigation
 }
 
-export const TextMessageComponent: React.FC<TextMessageComponentProps> = ({ message, messageId, pending, openUrl }) => {
+export const TextMessageComponent: React.FC<TextMessageComponentProps> = ({
+  message,
+  messageId,
+  pending,
+  openUrl,
+  channelLinks,
+}) => {
+  const remarkPlugins: PluggableList = [[remarkGfm, { singleTilde: false }]]
+  if (channelLinks && channelLinks.channels.size > 0) {
+    remarkPlugins.push([remarkChannelLinks, { channels: channelLinks.channels }])
+  }
+
+  // Guards against a hand-written `[x](#channel/…)` link pointing at a channel the user cannot see.
+  const isVisibleChannel = (channelId: string): boolean =>
+    Array.from(channelLinks?.channels.values() ?? []).includes(channelId)
+
   const componentDecorator = (decoratedHref: string, decoratedText: string, key: number): ReactNode => {
     return (
       <a
@@ -138,19 +167,28 @@ export const TextMessageComponent: React.FC<TextMessageComponentProps> = ({ mess
       data-testid={`messagesGroupContent-${messageId}`}
     >
       <ReactMarkdown
-        remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
+        remarkPlugins={remarkPlugins}
         children={message}
         components={{
-          a: ({ node, ...props }) => (
-            <a
-              onClick={e => {
-                e.preventDefault()
-                if (props.href) openUrl(props.href)
-              }}
-              className={classNames({ [classes.link]: true })}
-              {...props}
-            />
-          ),
+          a: ({ node, ...props }) => {
+            const channelId = parseChannelLinkHref(props.href)
+            return (
+              <a
+                onClick={e => {
+                  e.preventDefault()
+                  if (channelId !== null) {
+                    // Channel links never reach openUrl - they navigate inside the app.
+                    if (isVisibleChannel(channelId)) channelLinks?.onChannelLinkClick(channelId)
+                    return
+                  }
+                  if (props.href) openUrl(props.href)
+                }}
+                className={classNames({ [classes.link]: true })}
+                data-testid={channelId !== null ? 'channelLink' : undefined}
+                {...props}
+              />
+            )
+          },
           // Not working in older ReactMarkdown version we use because of ESM
           // blockquote: ({ node, ...props }) => (
           //   <blockquote className={classNames({ [classes.blockquote]: true })} {...props} />

--- a/packages/desktop/src/renderer/components/widgets/channels/remarkChannelLinks.ts
+++ b/packages/desktop/src/renderer/components/widgets/channels/remarkChannelLinks.ts
@@ -1,0 +1,149 @@
+/**
+ * A remark (mdast) plugin that turns `#some-channel` mentions into links.
+ *
+ * It runs on the parsed markdown tree rather than on the raw message string so that
+ * markdown's own rules are respected for free:
+ *  - `#general` inside `` `code` `` or a fenced block is never touched, because those are
+ *    `inlineCode`/`code` nodes and carry their content on the node itself, not in a `text` child
+ *  - `#general` inside an existing link (including a GFM autolinked URL such as
+ *    `https://example.com/#general`) is skipped, because we do not descend into `link` nodes
+ *  - `# general` at the start of a line is a heading, so there is no `#` left in the text to match
+ *
+ * Only mentions that resolve to a channel the user can currently see become links. Everything
+ * else - unknown names, private channels the user has no access to - stays plain text.
+ */
+
+/** Minimal structural view of an mdast node; avoids depending on `@types/mdast` / `unist`. */
+interface MdastNode {
+  type: string
+  value?: string
+  url?: string
+  title?: string | null
+  children?: MdastNode[]
+}
+
+export interface RemarkChannelLinksOptions {
+  /** lowercased channel name -> channel id, for every channel the user can currently see */
+  channels: Map<string, string>
+}
+
+/**
+ * Href prefix for channel links. It deliberately starts with `#` so that react-markdown's default
+ * `uriTransformer` passes it through untouched - any custom scheme (`quiet://…`) is rewritten to
+ * `javascript:void(0)` by that sanitizer.
+ */
+export const CHANNEL_LINK_HREF_PREFIX = '#channel/'
+
+export const channelLinkHref = (channelId: string): string =>
+  `${CHANNEL_LINK_HREF_PREFIX}${encodeURIComponent(channelId)}`
+
+/** Returns the channel id encoded in `href`, or null when `href` is not a channel link. */
+export const parseChannelLinkHref = (href?: string): string | null => {
+  if (!href || !href.startsWith(CHANNEL_LINK_HREF_PREFIX)) return null
+  const encoded = href.slice(CHANNEL_LINK_HREF_PREFIX.length)
+  if (!encoded) return null
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Channel names are normalized by `parseName` in @quiet/common to `[\w._-]` lowercase, so a mention
+ * candidate is a word character followed by more of that same set. Requiring a word character first
+ * keeps `#-` / `#.` / `##general` from being treated as mentions.
+ */
+const CHANNEL_MENTION_REGEX = /#(\w[\w.-]{0,63})/g
+
+/**
+ * A mention must start at the beginning of a text node or right after whitespace or an opening
+ * bracket/quote. This is what keeps `foo#general` and `example.com/#general` plain text.
+ */
+const ALLOWED_CHARACTER_BEFORE_MENTION = /[\s([{<"'‘“]/
+
+/** Trailing punctuation that is legal inside a channel name but usually belongs to the sentence. */
+const TRIMMABLE_TRAILING_CHARACTER = /[._-]$/
+
+/** Node types whose subtree must not be rewritten - they are already links, or already resolved. */
+const SKIPPED_NODE_TYPES = new Set(['link', 'linkReference', 'definition', 'image', 'imageReference'])
+
+/**
+ * Resolves a mention candidate to a channel, giving back the matched name so the rendered link text
+ * keeps only the part that is really a channel. `#general.` at the end of a sentence resolves to
+ * `general` and leaves the full stop outside the link; `#generalize` resolves to nothing.
+ */
+const resolveChannel = (candidate: string, channels: Map<string, string>): { id: string; name: string } | null => {
+  let name = candidate
+  while (name.length > 0) {
+    const id = channels.get(name.toLowerCase())
+    if (id !== undefined) return { id, name }
+    if (!TRIMMABLE_TRAILING_CHARACTER.test(name)) return null
+    name = name.slice(0, -1)
+  }
+  return null
+}
+
+/** Splits one text node into text/link nodes, or returns null when it holds no channel mention. */
+const splitTextNode = (value: string, channels: Map<string, string>): MdastNode[] | null => {
+  const nodes: MdastNode[] = []
+  let cursor = 0
+  let match: RegExpExecArray | null
+
+  CHANNEL_MENTION_REGEX.lastIndex = 0
+  while ((match = CHANNEL_MENTION_REGEX.exec(value)) !== null) {
+    const start = match.index
+    const characterBefore = start === 0 ? undefined : value[start - 1]
+    if (characterBefore !== undefined && !ALLOWED_CHARACTER_BEFORE_MENTION.test(characterBefore)) continue
+
+    const channel = resolveChannel(match[1], channels)
+    if (!channel) continue
+
+    if (start > cursor) nodes.push({ type: 'text', value: value.slice(cursor, start) })
+    nodes.push({
+      type: 'link',
+      url: channelLinkHref(channel.id),
+      title: null,
+      children: [{ type: 'text', value: `#${channel.name}` }],
+    })
+
+    cursor = start + 1 + channel.name.length
+    CHANNEL_MENTION_REGEX.lastIndex = cursor
+  }
+
+  if (nodes.length === 0) return null
+  if (cursor < value.length) nodes.push({ type: 'text', value: value.slice(cursor) })
+  return nodes
+}
+
+/** Depth-first walk. Deliberately small so we do not need `unist-util-visit` as a new dependency. */
+const transformNode = (node: MdastNode, channels: Map<string, string>): void => {
+  const children = node.children
+  if (!children) return
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index]
+    if (SKIPPED_NODE_TYPES.has(child.type)) continue
+
+    if (child.type === 'text' && typeof child.value === 'string') {
+      const replacement = splitTextNode(child.value, channels)
+      if (replacement) {
+        children.splice(index, 1, ...replacement)
+        index += replacement.length - 1
+      }
+      continue
+    }
+
+    transformNode(child, channels)
+  }
+}
+
+export const remarkChannelLinks = (options?: RemarkChannelLinksOptions) => {
+  const channels = options?.channels
+  return (tree: MdastNode): void => {
+    if (!channels || channels.size === 0) return
+    transformNode(tree, channels)
+  }
+}
+
+export default remarkChannelLinks


### PR DESCRIPTION
Fixes #1745

## What

A 150-line remark plugin walks the parsed mdast and turns `#name` text tokens that resolve to a channel the user can see into link nodes, so markdown's own rules hold for free: code spans/fences, existing links and GFM autolinked URLs (example.com/#general) are never touched, and a word boundary is required before `#` (foo#bar stays text). Trailing sentence punctuation is trimmed (#general. links 'general'). Href is `#channel/<id>` because react-markdown's uriTransformer rewrites custom schemes to javascript:void. One optional `channelLinks` prop travels the same path as openUrl (Channel → ChannelComponent → ChannelMessages → BasicMessage → TextMessage; one line per hop); click dispatches setCurrentChannel. Unknown/private channels stay plain text.

## Evidence

Cypress before/after of a message with #general, #nope, `#general` in code and a URL fragment; 16 RTL tests (5 red on unmodified code; the invisible-channel guard now also asserts openUrl is never called). Full desktop 96/97, zero snapshots changed; typecheck + eslint clean on 9 files. Lead read the plugin and re-ran 20/21 with the known pre-existing failure. Largest footprint in the batch (9 files, +382) — a feature, not a bug fix.

### Screenshots

**after**

![1745-after.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1745/1745-after.png)

**before**

![1745-before.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/1745/1745-before.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-1745.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
