### PR TITLE
fix: drop whitespace-only text messages before sending (#2778)

### DIFF
--- a/packages/desktop/src/renderer/components/Channel/Channel.tsx
+++ b/packages/desktop/src/renderer/components/Channel/Channel.tsx
@@ -67,8 +67,9 @@ const Channel = () => {
 
   const onInputEnter = useCallback(
     (message: string) => {
-      // Send message out of input value
-      if (message) {
+      // Send message out of input value. Whitespace-only input has nothing to
+      // send, but any attached files below still go out.
+      if (message.trim()) {
         dispatch(messages.actions.sendMessage({ message }))
       }
       // Upload files, then send corresponding message (contaning cid) for each of them

--- a/packages/desktop/src/rtl-tests/channel.main.test.tsx
+++ b/packages/desktop/src/rtl-tests/channel.main.test.tsx
@@ -464,6 +464,102 @@ describe('PublicChannel', () => {
     expect(await screen.findByText(messageText)).not.toHaveStyle('color:#B2B2B2')
   })
 
+  it('does not send a whitespace-only message as the first message in a new channel', async () => {
+    const { store } = await prepareStore(
+      {},
+      socket // Fork state manager's sagas
+    )
+
+    const factory = await getReduxStoreFactory(store)
+
+    const community = await factory.create('Community')
+
+    const alice = await factory.create('Identity', {
+      communityId: community.id,
+    })
+    await factory.create('UserProfile', {
+      userId: alice.userId,
+      nickname: alice.nickname,
+    })
+
+    window.HTMLElement.prototype.scrollTo = jest.fn()
+
+    renderComponent(
+      <>
+        <Channel />
+      </>,
+      store
+    )
+
+    await act(async () => {
+      store.dispatch(network.actions.addInitializedCommunity(community.id))
+    })
+
+    // The channel starts out empty - this is the exact case from the bug report
+    expect(publicChannels.selectors.currentChannelMessages(store.getState()).length).toBe(0)
+
+    const messageInput = screen.getByTestId('messageInput')
+
+    await userEvent.type(messageInput, ' ')
+    // Guard against the input silently swallowing the keystroke
+    expect((messageInput as HTMLTextAreaElement).value).toBe(' ')
+
+    await userEvent.type(messageInput, '{enter}')
+
+    await act(async () => {})
+
+    expect(publicChannels.selectors.currentChannelMessages(store.getState())).toEqual([])
+    expect(Object.values(publicChannels.selectors.currentChannelMessagesMergedBySender(store.getState())).length).toBe(
+      0
+    )
+  })
+
+  it('still sends a message that only looks blank but has content', async () => {
+    const { store } = await prepareStore(
+      {},
+      socket // Fork state manager's sagas
+    )
+
+    const factory = await getReduxStoreFactory(store)
+
+    const community = await factory.create('Community')
+
+    const alice = await factory.create('Identity', {
+      communityId: community.id,
+    })
+    await factory.create('UserProfile', {
+      userId: alice.userId,
+      nickname: alice.nickname,
+    })
+
+    window.HTMLElement.prototype.scrollTo = jest.fn()
+
+    renderComponent(
+      <>
+        <Channel />
+      </>,
+      store
+    )
+
+    await act(async () => {
+      store.dispatch(network.actions.addInitializedCommunity(community.id))
+    })
+
+    const messageInput = screen.getByTestId('messageInput')
+
+    // Four leading spaces are markdown-significant (code block) and must survive
+    await userEvent.type(messageInput, '    hi')
+    expect((messageInput as HTMLTextAreaElement).value).toBe('    hi')
+
+    await userEvent.type(messageInput, '{enter}')
+
+    await act(async () => {})
+
+    const sent = publicChannels.selectors.currentChannelMessages(store.getState())
+    expect(sent.length).toBe(1)
+    expect(sent[0].message).toBe('    hi')
+  })
+
   it("shows incoming message if it's not older than oldest message, and isn't the newest one", async () => {
     const { store, runSaga } = await prepareStore(
       {},

--- a/packages/mobile/src/screens/Channel/Channel.screen.tsx
+++ b/packages/mobile/src/screens/Channel/Channel.screen.tsx
@@ -147,7 +147,9 @@ export const ChannelScreen: FC = () => {
 
   const sendMessageAction = React.useCallback(
     async (message: string) => {
-      if (message) {
+      // Whitespace-only input has nothing to send, but any attached files below
+      // still go out.
+      if (message.trim()) {
         dispatch(messages.actions.sendMessage({ message }))
       }
       // Attach files, then send corresponding message (contaning cid) for each of them

--- a/packages/mobile/src/tests/channel.sendMessage.test.tsx
+++ b/packages/mobile/src/tests/channel.sendMessage.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import '@testing-library/jest-native/extend-expect'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native'
+import { EmitterSubscription, Keyboard, KeyboardEventName } from 'react-native'
+import MockedSocket from 'socket.io-mock'
+import { Task } from 'redux-saga'
+import { FactoryGirl } from 'factory-girl'
+import { getReduxStoreFactory, publicChannels } from '@quiet/state-manager'
+import { MessageType } from '@quiet/types'
+import { DateTime } from 'luxon'
+import { ioMock } from '../setupTests'
+import { prepareStore } from './utils/prepareStore'
+import { renderComponent } from './utils/renderComponent'
+import { ChannelScreen } from '../screens/Channel/Channel.screen'
+import { initSelectors } from '../store/init/init.selectors'
+import { Store } from '../store/store.types'
+
+// Chat.component defers the actual send by 50ms so iOS can commit a pending autocorrection
+const AUTOCORRECT_COMMIT_DELAY = 50
+
+// Mobile already trims the input inside Chat.component before it reaches this screen,
+// so these tests pin the end-to-end invariant rather than reproduce #2778 - the drop
+// itself now lives in the shared state-manager sendMessage saga, which both platforms
+// go through.
+describe('Sending a message from a channel', () => {
+  let socket: MockedSocket
+  let root: Task | null = null
+  let keyboardListeners: Record<string, () => void> = {}
+
+  beforeEach(() => {
+    socket = new MockedSocket()
+    ioMock.mockImplementation(() => socket)
+    keyboardListeners = {}
+    // The send button only renders once the keyboard is up, and the react-native jest
+    // preset never delivers keyboard events, so capture the listeners and call them.
+    jest.spyOn(Keyboard, 'addListener').mockImplementation((event: KeyboardEventName, handler) => {
+      keyboardListeners[event] = handler as () => void
+      return { remove: jest.fn() } as unknown as EmitterSubscription
+    })
+  })
+
+  afterEach(() => {
+    // Always stop the state-manager sagas - a failed assertion would otherwise leave
+    // them running and hang jest.
+    root?.cancel()
+    root = null
+    jest.restoreAllMocks()
+  })
+
+  const renderChannel = async (): Promise<Store> => {
+    const prepared = await prepareStore({}, socket)
+    root = prepared.root
+    const store = prepared.store
+
+    const factory: FactoryGirl = await getReduxStoreFactory(store)
+
+    const community = await factory.create('Community')
+    const alice = await factory.create('Identity', { communityId: community.id })
+    await factory.create('UserProfile', { userId: alice.userId, nickname: alice.nickname })
+
+    // A freshly created channel is not literally empty - it holds the "created this
+    // channel" info message. Mobile renders a loading state (and no input at all)
+    // until a channel has at least one message, so seed that info message here.
+    const channelId = publicChannels.selectors.currentChannelId(store.getState())
+    await factory.create('TestMessage', {
+      message: {
+        id: 'channel-created',
+        type: MessageType.Info,
+        message: `@${alice.nickname} created #general`,
+        createdAt: DateTime.utc().valueOf(),
+        channelId,
+        userId: alice.userId,
+        verified: true,
+      },
+      verifyAutomatically: true,
+    })
+
+    renderComponent(<ChannelScreen />, store)
+
+    // Sending is only enabled once the (mocked) websocket reports a connection
+    await waitFor(() => expect(initSelectors.isWebsocketConnected(store.getState())).toBe(true), { timeout: 5000 })
+
+    act(() => {
+      keyboardListeners.keyboardDidShow?.()
+    })
+
+    return store
+  }
+
+  const send = async (text: string) => {
+    fireEvent.changeText(screen.getByTestId('input'), text)
+    fireEvent.press(screen.getByTestId('send_message_button'))
+    // Let the deferred send fire and the state-manager saga run
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, AUTOCORRECT_COMMIT_DELAY * 4))
+    })
+  }
+
+  // https://github.com/TryQuiet/quiet/issues/2778
+  test('a whitespace-only message is not sent from a fresh channel', async () => {
+    const store = await renderChannel()
+
+    const before = publicChannels.selectors.currentChannelMessages(store.getState())
+    expect(before.map(message => message.type)).toEqual([MessageType.Info])
+
+    await send(' ')
+
+    // Nothing new arrived - the blank message was dropped
+    expect(publicChannels.selectors.currentChannelMessages(store.getState())).toEqual(before)
+  })
+
+  test('a message with content is still sent', async () => {
+    const store = await renderChannel()
+
+    await send('hello')
+
+    const sent = publicChannels.selectors
+      .currentChannelMessages(store.getState())
+      .filter(message => message.type === MessageType.Basic)
+    expect(sent.length).toBe(1)
+    expect(sent[0].message).toBe('hello')
+  })
+})

--- a/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.test.ts
+++ b/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.test.ts
@@ -208,4 +208,103 @@ describe('sendMessageSaga', () => {
       ])
       .run()
   })
+
+  // https://github.com/TryQuiet/quiet/issues/2778 - a text message that is only
+  // whitespace must never be broadcast or shown in the channel.
+  test('drops a whitespace-only text message', async () => {
+    const reducer = combineReducers(testReducers)
+    await expectSaga(sendMessageSaga, socket as unknown as Socket, messagesActions.sendMessage({ message: ' ' }))
+      .withReducer(reducer)
+      .withState(store.getState())
+      .provide([
+        [call.fn(generateMessageId), 'whitespace-only'],
+        [call.fn(getCurrentTime), 1],
+      ])
+      // The saga bails out before it does any work at all
+      .not.call.fn(generateMessageId)
+      .not.put.actionType(messagesActions.addMessagesSendingStatus.type)
+      .not.put.actionType(messagesActions.addMessages.type)
+      .run()
+  })
+
+  test('drops a text message made only of newlines and tabs', async () => {
+    const reducer = combineReducers(testReducers)
+    await expectSaga(sendMessageSaga, socket as unknown as Socket, messagesActions.sendMessage({ message: '\n\t  \n' }))
+      .withReducer(reducer)
+      .withState(store.getState())
+      .provide([
+        [call.fn(generateMessageId), 'whitespace-only-2'],
+        [call.fn(getCurrentTime), 1],
+      ])
+      .not.call.fn(generateMessageId)
+      .not.put.actionType(messagesActions.addMessages.type)
+      .run()
+  })
+
+  test('sends surrounding whitespace verbatim when the message has content', async () => {
+    // Leading whitespace is markdown-significant (four spaces open a code block),
+    // so message content is never trimmed - only fully blank messages are dropped.
+    const currentChannel = currentChannelId(store.getState())
+    const message = '    const x = 1  '
+    const channelMessage = await baseTypesFactory.build<ChannelMessage>('ChannelMessage', {
+      userId: alice.userId,
+      channelId: currentChannel,
+      message,
+    })
+
+    const reducer = combineReducers(testReducers)
+    await expectSaga(sendMessageSaga, socket as unknown as Socket, messagesActions.sendMessage({ message }))
+      .withReducer(reducer)
+      .withState(store.getState())
+      .provide([
+        [call.fn(generateMessageId), channelMessage.id],
+        [call.fn(getCurrentTime), channelMessage.createdAt],
+      ])
+      .apply(socket, socket.emit, applyEmitParams(SocketActions.SEND_MESSAGE, channelMessage))
+      .run()
+  })
+
+  test('sends an uploaded file message even though its text is empty', async () => {
+    const currentChannel = currentChannelId(store.getState())
+    if (!currentChannel) {
+      throw new Error('no currentChannel')
+    }
+
+    const messageId = 'uploaded-file-message'
+    const media: FileMetadata = {
+      cid: 'QmUploadedFileCid',
+      path: null,
+      name: 'file',
+      ext: '.ext',
+      message: {
+        id: messageId,
+        channelId: currentChannel,
+      },
+    }
+
+    const expectedMessage: ChannelMessage = {
+      id: messageId,
+      userId: alice.userId,
+      type: MessageType.Basic,
+      message: '',
+      createdAt: 8,
+      channelId: currentChannel,
+      media,
+    }
+
+    const reducer = combineReducers(testReducers)
+    await expectSaga(
+      sendMessageSaga,
+      socket as unknown as Socket,
+      messagesActions.sendMessage({ message: '', id: messageId, media })
+    )
+      .withReducer(reducer)
+      .withState(store.getState())
+      .provide([
+        [call.fn(generateMessageId), messageId],
+        [call.fn(getCurrentTime), 8],
+      ])
+      .apply(socket, socket.emit, applyEmitParams(SocketActions.SEND_MESSAGE, expectedMessage))
+      .run()
+  })
 })

--- a/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.ts
+++ b/packages/state-manager/src/sagas/messages/sendMessage/sendMessage.saga.ts
@@ -17,6 +17,19 @@ export function* sendMessageSaga(
   action: PayloadAction<ReturnType<typeof messagesActions.sendMessage>['payload']>
 ): Generator {
   const payload = action.payload as ReturnType<typeof messagesActions.sendMessage>['payload']
+
+  // A plain text message holding nothing but whitespace has nothing to deliver,
+  // so drop it instead of broadcasting a blank message. Image and file messages
+  // are exempt: they legitimately carry empty text alongside their media, as do
+  // the Info messages the app generates itself. Note that we only test for
+  // blankness and never trim the content we send, because leading whitespace is
+  // markdown-significant (four spaces start a code block).
+  const isPlainTextMessage = (payload.type ?? MessageType.Basic) === MessageType.Basic && payload.media == null
+  if (isPlainTextMessage && (payload.message ?? '').trim().length === 0) {
+    logger.warn('Not sending message - it has no content')
+    return
+  }
+
   const generatedMessageId = yield* call(generateMessageId)
   const id = payload.id || generatedMessageId
   let identity = yield* select(identitySelectors.currentIdentity)


### PR DESCRIPTION
Fixes #2778

## What

No first-message code path exists: both screens guarded with a bare truthiness check a single space satisfies, and the shared saga broadcast whatever it got. 'First message only' is VISIBILITY — messages merge by sender within 300 s and only a group's first message draws avatar/nickname/timestamp; a fresh channel forces the first user message to open a group, so the blank one renders fully dressed. Fix: drop whitespace-only Basic messages without media in the shared sendMessage saga (desktop + mobile identical), tighten both UI guards to match, never trim content (leading spaces are markdown-significant), info/image/file messages exempt.

## Evidence

2 saga tests + desktop rtl test red on unmodified code (the store literally receives message ' '); mobile test is a regression guard only — mobile already trims for an iOS autocorrect workaround, which is exactly why the fix belongs in the shared saga (stated plainly). state-manager 201/201, desktop 270 passed with the known failure, mobile 149/149. Lead re-ran 8/8, 18/20 (2 skipped), 2/2 and confirmed the rebuilt lib carries the guard. Reviewers must `npm run build` in state-manager first.

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Touches `packages/state-manager`: run `npm run build` there before running desktop/mobile suites.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2778.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
