### PR TITLE
Say invite link, not invitation code, in join errors (#2441)

### DIFF
--- a/packages/desktop/src/renderer/forms/fieldsErrors.ts
+++ b/packages/desktop/src/renderer/forms/fieldsErrors.ts
@@ -13,7 +13,7 @@ export enum CommunityNameErrors {
 }
 
 export enum InviteLinkErrors {
-  InvalidCode = 'Please check your invitation code and try again',
+  InvalidCode = 'Please check your invite link and try again',
 }
 
 export enum ChannelNameErrors {

--- a/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
+++ b/packages/mobile/src/components/JoinCommunity/JoinCommunity.component.tsx
@@ -54,7 +54,7 @@ export const JoinCommunity: FC<JoinCommunityProps> = ({
 
     if (!submitValue) {
       setLoading(false)
-      setInputError('Please check your invitation code and try again')
+      setInputError('Please check your invite link and try again')
       return
     }
 

--- a/packages/mobile/src/components/JoinCommunity/__tests__/JoinCommunity.test.tsx
+++ b/packages/mobile/src/components/JoinCommunity/__tests__/JoinCommunity.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react-native'
 import { renderComponent } from '../../../utils/functions/renderComponent/renderComponent'
 import { JoinCommunity } from '../JoinCommunity.component'
 
@@ -19,5 +20,22 @@ describe('JoinCommunity component', () => {
       />
     )
     expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('shows an invite link error when the pasted value cannot be parsed', () => {
+    const joinCommunityAction = jest.fn()
+    const { getByPlaceholderText, getByTestId, getByText } = renderComponent(
+      <JoinCommunity
+        joinCommunityAction={joinCommunityAction}
+        redirectionAction={jest.fn()}
+        hasReceivedResponse={false}
+      />
+    )
+
+    fireEvent.changeText(getByPlaceholderText('Invite link'), 'nqnw4kc4c77fb47lk52m5l57h4tc')
+    fireEvent.press(getByTestId('button'))
+
+    expect(getByText('Please check your invite link and try again')).toBeTruthy()
+    expect(joinCommunityAction).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #2441

## What

Both remaining user-facing strings now read 'Please check your invite link and try again' (desktop fieldsErrors enum + mobile JoinCommunity). Added the only regression test either platform has for this wording. Flagged a near-duplicate 'invitation link' string in common/const.ts as a follow-up, deliberately untouched.

## Evidence

Cypress before/after of the desktop join screen (the 'before' shows label 'Paste your invite link' above error 'invitation code'). Desktop 95/96 identical before/after; lead re-ran the mobile test after fixing a worktree snapshot-path artifact.

### Screenshots

**desktop-after**

![2441-desktop-after.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2441/2441-desktop-after.png)

**desktop-before**

![2441-desktop-before.png](https://raw.githubusercontent.com/TryQuiet/quiet/lhf/pr-evidence/2441/2441-desktop-before.png)

## Reviewer notes

- Based on `origin/develop @ 1ed08d8fb`, 1 commit; rebase before merge.
- Mobile: verified with jest/RNTL only (no device in the swarm environment); the on-device check is in the reviewer checklist.
- CHANGELOG entry intentionally not added yet — this is one of ~20 concurrent drafts; add on merge to avoid a 20-way conflict.
- Full report with suite logs: local review bundle `lhf/review/issue-2441.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShqjxQtKsjo2AkvF7eGQ2Q
