### PR TITLE
Meta: RN, mobile testing, desktop upgrades and small-fix PRs

### DIFF
--- a/docs/10.0-upgrade-stack-summary.md
+++ b/docs/10.0-upgrade-stack-summary.md
@@ -1,6 +1,6 @@
 # Quiet 10.0 upgrade, testing and update-signing PR stacks
 
-Verified against GitHub using `gh-org` at **2026-09-11 18:47 UTC**. This summary covers the session from the initial request to restack #3422 on `10.0.0`, through multiplayer and notification tests, publication of the remaining workflow commits, and the other agent's Electron/packaging/update-signing stack. Seven Quiet PRs form two tracks sharing #3422; two related PRs provide SDK and authentication work. The published heads are listed below; test status and outstanding work are recorded separately. The other agent's validation is attributed to its published PR descriptions; those native test suites were not rerun for this document.
+Verified against GitHub using `gh-org` at **2026-09-11 18:55 UTC**. This summary covers the session from the initial request to restack #3422 on `10.0.0`, through multiplayer and notification tests, publication of the remaining workflow commits, the other agent's Electron/packaging/update-signing stack, and the 22 published fixes from the local tracker. Seven Quiet PRs form two tracks sharing #3422; two related PRs provide SDK and authentication work. The published heads are listed below; test status and outstanding work are recorded separately. The other agent's validation is attributed to its published PR descriptions; those native test suites were not rerun for this document.
 
 ## Stack and merge order
 
@@ -29,7 +29,7 @@ Review and merge parents before children: **#3422 → #3423 → #3483** for mobi
 | [quiet#3482](https://github.com/TryQuiet/quiet/pull/3482) | `upgrade/electron-44` | `upgrade/react-native-081` | [7b81e19aa](https://github.com/TryQuiet/quiet/commit/7b81e19aaabd83e12e57868d1f5c884b3f2b6ff0) | Open; pushed |
 | [quiet#3484](https://github.com/TryQuiet/quiet/pull/3484) | `upgrade/electron-builder-26` | `upgrade/electron-44` | [a1d103642](https://github.com/TryQuiet/quiet/commit/a1d10364247eae90c7e0b8f328014dc601579f3b) | Open, draft; pushed |
 | [quiet#3485](https://github.com/TryQuiet/quiet/pull/3485) | `fix/desktop-update-signing` | `upgrade/electron-builder-26` | [8f33f2852](https://github.com/TryQuiet/quiet/commit/8f33f2852017435bad25532779acd79cc0a6d46a) | Open, draft; pushed |
-| [quiet#3487](https://github.com/TryQuiet/quiet/pull/3487) | `docs/tuf-deployment-proposal` | `fix/desktop-update-signing` | [4509613ef](https://github.com/TryQuiet/quiet/commit/4509613eff0f7a3e20ea200e412ac3c2d94cdb4a) | Open, draft; pushed |
+| [quiet#3487](https://github.com/TryQuiet/quiet/pull/3487) | `docs/tuf-deployment-proposal` | `fix/desktop-update-signing` | [c007ceac3](https://github.com/TryQuiet/quiet/commit/c007ceac397d428d8fede676be0b7b558ed1df29) | Open, draft; pushed |
 | [quiet#3420](https://github.com/TryQuiet/quiet/pull/3420) | `fix/android-api-36-sdk` | `develop` | [854e82692](https://github.com/TryQuiet/quiet/commit/854e82692fbc7c94b66dc07f0418603ededeeb60) | Open; pushed |
 | [auth#35](https://github.com/TryQuiet/auth/pull/35) | `fix/node24-msgpackr` | `main` | [d3fc6d2ca](https://github.com/TryQuiet/auth/commit/d3fc6d2ca0a1bdd5852470584153b9a716427796) | Open; pushed |
 
@@ -90,7 +90,7 @@ The other agent reports [dedicated Linux and native Windows CI passing](https://
 
 ### [Quiet #3487 — Consider operating TUF for desktop updates](https://github.com/TryQuiet/quiet/pull/3487)
 
-Stacked on #3485, this documentation-only proposal records TUF service ownership, hardware signer custody, AWS/GitHub provisioning, native prerelease verification, renewals and recovery responsibilities. It links the setup guide to the adoption proposal. Its nine relative documentation links resolve and the Markdown diff passes whitespace checks; runtime tests were not rerun. Deferring TUF deployment also defers #3485's updater rollout unless that design is separately revised and reviewed. It remains a draft.
+Stacked on #3485, this documentation-only proposal records TUF service ownership, hardware signer custody, AWS/GitHub provisioning, native prerelease verification, renewals and recovery responsibilities. Its latest update records TUF as accepted in principle; provisioning and live release validation still block the rollout, and the existing YubiKey’s PIV support remains unconfirmed. It links the setup guide to the adoption proposal. Its nine relative documentation links resolve and the Markdown diff passes whitespace checks; runtime tests were not rerun. Deferring TUF deployment also defers #3485's updater rollout unless that design is separately revised and reviewed. It remains a draft.
 
 ### [Quiet #3420 — Target Android 16 without the React Native migration](https://github.com/TryQuiet/quiet/pull/3420)
 
@@ -101,6 +101,55 @@ This separate SDK/API 36 PR targets `develop`. Its prerequisites were carried in
 The migration exposed MessagePack 1.10.2's out-of-bounds `Buffer.utf8Write` behavior on Node 24. This companion PR pins all four auth consumers to 1.11.8 and adds six crypto regressions with Unicode and binary payloads. Its CI correction uses pnpm 10.6.0, a frozen lockfile, Node 20/24 and the actual test command.
 
 The previously local, reviewed CI correction **`d3fc6d2ca` is now pushed**; actionlint was rerun before publication. Focused crypto/backend checks pass, but the full auth suite retains **88 failures also reproduced on its baseline**. Green hosted CI is not claimed. Publishing the CI correction did not change Quiet's current auth submodule pin.
+
+## PRs from the local review tracker
+
+The requested [local tracker](http://localhost:8787/) also contains **22 published draft PRs, #3488–#3509**. Each targets `develop` independently; they are siblings, not a 22-level stack, and are not based on the RN/Electron upgrade tracks. Each GitHub head was checked against its local worktree under `/mnt/storage/holmes-worktrees/quiet-lhf-wt/` and matched. Their original base is `1ed08d8fb`; refresh before merging and validate integration with the upgrades.
+
+```text
+develop
+  ├─ #3488 … #3509  (22 independent draft PRs)
+  └─ #3386          (existing contributor Android clipboard fix)
+```
+
+The evidence below comes from the other agent's published PR descriptions and local reports. It was not rerun while compiling this inventory. Several full desktop runs retain a documented baseline failure; mobile component tests do not establish behavior on a device.
+
+| PR | Issue | Change | Reported validation / limit | Verified pushed head |
+| --- | --- | --- | --- | --- |
+| [#3488](https://github.com/TryQuiet/quiet/pull/3488) | #2998 | Make README security caveat prominent | Documentation diff reviewed. | [`f2a1790c8`](https://github.com/TryQuiet/quiet/commit/f2a1790c810df48856bd2d1d3b35d62b81a77589) |
+| [#3489](https://github.com/TryQuiet/quiet/pull/3489) | #2959 | Keep identicon backgrounds light in both themes | Cypress regression failed before the fix; before/after screenshots. | [`ee1cf4ed0`](https://github.com/TryQuiet/quiet/commit/ee1cf4ed0d86f2da4ab00da15e59c3e37e7fcfa4) |
+| [#3490](https://github.com/TryQuiet/quiet/pull/3490) | #1618 | Desktop blank-line rendering regression guard | Five Jest assertions and Cypress pass on existing behavior; test-only. | [`0635cdb32`](https://github.com/TryQuiet/quiet/commit/0635cdb327f431747a235b3b9fb777b6811c5c35) |
+| [#3491](https://github.com/TryQuiet/quiet/pull/3491) | #1592 | Give modal Close buttons accessible names | RTL fails before/passes after; screenshots unchanged. | [`9ad73fb39`](https://github.com/TryQuiet/quiet/commit/9ad73fb392b0a2a9c29dd5d80fce7e3bdde578f9) |
+| [#3492](https://github.com/TryQuiet/quiet/pull/3492) | #2751 | Refresh Today/date markers at local midnight | 11 tests pass, including real selector memo invalidation and rehydration. | [`954f65dfe`](https://github.com/TryQuiet/quiet/commit/954f65dfea5db1e31a5f7ce8998a6d28b694707f) |
+| [#3493](https://github.com/TryQuiet/quiet/pull/3493) | #53 | Prevent idle suspension while desktop backend runs | Four new regressions; main-process suite 20/20. | [`75224f6da`](https://github.com/TryQuiet/quiet/commit/75224f6da1ab75a09b06806f772858f3fcb22fbd) |
+| [#3494](https://github.com/TryQuiet/quiet/pull/3494) | #2103 | Persist and restore desktop window size | Eight new tests; main-process suite 24/24. | [`6e23806f8`](https://github.com/TryQuiet/quiet/commit/6e23806f8f5fc17b70c8bb393b24e6c871368b41) |
+| [#3495](https://github.com/TryQuiet/quiet/pull/3495) | #2953 | Compress profile photos to the 200KB budget | Chromium Cypress 7/7; 48 Jest passes, two skipped. Large PNG/GIF lose transparency/animation. | [`4f52a6383`](https://github.com/TryQuiet/quiet/commit/4f52a63837c1e94466343c9568be89209497b9fe) |
+| [#3496](https://github.com/TryQuiet/quiet/pull/3496) | #1266 | Keep mobile channel previews on one line | Two new regressions; 53 mobile suites, 149 tests pass. | [`3ea6c8a09`](https://github.com/TryQuiet/quiet/commit/3ea6c8a0909f76974bf7196ddd9caccf5bccf1a6) |
+| [#3497](https://github.com/TryQuiet/quiet/pull/3497) | #1618-mobile | Collapse excess mobile message blank lines; preserve code fences | 21 assertions; 54 mobile suites, 168 tests pass. | [`2e13bcd42`](https://github.com/TryQuiet/quiet/commit/2e13bcd42205b44998c2c340506f5cff1e06c612) |
+| [#3498](https://github.com/TryQuiet/quiet/pull/3498) | #2586 | Raise mobile Button minimum height to 50dp | Both variants tested; 54 mobile suites, 150 tests pass. | [`1d06dcf14`](https://github.com/TryQuiet/quiet/commit/1d06dcf1448b703833281d692d302f64052b70da) |
+| [#3499](https://github.com/TryQuiet/quiet/pull/3499) | #1349 | Close Settings when navigation changes the channel | Four tests exercise the real root saga; three fail before the fix. | [`c787b9515`](https://github.com/TryQuiet/quiet/commit/c787b9515fdda182a3c195a6e6728842a7058c3c) |
+| [#3500](https://github.com/TryQuiet/quiet/pull/3500) | #1701 | Decode escaped attachment basenames safely | Common tests 13/13 plus mobile render regression; rebuild common before review. | [`c241d4f67`](https://github.com/TryQuiet/quiet/commit/c241d4f6745ff5c93cd66399faf788492029c2bf) |
+| [#3501](https://github.com/TryQuiet/quiet/pull/3501) | #1086 | Copy mobile text messages on long press | Seven new RNTL tests; 54 mobile suites, 154 tests pass. | [`e777f96c2`](https://github.com/TryQuiet/quiet/commit/e777f96c2e3fb8739b44277f389180203d4f5972) |
+| [#3502](https://github.com/TryQuiet/quiet/pull/3502) | #1495 | Delay row dimming so scrolling does not flash pressed feedback | Three regressions; 54 mobile suites, 153 tests pass. Device motion check remains. | [`5ca469403`](https://github.com/TryQuiet/quiet/commit/5ca469403a1f6a3ac79fbf62d74c9ee0051d87e2) |
+| [#3503](https://github.com/TryQuiet/quiet/pull/3503) | #773 | Search mobile channels by name | Seven new tests; 53 mobile suites, 153 tests pass. Device/design checks remain. | [`4e5b64cf2`](https://github.com/TryQuiet/quiet/commit/4e5b64cf2833fdc06a7cde88bfe4c08c9e5917d7) |
+| [#3504](https://github.com/TryQuiet/quiet/pull/3504) | #1306 | Explain and reject leading-hyphen usernames | Desktop/mobile regressions and Cypress screenshots; leading spaces also rejected after normalization. | [`bc47a432c`](https://github.com/TryQuiet/quiet/commit/bc47a432cdddd13683c52e8f30a33a1016b76f97) |
+| [#3505](https://github.com/TryQuiet/quiet/pull/3505) | #372 | Guard wrapping around long desktop links | Cypress 25/25 across four specs; deliberate break-all fault fails. Test-only. | [`cb0caa29b`](https://github.com/TryQuiet/quiet/commit/cb0caa29b855eb50f7339d80e14c0d7b07d72737) |
+| [#3506](https://github.com/TryQuiet/quiet/pull/3506) | #2655 | Let Android message input shrink after deletion | Two regressions fail before; 53 mobile suites, 150 tests pass. Device validation remains. | [`2b785c676`](https://github.com/TryQuiet/quiet/commit/2b785c6765aa1f7a98dd880eef7a877903b055c6) |
+| [#3507](https://github.com/TryQuiet/quiet/pull/3507) | #1745 | Link visible desktop #channel mentions to their channels | 16 RTL cases plus Cypress; hidden channels, code and URLs preserved. | [`6d2c40566`](https://github.com/TryQuiet/quiet/commit/6d2c4056650a2bfda74f26c6d7f9a598fd21c50d) |
+| [#3508](https://github.com/TryQuiet/quiet/pull/3508) | #2778 | Reject whitespace-only text messages in shared send flow | State-manager 201/201; focused desktop/mobile checks. Rebuild state-manager before review. | [`5765cd7b4`](https://github.com/TryQuiet/quiet/commit/5765cd7b425552f404cf4fa01ba027e350b5b6c2) |
+| [#3509](https://github.com/TryQuiet/quiet/pull/3509) | #2441 | Use invite link consistently in join-error copy | Desktop/mobile wording regressions and desktop Cypress screenshots. | [`932d4dfdf`](https://github.com/TryQuiet/quiet/commit/932d4dfdf98777b2f6ce2702e9bf1868681991a7) |
+
+Three tracker entries intentionally have no new PR:
+
+- **#1319 dock badge:** withdrawn by product decision because it would count bold channels rather than unread messages. Its local implementation is retained and is not proposed for merge.
+- **#2333 sidebar border:** already fixed by [#3184](https://github.com/TryQuiet/quiet/pull/3184); the investigation left no production change.
+- **#3369 Android invite-link copy:** the existing contributor [PR #3386](https://github.com/TryQuiet/quiet/pull/3386) supersedes the local duplicate. The additional local platform-matrix regression tests remain a follow-up pending that PR's merge; they have not been published as a separate PR.
+
+The triage also dropped the duplicate mobile emoji-size work in favor of the existing [#3414](https://github.com/TryQuiet/quiet/pull/3414). Screenshots used by the small-fix PRs are published on the `lhf/pr-evidence` branch; that evidence branch is not an implementation PR.
+
+Thus **31 work PRs are inventoried here** (nine upgrade/dependency PRs plus 22 tracker drafts), with existing superseding PRs linked separately. This meta PR is documentation only and targets `10.0.0`; it does not add an implementation dependency. Proposed changes are pushed; withdrawn and superseded local branches are explicitly accounted for above.
+
+The `mobile upgrades` label groups Quiet #3420, #3422, #3423, #3483 and tracking issue #3013, plus Auth #35: the RN/runtime upgrades and mobile test improvements. The tracker fixes retain their separate small-fix grouping.
 
 ## Publication and working copies
 
@@ -117,7 +166,7 @@ The Android agent's `test/android-qss-multiplayer` branch has **no separate PR**
 1. Enable `TryQuiet/quiet` to receive the organization secrets `QSS_AWS_ACCESS_KEY_ID` and `QSS_AWS_SECRET_ACCESS_KEY`. CI receives empty values. They are needed to retrieve `DEV_FIREBASE_ANDROID_PRIVATE_KEY` and `DEV_FIREBASE_IOS_PRIVATE_KEY` from QSS's development AWS Secrets Manager configuration. Native client configs decrypt successfully; `ANDROID_FIREBASE_KEY` and `IOS_FIREBASE_KEY` are decryption passphrases, not push-sending credentials. No secret values need to be shared in this document or chat.
 2. Finish the Android CI desktop-creation diagnosis using the new reporter. Local Appium onboarding passes; hosted onboarding has not yet been established as passing.
 3. Run iOS Appium when a Mac runner is available, then verify provider delivery, extension activation and taps. The queue snapshot at 17:28 UTC showed five running and 31 queued Mac jobs. The attached Mac's full app build previously stopped at its free-disk guard.
-4. For the desktop track, decide on and provision the TUF service and approved roots described by #3485/#3487, then validate native production signing and notarization. The production update gate remains in place.
+4. For the desktop track, finish provisioning the TUF service and approved roots described by #3485/#3487, then validate native production signing and notarization. The production update gate remains in place.
 5. Review and merge both tracks from the bottom up, using their separate local/native, hosted and provider evidence, and validate the combined mobile/desktop stack.
 
 Current attempts are linked from [#3483](https://github.com/TryQuiet/quiet/pull/3483) and the [Android](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-e2e.yml) / [iOS](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-ios.yml) workflow pages. This document is a dated snapshot rather than a live CI feed.

--- a/docs/10.0-upgrade-stack-summary.md
+++ b/docs/10.0-upgrade-stack-summary.md
@@ -1,0 +1,125 @@
+# Quiet 10.0 upgrade, testing and update-signing PR stacks
+
+Verified against GitHub using `gh-org` at **2026-09-11 18:47 UTC**. This summary covers the session from the initial request to restack #3422 on `10.0.0`, through multiplayer and notification tests, publication of the remaining workflow commits, and the other agent's Electron/packaging/update-signing stack. Seven Quiet PRs form two tracks sharing #3422; two related PRs provide SDK and authentication work. The published heads are listed below; test status and outstanding work are recorded separately. The other agent's validation is attributed to its published PR descriptions; those native test suites were not rerun for this document.
+
+## Stack and merge order
+
+```text
+Quiet: 10.0.0
+  └─ #3422  upgrade/react-native-081
+       ├─ #3423  upgrade/react-native-new-architecture-node
+       │    └─ #3483  docs/qss-notification-regression-plan
+       └─ #3482  upgrade/electron-44
+            └─ #3484  upgrade/electron-builder-26
+                 └─ #3485  fix/desktop-update-signing
+                      └─ #3487  docs/tuf-deployment-proposal
+
+Related work outside that sequence:
+  Quiet #3420 → develop   SDK/API 36 prerequisites carried into #3422
+  Auth  #35   → main      Node 24 MessagePack compatibility
+```
+
+Review and merge parents before children: **#3422 → #3423 → #3483** for mobile/testing, and **#3422 → #3482 → #3484 → #3485 → #3487** for desktop/update signing. After merging a parent, verify that GitHub retargets its child to `10.0.0` and that the child diff contains only its own changes. The two tracks share #3422 but do not currently include each other's descendants; combined New Architecture/Electron integration still needs validation. #3420 is the standalone SDK alternative, not another required stack level. Auth#35 lives in a separate repository. All nine PRs remain open; the table identifies drafts.
+
+| PR | Published head branch | PR base | Verified head commit | Status |
+| --- | --- | --- | --- | --- |
+| [quiet#3422](https://github.com/TryQuiet/quiet/pull/3422) | `upgrade/react-native-081` | `10.0.0` | [631ae3511](https://github.com/TryQuiet/quiet/commit/631ae351105762e6fc883f33d30fa33f853e6c73) | Open, draft; pushed |
+| [quiet#3423](https://github.com/TryQuiet/quiet/pull/3423) | `upgrade/react-native-new-architecture-node` | `upgrade/react-native-081` | [77a075181](https://github.com/TryQuiet/quiet/commit/77a07518137928ffa5208f99bc190044550ce0ac) | Open, draft; pushed |
+| [quiet#3483](https://github.com/TryQuiet/quiet/pull/3483) | `docs/qss-notification-regression-plan` | `upgrade/react-native-new-architecture-node` | [442aedcb3](https://github.com/TryQuiet/quiet/commit/442aedcb37d253981b1fe088b9ddb07d8f37bedb) | Open; pushed |
+| [quiet#3482](https://github.com/TryQuiet/quiet/pull/3482) | `upgrade/electron-44` | `upgrade/react-native-081` | [7b81e19aa](https://github.com/TryQuiet/quiet/commit/7b81e19aaabd83e12e57868d1f5c884b3f2b6ff0) | Open; pushed |
+| [quiet#3484](https://github.com/TryQuiet/quiet/pull/3484) | `upgrade/electron-builder-26` | `upgrade/electron-44` | [a1d103642](https://github.com/TryQuiet/quiet/commit/a1d10364247eae90c7e0b8f328014dc601579f3b) | Open, draft; pushed |
+| [quiet#3485](https://github.com/TryQuiet/quiet/pull/3485) | `fix/desktop-update-signing` | `upgrade/electron-builder-26` | [8f33f2852](https://github.com/TryQuiet/quiet/commit/8f33f2852017435bad25532779acd79cc0a6d46a) | Open, draft; pushed |
+| [quiet#3487](https://github.com/TryQuiet/quiet/pull/3487) | `docs/tuf-deployment-proposal` | `fix/desktop-update-signing` | [4509613ef](https://github.com/TryQuiet/quiet/commit/4509613eff0f7a3e20ea200e412ac3c2d94cdb4a) | Open, draft; pushed |
+| [quiet#3420](https://github.com/TryQuiet/quiet/pull/3420) | `fix/android-api-36-sdk` | `develop` | [854e82692](https://github.com/TryQuiet/quiet/commit/854e82692fbc7c94b66dc07f0418603ededeeb60) | Open; pushed |
+| [auth#35](https://github.com/TryQuiet/auth/pull/35) | `fix/node24-msgpackr` | `main` | [d3fc6d2ca](https://github.com/TryQuiet/auth/commit/d3fc6d2ca0a1bdd5852470584153b9a716427796) | Open; pushed |
+
+Git ancestry checks confirm the parent-child relationships shown above, including the current `10.0.0` tip beneath #3422. GitHub's PR base fields match both tracks.
+
+## PR summaries, from the beginning
+
+### [Quiet #3422 — Migrate mobile to React Native 0.81 for Android 16](https://github.com/TryQuiet/quiet/pull/3422)
+
+This existing PR was the starting point of the session. It upgrades mobile to React Native 0.81.5, React 19.1 and Hermes, retains target API 36, and incorporates SDK prerequisites from #3420. It includes navigation, Metro resolution, keyboard behavior, native dependency and iOS simulator compatibility work. It retains the old bridge architecture and embedded Node 18.20.4; #3423 changes those.
+
+Session work restacked it on `10.0.0`, preserving security/recovery fixes and resolving attachment-test expectations around explicit channel routing. Recorded restack validation: **62 active mobile Jest suites, 181 tests and 44 snapshots**, passing TypeScript/lint, 14 Metro/CLI/Promise checks, six classic-level checks and 20 guarded Tor-builder checks. Native device builds were not rerun specifically for that merge.
+
+The original CI investigation found desktop multiplayer failures: Tor delays exhausted join deadlines; an old auth pin could reconstruct duplicate invitee registrations and reject acceptance with `ADMIT_MEMBER_LINK_MISSING`; macOS also hit a stale Selenium element and synchronization timeouts. The new base contained admission retry/uniqueness fixes. A fully green cross-platform CI run was not established.
+
+### [Quiet #3423 — Enable React Native New Architecture and upgrade mobile Node to 24](https://github.com/TryQuiet/quiet/pull/3423)
+
+This existing child PR enables Fabric and bridgeless React Native on Android and iOS, upgrades embedded mobile Node to pinned 24.18.0, and adapts native events, bridge calls, Config/Share code generation and Screens. Host build Node and desktop Node are separate runtimes. The mobile runtime is a pinned community prerelease, not an independently reproduced binary.
+
+It supplies the QSS E2E foundation: a pinned local QSS/Postgres/Redis fixture with real hCaptcha test-key verification, iOS one-player onboarding/message/restart coverage, and shared desktop Selenium selectors. Recorded native validation includes **iOS QSS one-player 1/1**, **desktop+iOS multiplayer 6/6 stages**, and **iOS baseline 26/26**. Mixed tests check exact text and author, offline retrieval in both directions, and restart persistence. Private channels, attachments, cancellation and long paginated histories remain gaps relative to desktop coverage.
+
+This session refreshed it onto the updated #3422. During this inventory, **four previously unpublished iOS workflow commits were ported onto the current parent and pushed**, preserving the base's submodule checkout token. The manual iOS workflow runs baseline, one-player QSS and mixed desktop/iOS tests sequentially. The **11 workflow routing tests and four CI helper tests** pass after the restack; actionlint and repository concurrency checks pass. Hosted execution of this manual workflow remains unvalidated.
+
+### [Quiet #3483 — Test mobile QSS notifications with Appium and native regressions](https://github.com/TryQuiet/quiet/pull/3483)
+
+This is the new PR created in this session, stacked on #3423. It began as a regression plan, then became executable tests when actual tests were requested. Its branch still contains `docs/` in the name; the current PR includes native tests, multiplayer support and Appium CI workflows.
+
+- **Android multiplayer:** six Detox messaging/offline/restart stages passed in **206.98 seconds** with an explicit QSS-only backend. Tor metadata is simulated, P2P and push are disabled, and the Android emulator communicates with a real desktop peer through QSS.
+- **Android native notifications:** **13/13 passed**, exercising production receiver code, native storage, authenticated HTTP responses, signature verification, decryption and OS posting. Controlled wakeups/server responses cover cursor races, duplicates, retry, named channels, author filtering and leave/re-enrollment. A deliberate stale-cursor fault caused the expected regression failure. These tests do not establish FCM transport.
+- **iOS native notifications:** **34/34 passed** on the attached Mac: 21 authenticator, five NSE auth/fetch/decrypt/render and eight background lifecycle tests. Hostless notification tests are separated from tests requiring the full app.
+- **Fast state checks:** eight notification/token and leave-cleanup Jest tests pass. Messaging stays in Detox. No RN-for-web/Cypress mobile notification suite was added.
+- **Appium on both platforms:** two provider journeys cover fresh join → background notification → tap, and named-channel notification → the correct conversation while another channel is selected. They require a real desktop sender, QSS/QPS, FCM or FCM/APNs, the native receiver/extension and actual OS notification UI. There is no injected-notification fallback for a provider pass.
+- **Android Appium onboarding:** the separate push-disabled fresh enrollment and peer-message journey passes locally, most recently in **55.977 seconds** on Node 20.20.1, including cleanup and the CI failure reporter.
+
+CI now has independent onboarding/provider lanes, credential checks, Linux/macOS QSS fixtures, a pinned Tor simulator source build, and safe result/error artifacts. Fixes include missing runner tools, the hosted Xcode path, Tor's undeclared generated version header, simulator entitlement placement and a reproduced Fluxbox shutdown-order abort. The [latest completed Android attempt](https://github.com/TryQuiet/quiet/actions/runs/34632147149) reached a healthy QSS fixture but failed with `TimeoutError` while creating the desktop community, before mobile startup. Its safe report confirmed that both the display and window manager were still alive; the exact timed-out desktop wait remains to be identified.
+
+The iOS helper links XML/DER capabilities into simulator executables and uses empty host signing entitlements, matching Xcode's simulator behavior. A UIKit probe using the helper-generated capabilities launched and registered with real APNs. That proves registration setup only; it is not a Quiet delivery or Appium pass.
+
+**No complete real FCM/APNs notification loop has passed yet, and no Quiet iOS Appium UI journey has been validated.** Private-channel notification taps, server token tombstones, process-death delivery, quick reply and hardware power-management behavior are outside these two journeys.
+
+### [Quiet #3482 — Upgrade desktop to Electron 44 on the React Native 0.81 stack](https://github.com/TryQuiet/quiet/pull/3482)
+
+This is the other agent's first PR, stacked directly on #3422. It upgrades desktop from Electron 32 to 44.3.0, matches ChromeDriver, and moves the host toolchain to Node 24.21.0 with npm 10.8.2. Clipboard/context-menu and DevTools APIs are updated, and the minimum macOS version becomes 13. It also fixes CAPTCHA retry ordering, splash/stale-element handling, premature Tor restarts and replication recovery across delayed membership synchronization.
+
+The published PR records **60 packaged single-player tests**, **131 packaged QSS multiplayer data/onboarding tests**, **24 direct libp2p cases across nine suites**, and **287 desktop Jest tests / 127 snapshots** passing. Native Electron database/clipboard checks, final AppImage smoke and focused harness/backend tests also pass. Eight Tor-presence checks were excluded from the QSS totals. One full live-Tor run passed 79/82; full Tor-suite success is not claimed.
+
+### [Quiet #3484 — Upgrade desktop packaging to electron-builder 26](https://github.com/TryQuiet/quiet/pull/3484)
+
+Stacked on #3482, this upgrades electron-builder to 26.15.3, migrates Windows signing to `signtoolOptions`, rebuilds msgpackr-extract in Node-API mode, and preserves the Linux launcher's sandbox behavior. Linux preload customization now happens before squashfs/blockmap generation. Production `electron-store` and existing PKIJS dependencies are retained.
+
+Its published validation includes passing main/renderer builds, **nine launcher/hook tests**, a forced native rebuild and Unicode round-trip in Electron, artifact dependency/hash/blockmap checks, and packaged startup E2E. The artifact test reproduced the missing `electron-store` failure before the fix. Native Windows/macOS packaging and signing still need validation; this PR remains a draft.
+
+### [Quiet #3485 — Authenticate desktop updates and modernize signing tooling](https://github.com/TryQuiet/quiet/pull/3485)
+
+Stacked on #3484, this authenticates Linux/Windows update manifests with TUF before download and rechecks authorization and the cached installer before installation. Windows additionally requires the configured publisher subject and OS Authenticode validation. It upgrades updater/notarization tooling, stages immutable artifacts, binds publication to a successful release build/tag, and adds KMS/OIDC provisioning and bootstrap-root setup guidance.
+
+The other agent reports [dedicated Linux and native Windows CI passing](https://github.com/TryQuiet/quiet/actions/runs/34627120752), including real Authenticode and cached/downloaded installer execution. **46 updater/release/provisioning tests and nine launcher tests**, builds, a fresh AppImage smoke and CloudFormation lint pass. This is still a draft: production Linux/Windows builds intentionally fail until approved TUF roots and repository URLs are committed. Live IAM/OIDC/KMS authorization, operational signing/metadata publication, production Windows signing and macOS notarization remain to be validated. Older clients receive TUF protection only after the transition release.
+
+### [Quiet #3487 — Consider operating TUF for desktop updates](https://github.com/TryQuiet/quiet/pull/3487)
+
+Stacked on #3485, this documentation-only proposal records TUF service ownership, hardware signer custody, AWS/GitHub provisioning, native prerelease verification, renewals and recovery responsibilities. It links the setup guide to the adoption proposal. Its nine relative documentation links resolve and the Markdown diff passes whitespace checks; runtime tests were not rerun. Deferring TUF deployment also defers #3485's updater rollout unless that design is separately revised and reviewed. It remains a draft.
+
+### [Quiet #3420 — Target Android 16 without the React Native migration](https://github.com/TryQuiet/quiet/pull/3420)
+
+This separate SDK/API 36 PR targets `develop`. Its prerequisites were carried into #3422. It belongs in the dependency/context inventory but is outside the two `10.0.0` tracks. Its existing published branch was verified; no new changes or validation run are claimed for it during this inventory.
+
+### [Auth #35 — Fix MessagePack serialization on Node 24](https://github.com/TryQuiet/auth/pull/35)
+
+The migration exposed MessagePack 1.10.2's out-of-bounds `Buffer.utf8Write` behavior on Node 24. This companion PR pins all four auth consumers to 1.11.8 and adds six crypto regressions with Unicode and binary payloads. Its CI correction uses pnpm 10.6.0, a frozen lockfile, Node 20/24 and the actual test command.
+
+The previously local, reviewed CI correction **`d3fc6d2ca` is now pushed**; actionlint was rerun before publication. Focused crypto/backend checks pass, but the full auth suite retains **88 failures also reproduced on its baseline**. Green hosted CI is not claimed. Publishing the CI correction did not change Quiet's current auth submodule pin.
+
+## Publication and working copies
+
+- #3422: `/mnt/storage/holmes-worktrees/quiet-pr3422-10.0.0`, local branch `fix/pr3422-on-10.0.0`, published to `upgrade/react-native-081`.
+- #3423: `/mnt/storage/holmes-worktrees/quiet-pr3423-publish`, local branch `publish/pr3423-ci-workflows`, published to `upgrade/react-native-new-architecture-node`. It contains the current base and all four previously local workflow changes. The older `quiet-rn-newarch` checkout remains available.
+- #3483: `/mnt/storage/holmes-worktrees/quiet-qss-notification-plan`, branch `docs/qss-notification-regression-plan`, refreshed on the published #3423 head.
+- The other agent's published branches are `upgrade/electron-44` (#3482), `upgrade/electron-builder-26` (#3484), `fix/desktop-update-signing` (#3485), and `docs/tuf-deployment-proposal` (#3487). Their remote heads and PR bases were verified; their working branches were not rewritten by this reporting task.
+- Auth#35: local `fix/node24-msgpackr` was pushed explicitly to `TryQuiet/auth` using `gh-org`.
+
+The Android agent's `test/android-qss-multiplayer` branch has **no separate PR**; its relevant tests are included in #3483. The iOS agent's notification changes are also in #3483. No QSS-server PR was created. [Quiet #3013](https://github.com/TryQuiet/quiet/issues/3013) tracks the wider Android 16 upgrade and is an issue, not another PR.
+
+## Remaining work
+
+1. Enable `TryQuiet/quiet` to receive the organization secrets `QSS_AWS_ACCESS_KEY_ID` and `QSS_AWS_SECRET_ACCESS_KEY`. CI receives empty values. They are needed to retrieve `DEV_FIREBASE_ANDROID_PRIVATE_KEY` and `DEV_FIREBASE_IOS_PRIVATE_KEY` from QSS's development AWS Secrets Manager configuration. Native client configs decrypt successfully; `ANDROID_FIREBASE_KEY` and `IOS_FIREBASE_KEY` are decryption passphrases, not push-sending credentials. No secret values need to be shared in this document or chat.
+2. Finish the Android CI desktop-creation diagnosis using the new reporter. Local Appium onboarding passes; hosted onboarding has not yet been established as passing.
+3. Run iOS Appium when a Mac runner is available, then verify provider delivery, extension activation and taps. The queue snapshot at 17:28 UTC showed five running and 31 queued Mac jobs. The attached Mac's full app build previously stopped at its free-disk guard.
+4. For the desktop track, decide on and provision the TUF service and approved roots described by #3485/#3487, then validate native production signing and notarization. The production update gate remains in place.
+5. Review and merge both tracks from the bottom up, using their separate local/native, hosted and provider evidence, and validate the combined mobile/desktop stack.
+
+Current attempts are linked from [#3483](https://github.com/TryQuiet/quiet/pull/3483) and the [Android](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-e2e.yml) / [iOS](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-ios.yml) workflow pages. This document is a dated snapshot rather than a live CI feed.
+
+The requested Mac disk inventory at `/mnt/storage/holmes-tmp/mac-disk-inventory-20260911.md` identifies about **11.2 GiB** in initial cache/installer/build-output cleanup candidates. No inventory cleanup was performed. It is a supporting document, not another PR.


### PR DESCRIPTION
# Quiet 10.0 upgrade, testing and update-signing PR stacks

Verified against GitHub using `gh-org` at **2026-09-11 18:55 UTC**. This summary covers the session from the initial request to restack #3422 on `10.0.0`, through multiplayer and notification tests, publication of the remaining workflow commits, the other agent's Electron/packaging/update-signing stack, and the 22 published fixes from the local tracker. Seven Quiet PRs form two tracks sharing #3422; two related PRs provide SDK and authentication work. The published heads are listed below; test status and outstanding work are recorded separately. The other agent's validation is attributed to its published PR descriptions; those native test suites were not rerun for this document.

## Stack and merge order

```text
Quiet: 10.0.0
  └─ #3422  upgrade/react-native-081
       ├─ #3423  upgrade/react-native-new-architecture-node
       │    └─ #3483  docs/qss-notification-regression-plan
       └─ #3482  upgrade/electron-44
            └─ #3484  upgrade/electron-builder-26
                 └─ #3485  fix/desktop-update-signing
                      └─ #3487  docs/tuf-deployment-proposal

Related work outside that sequence:
  Quiet #3420 → develop   SDK/API 36 prerequisites carried into #3422
  Auth  #35   → main      Node 24 MessagePack compatibility
```

Review and merge parents before children: **#3422 → #3423 → #3483** for mobile/testing, and **#3422 → #3482 → #3484 → #3485 → #3487** for desktop/update signing. After merging a parent, verify that GitHub retargets its child to `10.0.0` and that the child diff contains only its own changes. The two tracks share #3422 but do not currently include each other's descendants; combined New Architecture/Electron integration still needs validation. #3420 is the standalone SDK alternative, not another required stack level. Auth#35 lives in a separate repository. All nine PRs remain open; the table identifies drafts.

| PR | Published head branch | PR base | Verified head commit | Status |
| --- | --- | --- | --- | --- |
| [quiet#3422](https://github.com/TryQuiet/quiet/pull/3422) | `upgrade/react-native-081` | `10.0.0` | [631ae3511](https://github.com/TryQuiet/quiet/commit/631ae351105762e6fc883f33d30fa33f853e6c73) | Open, draft; pushed |
| [quiet#3423](https://github.com/TryQuiet/quiet/pull/3423) | `upgrade/react-native-new-architecture-node` | `upgrade/react-native-081` | [77a075181](https://github.com/TryQuiet/quiet/commit/77a07518137928ffa5208f99bc190044550ce0ac) | Open, draft; pushed |
| [quiet#3483](https://github.com/TryQuiet/quiet/pull/3483) | `docs/qss-notification-regression-plan` | `upgrade/react-native-new-architecture-node` | [442aedcb3](https://github.com/TryQuiet/quiet/commit/442aedcb37d253981b1fe088b9ddb07d8f37bedb) | Open; pushed |
| [quiet#3482](https://github.com/TryQuiet/quiet/pull/3482) | `upgrade/electron-44` | `upgrade/react-native-081` | [7b81e19aa](https://github.com/TryQuiet/quiet/commit/7b81e19aaabd83e12e57868d1f5c884b3f2b6ff0) | Open; pushed |
| [quiet#3484](https://github.com/TryQuiet/quiet/pull/3484) | `upgrade/electron-builder-26` | `upgrade/electron-44` | [a1d103642](https://github.com/TryQuiet/quiet/commit/a1d10364247eae90c7e0b8f328014dc601579f3b) | Open, draft; pushed |
| [quiet#3485](https://github.com/TryQuiet/quiet/pull/3485) | `fix/desktop-update-signing` | `upgrade/electron-builder-26` | [8f33f2852](https://github.com/TryQuiet/quiet/commit/8f33f2852017435bad25532779acd79cc0a6d46a) | Open, draft; pushed |
| [quiet#3487](https://github.com/TryQuiet/quiet/pull/3487) | `docs/tuf-deployment-proposal` | `fix/desktop-update-signing` | [c007ceac3](https://github.com/TryQuiet/quiet/commit/c007ceac397d428d8fede676be0b7b558ed1df29) | Open, draft; pushed |
| [quiet#3420](https://github.com/TryQuiet/quiet/pull/3420) | `fix/android-api-36-sdk` | `develop` | [854e82692](https://github.com/TryQuiet/quiet/commit/854e82692fbc7c94b66dc07f0418603ededeeb60) | Open; pushed |
| [auth#35](https://github.com/TryQuiet/auth/pull/35) | `fix/node24-msgpackr` | `main` | [d3fc6d2ca](https://github.com/TryQuiet/auth/commit/d3fc6d2ca0a1bdd5852470584153b9a716427796) | Open; pushed |

Git ancestry checks confirm the parent-child relationships shown above, including the current `10.0.0` tip beneath #3422. GitHub's PR base fields match both tracks.

## PR summaries, from the beginning

### [Quiet #3422 — Migrate mobile to React Native 0.81 for Android 16](https://github.com/TryQuiet/quiet/pull/3422)

This existing PR was the starting point of the session. It upgrades mobile to React Native 0.81.5, React 19.1 and Hermes, retains target API 36, and incorporates SDK prerequisites from #3420. It includes navigation, Metro resolution, keyboard behavior, native dependency and iOS simulator compatibility work. It retains the old bridge architecture and embedded Node 18.20.4; #3423 changes those.

Session work restacked it on `10.0.0`, preserving security/recovery fixes and resolving attachment-test expectations around explicit channel routing. Recorded restack validation: **62 active mobile Jest suites, 181 tests and 44 snapshots**, passing TypeScript/lint, 14 Metro/CLI/Promise checks, six classic-level checks and 20 guarded Tor-builder checks. Native device builds were not rerun specifically for that merge.

The original CI investigation found desktop multiplayer failures: Tor delays exhausted join deadlines; an old auth pin could reconstruct duplicate invitee registrations and reject acceptance with `ADMIT_MEMBER_LINK_MISSING`; macOS also hit a stale Selenium element and synchronization timeouts. The new base contained admission retry/uniqueness fixes. A fully green cross-platform CI run was not established.

### [Quiet #3423 — Enable React Native New Architecture and upgrade mobile Node to 24](https://github.com/TryQuiet/quiet/pull/3423)

This existing child PR enables Fabric and bridgeless React Native on Android and iOS, upgrades embedded mobile Node to pinned 24.18.0, and adapts native events, bridge calls, Config/Share code generation and Screens. Host build Node and desktop Node are separate runtimes. The mobile runtime is a pinned community prerelease, not an independently reproduced binary.

It supplies the QSS E2E foundation: a pinned local QSS/Postgres/Redis fixture with real hCaptcha test-key verification, iOS one-player onboarding/message/restart coverage, and shared desktop Selenium selectors. Recorded native validation includes **iOS QSS one-player 1/1**, **desktop+iOS multiplayer 6/6 stages**, and **iOS baseline 26/26**. Mixed tests check exact text and author, offline retrieval in both directions, and restart persistence. Private channels, attachments, cancellation and long paginated histories remain gaps relative to desktop coverage.

This session refreshed it onto the updated #3422. During this inventory, **four previously unpublished iOS workflow commits were ported onto the current parent and pushed**, preserving the base's submodule checkout token. The manual iOS workflow runs baseline, one-player QSS and mixed desktop/iOS tests sequentially. The **11 workflow routing tests and four CI helper tests** pass after the restack; actionlint and repository concurrency checks pass. Hosted execution of this manual workflow remains unvalidated.

### [Quiet #3483 — Test mobile QSS notifications with Appium and native regressions](https://github.com/TryQuiet/quiet/pull/3483)

This is the new PR created in this session, stacked on #3423. It began as a regression plan, then became executable tests when actual tests were requested. Its branch still contains `docs/` in the name; the current PR includes native tests, multiplayer support and Appium CI workflows.

- **Android multiplayer:** six Detox messaging/offline/restart stages passed in **206.98 seconds** with an explicit QSS-only backend. Tor metadata is simulated, P2P and push are disabled, and the Android emulator communicates with a real desktop peer through QSS.
- **Android native notifications:** **13/13 passed**, exercising production receiver code, native storage, authenticated HTTP responses, signature verification, decryption and OS posting. Controlled wakeups/server responses cover cursor races, duplicates, retry, named channels, author filtering and leave/re-enrollment. A deliberate stale-cursor fault caused the expected regression failure. These tests do not establish FCM transport.
- **iOS native notifications:** **34/34 passed** on the attached Mac: 21 authenticator, five NSE auth/fetch/decrypt/render and eight background lifecycle tests. Hostless notification tests are separated from tests requiring the full app.
- **Fast state checks:** eight notification/token and leave-cleanup Jest tests pass. Messaging stays in Detox. No RN-for-web/Cypress mobile notification suite was added.
- **Appium on both platforms:** two provider journeys cover fresh join → background notification → tap, and named-channel notification → the correct conversation while another channel is selected. They require a real desktop sender, QSS/QPS, FCM or FCM/APNs, the native receiver/extension and actual OS notification UI. There is no injected-notification fallback for a provider pass.
- **Android Appium onboarding:** the separate push-disabled fresh enrollment and peer-message journey passes locally, most recently in **55.977 seconds** on Node 20.20.1, including cleanup and the CI failure reporter.

CI now has independent onboarding/provider lanes, credential checks, Linux/macOS QSS fixtures, a pinned Tor simulator source build, and safe result/error artifacts. Fixes include missing runner tools, the hosted Xcode path, Tor's undeclared generated version header, simulator entitlement placement and a reproduced Fluxbox shutdown-order abort. The [latest completed Android attempt](https://github.com/TryQuiet/quiet/actions/runs/34632147149) reached a healthy QSS fixture but failed with `TimeoutError` while creating the desktop community, before mobile startup. Its safe report confirmed that both the display and window manager were still alive; the exact timed-out desktop wait remains to be identified.

The iOS helper links XML/DER capabilities into simulator executables and uses empty host signing entitlements, matching Xcode's simulator behavior. A UIKit probe using the helper-generated capabilities launched and registered with real APNs. That proves registration setup only; it is not a Quiet delivery or Appium pass.

**No complete real FCM/APNs notification loop has passed yet, and no Quiet iOS Appium UI journey has been validated.** Private-channel notification taps, server token tombstones, process-death delivery, quick reply and hardware power-management behavior are outside these two journeys.

### [Quiet #3482 — Upgrade desktop to Electron 44 on the React Native 0.81 stack](https://github.com/TryQuiet/quiet/pull/3482)

This is the other agent's first PR, stacked directly on #3422. It upgrades desktop from Electron 32 to 44.3.0, matches ChromeDriver, and moves the host toolchain to Node 24.21.0 with npm 10.8.2. Clipboard/context-menu and DevTools APIs are updated, and the minimum macOS version becomes 13. It also fixes CAPTCHA retry ordering, splash/stale-element handling, premature Tor restarts and replication recovery across delayed membership synchronization.

The published PR records **60 packaged single-player tests**, **131 packaged QSS multiplayer data/onboarding tests**, **24 direct libp2p cases across nine suites**, and **287 desktop Jest tests / 127 snapshots** passing. Native Electron database/clipboard checks, final AppImage smoke and focused harness/backend tests also pass. Eight Tor-presence checks were excluded from the QSS totals. One full live-Tor run passed 79/82; full Tor-suite success is not claimed.

### [Quiet #3484 — Upgrade desktop packaging to electron-builder 26](https://github.com/TryQuiet/quiet/pull/3484)

Stacked on #3482, this upgrades electron-builder to 26.15.3, migrates Windows signing to `signtoolOptions`, rebuilds msgpackr-extract in Node-API mode, and preserves the Linux launcher's sandbox behavior. Linux preload customization now happens before squashfs/blockmap generation. Production `electron-store` and existing PKIJS dependencies are retained.

Its published validation includes passing main/renderer builds, **nine launcher/hook tests**, a forced native rebuild and Unicode round-trip in Electron, artifact dependency/hash/blockmap checks, and packaged startup E2E. The artifact test reproduced the missing `electron-store` failure before the fix. Native Windows/macOS packaging and signing still need validation; this PR remains a draft.

### [Quiet #3485 — Authenticate desktop updates and modernize signing tooling](https://github.com/TryQuiet/quiet/pull/3485)

Stacked on #3484, this authenticates Linux/Windows update manifests with TUF before download and rechecks authorization and the cached installer before installation. Windows additionally requires the configured publisher subject and OS Authenticode validation. It upgrades updater/notarization tooling, stages immutable artifacts, binds publication to a successful release build/tag, and adds KMS/OIDC provisioning and bootstrap-root setup guidance.

The other agent reports [dedicated Linux and native Windows CI passing](https://github.com/TryQuiet/quiet/actions/runs/34627120752), including real Authenticode and cached/downloaded installer execution. **46 updater/release/provisioning tests and nine launcher tests**, builds, a fresh AppImage smoke and CloudFormation lint pass. This is still a draft: production Linux/Windows builds intentionally fail until approved TUF roots and repository URLs are committed. Live IAM/OIDC/KMS authorization, operational signing/metadata publication, production Windows signing and macOS notarization remain to be validated. Older clients receive TUF protection only after the transition release.

### [Quiet #3487 — Consider operating TUF for desktop updates](https://github.com/TryQuiet/quiet/pull/3487)

Stacked on #3485, this documentation-only proposal records TUF service ownership, hardware signer custody, AWS/GitHub provisioning, native prerelease verification, renewals and recovery responsibilities. Its latest update records TUF as accepted in principle; provisioning and live release validation still block the rollout, and the existing YubiKey’s PIV support remains unconfirmed. It links the setup guide to the adoption proposal. Its nine relative documentation links resolve and the Markdown diff passes whitespace checks; runtime tests were not rerun. Deferring TUF deployment also defers #3485's updater rollout unless that design is separately revised and reviewed. It remains a draft.

### [Quiet #3420 — Target Android 16 without the React Native migration](https://github.com/TryQuiet/quiet/pull/3420)

This separate SDK/API 36 PR targets `develop`. Its prerequisites were carried into #3422. It belongs in the dependency/context inventory but is outside the two `10.0.0` tracks. Its existing published branch was verified; no new changes or validation run are claimed for it during this inventory.

### [Auth #35 — Fix MessagePack serialization on Node 24](https://github.com/TryQuiet/auth/pull/35)

The migration exposed MessagePack 1.10.2's out-of-bounds `Buffer.utf8Write` behavior on Node 24. This companion PR pins all four auth consumers to 1.11.8 and adds six crypto regressions with Unicode and binary payloads. Its CI correction uses pnpm 10.6.0, a frozen lockfile, Node 20/24 and the actual test command.

The previously local, reviewed CI correction **`d3fc6d2ca` is now pushed**; actionlint was rerun before publication. Focused crypto/backend checks pass, but the full auth suite retains **88 failures also reproduced on its baseline**. Green hosted CI is not claimed. Publishing the CI correction did not change Quiet's current auth submodule pin.

## PRs from the local review tracker

The requested [local tracker](http://localhost:8787/) also contains **22 published draft PRs, #3488–#3509**. Each targets `develop` independently; they are siblings, not a 22-level stack, and are not based on the RN/Electron upgrade tracks. Each GitHub head was checked against its local worktree under `/mnt/storage/holmes-worktrees/quiet-lhf-wt/` and matched. Their original base is `1ed08d8fb`; refresh before merging and validate integration with the upgrades.

```text
develop
  ├─ #3488 … #3509  (22 independent draft PRs)
  └─ #3386          (existing contributor Android clipboard fix)
```

The evidence below comes from the other agent's published PR descriptions and local reports. It was not rerun while compiling this inventory. Several full desktop runs retain a documented baseline failure; mobile component tests do not establish behavior on a device.

| PR | Issue | Change | Reported validation / limit | Verified pushed head |
| --- | --- | --- | --- | --- |
| [#3488](https://github.com/TryQuiet/quiet/pull/3488) | #2998 | Make README security caveat prominent | Documentation diff reviewed. | [`f2a1790c8`](https://github.com/TryQuiet/quiet/commit/f2a1790c810df48856bd2d1d3b35d62b81a77589) |
| [#3489](https://github.com/TryQuiet/quiet/pull/3489) | #2959 | Keep identicon backgrounds light in both themes | Cypress regression failed before the fix; before/after screenshots. | [`ee1cf4ed0`](https://github.com/TryQuiet/quiet/commit/ee1cf4ed0d86f2da4ab00da15e59c3e37e7fcfa4) |
| [#3490](https://github.com/TryQuiet/quiet/pull/3490) | #1618 | Desktop blank-line rendering regression guard | Five Jest assertions and Cypress pass on existing behavior; test-only. | [`0635cdb32`](https://github.com/TryQuiet/quiet/commit/0635cdb327f431747a235b3b9fb777b6811c5c35) |
| [#3491](https://github.com/TryQuiet/quiet/pull/3491) | #1592 | Give modal Close buttons accessible names | RTL fails before/passes after; screenshots unchanged. | [`9ad73fb39`](https://github.com/TryQuiet/quiet/commit/9ad73fb392b0a2a9c29dd5d80fce7e3bdde578f9) |
| [#3492](https://github.com/TryQuiet/quiet/pull/3492) | #2751 | Refresh Today/date markers at local midnight | 11 tests pass, including real selector memo invalidation and rehydration. | [`954f65dfe`](https://github.com/TryQuiet/quiet/commit/954f65dfea5db1e31a5f7ce8998a6d28b694707f) |
| [#3493](https://github.com/TryQuiet/quiet/pull/3493) | #53 | Prevent idle suspension while desktop backend runs | Four new regressions; main-process suite 20/20. | [`75224f6da`](https://github.com/TryQuiet/quiet/commit/75224f6da1ab75a09b06806f772858f3fcb22fbd) |
| [#3494](https://github.com/TryQuiet/quiet/pull/3494) | #2103 | Persist and restore desktop window size | Eight new tests; main-process suite 24/24. | [`6e23806f8`](https://github.com/TryQuiet/quiet/commit/6e23806f8f5fc17b70c8bb393b24e6c871368b41) |
| [#3495](https://github.com/TryQuiet/quiet/pull/3495) | #2953 | Compress profile photos to the 200KB budget | Chromium Cypress 7/7; 48 Jest passes, two skipped. Large PNG/GIF lose transparency/animation. | [`4f52a6383`](https://github.com/TryQuiet/quiet/commit/4f52a63837c1e94466343c9568be89209497b9fe) |
| [#3496](https://github.com/TryQuiet/quiet/pull/3496) | #1266 | Keep mobile channel previews on one line | Two new regressions; 53 mobile suites, 149 tests pass. | [`3ea6c8a09`](https://github.com/TryQuiet/quiet/commit/3ea6c8a0909f76974bf7196ddd9caccf5bccf1a6) |
| [#3497](https://github.com/TryQuiet/quiet/pull/3497) | #1618-mobile | Collapse excess mobile message blank lines; preserve code fences | 21 assertions; 54 mobile suites, 168 tests pass. | [`2e13bcd42`](https://github.com/TryQuiet/quiet/commit/2e13bcd42205b44998c2c340506f5cff1e06c612) |
| [#3498](https://github.com/TryQuiet/quiet/pull/3498) | #2586 | Raise mobile Button minimum height to 50dp | Both variants tested; 54 mobile suites, 150 tests pass. | [`1d06dcf14`](https://github.com/TryQuiet/quiet/commit/1d06dcf1448b703833281d692d302f64052b70da) |
| [#3499](https://github.com/TryQuiet/quiet/pull/3499) | #1349 | Close Settings when navigation changes the channel | Four tests exercise the real root saga; three fail before the fix. | [`c787b9515`](https://github.com/TryQuiet/quiet/commit/c787b9515fdda182a3c195a6e6728842a7058c3c) |
| [#3500](https://github.com/TryQuiet/quiet/pull/3500) | #1701 | Decode escaped attachment basenames safely | Common tests 13/13 plus mobile render regression; rebuild common before review. | [`c241d4f67`](https://github.com/TryQuiet/quiet/commit/c241d4f6745ff5c93cd66399faf788492029c2bf) |
| [#3501](https://github.com/TryQuiet/quiet/pull/3501) | #1086 | Copy mobile text messages on long press | Seven new RNTL tests; 54 mobile suites, 154 tests pass. | [`e777f96c2`](https://github.com/TryQuiet/quiet/commit/e777f96c2e3fb8739b44277f389180203d4f5972) |
| [#3502](https://github.com/TryQuiet/quiet/pull/3502) | #1495 | Delay row dimming so scrolling does not flash pressed feedback | Three regressions; 54 mobile suites, 153 tests pass. Device motion check remains. | [`5ca469403`](https://github.com/TryQuiet/quiet/commit/5ca469403a1f6a3ac79fbf62d74c9ee0051d87e2) |
| [#3503](https://github.com/TryQuiet/quiet/pull/3503) | #773 | Search mobile channels by name | Seven new tests; 53 mobile suites, 153 tests pass. Device/design checks remain. | [`4e5b64cf2`](https://github.com/TryQuiet/quiet/commit/4e5b64cf2833fdc06a7cde88bfe4c08c9e5917d7) |
| [#3504](https://github.com/TryQuiet/quiet/pull/3504) | #1306 | Explain and reject leading-hyphen usernames | Desktop/mobile regressions and Cypress screenshots; leading spaces also rejected after normalization. | [`bc47a432c`](https://github.com/TryQuiet/quiet/commit/bc47a432cdddd13683c52e8f30a33a1016b76f97) |
| [#3505](https://github.com/TryQuiet/quiet/pull/3505) | #372 | Guard wrapping around long desktop links | Cypress 25/25 across four specs; deliberate break-all fault fails. Test-only. | [`cb0caa29b`](https://github.com/TryQuiet/quiet/commit/cb0caa29b855eb50f7339d80e14c0d7b07d72737) |
| [#3506](https://github.com/TryQuiet/quiet/pull/3506) | #2655 | Let Android message input shrink after deletion | Two regressions fail before; 53 mobile suites, 150 tests pass. Device validation remains. | [`2b785c676`](https://github.com/TryQuiet/quiet/commit/2b785c6765aa1f7a98dd880eef7a877903b055c6) |
| [#3507](https://github.com/TryQuiet/quiet/pull/3507) | #1745 | Link visible desktop #channel mentions to their channels | 16 RTL cases plus Cypress; hidden channels, code and URLs preserved. | [`6d2c40566`](https://github.com/TryQuiet/quiet/commit/6d2c4056650a2bfda74f26c6d7f9a598fd21c50d) |
| [#3508](https://github.com/TryQuiet/quiet/pull/3508) | #2778 | Reject whitespace-only text messages in shared send flow | State-manager 201/201; focused desktop/mobile checks. Rebuild state-manager before review. | [`5765cd7b4`](https://github.com/TryQuiet/quiet/commit/5765cd7b425552f404cf4fa01ba027e350b5b6c2) |
| [#3509](https://github.com/TryQuiet/quiet/pull/3509) | #2441 | Use invite link consistently in join-error copy | Desktop/mobile wording regressions and desktop Cypress screenshots. | [`932d4dfdf`](https://github.com/TryQuiet/quiet/commit/932d4dfdf98777b2f6ce2702e9bf1868681991a7) |

Three tracker entries intentionally have no new PR:

- **#1319 dock badge:** withdrawn by product decision because it would count bold channels rather than unread messages. Its local implementation is retained and is not proposed for merge.
- **#2333 sidebar border:** already fixed by [#3184](https://github.com/TryQuiet/quiet/pull/3184); the investigation left no production change.
- **#3369 Android invite-link copy:** the existing contributor [PR #3386](https://github.com/TryQuiet/quiet/pull/3386) supersedes the local duplicate. The additional local platform-matrix regression tests remain a follow-up pending that PR's merge; they have not been published as a separate PR.

The triage also dropped the duplicate mobile emoji-size work in favor of the existing [#3414](https://github.com/TryQuiet/quiet/pull/3414). Screenshots used by the small-fix PRs are published on the `lhf/pr-evidence` branch; that evidence branch is not an implementation PR.

Thus **31 work PRs are inventoried here** (nine upgrade/dependency PRs plus 22 tracker drafts), with existing superseding PRs linked separately. This meta PR is documentation only and targets `10.0.0`; it does not add an implementation dependency. Proposed changes are pushed; withdrawn and superseded local branches are explicitly accounted for above.

The `mobile upgrades` label groups Quiet #3420, #3422, #3423, #3483 and tracking issue #3013, plus Auth #35: the RN/runtime upgrades and mobile test improvements. The tracker fixes retain their separate small-fix grouping.

## Publication and working copies

- #3422: `/mnt/storage/holmes-worktrees/quiet-pr3422-10.0.0`, local branch `fix/pr3422-on-10.0.0`, published to `upgrade/react-native-081`.
- #3423: `/mnt/storage/holmes-worktrees/quiet-pr3423-publish`, local branch `publish/pr3423-ci-workflows`, published to `upgrade/react-native-new-architecture-node`. It contains the current base and all four previously local workflow changes. The older `quiet-rn-newarch` checkout remains available.
- #3483: `/mnt/storage/holmes-worktrees/quiet-qss-notification-plan`, branch `docs/qss-notification-regression-plan`, refreshed on the published #3423 head.
- The other agent's published branches are `upgrade/electron-44` (#3482), `upgrade/electron-builder-26` (#3484), `fix/desktop-update-signing` (#3485), and `docs/tuf-deployment-proposal` (#3487). Their remote heads and PR bases were verified; their working branches were not rewritten by this reporting task.
- Auth#35: local `fix/node24-msgpackr` was pushed explicitly to `TryQuiet/auth` using `gh-org`.

The Android agent's `test/android-qss-multiplayer` branch has **no separate PR**; its relevant tests are included in #3483. The iOS agent's notification changes are also in #3483. No QSS-server PR was created. [Quiet #3013](https://github.com/TryQuiet/quiet/issues/3013) tracks the wider Android 16 upgrade and is an issue, not another PR.

## Remaining work

1. Enable `TryQuiet/quiet` to receive the organization secrets `QSS_AWS_ACCESS_KEY_ID` and `QSS_AWS_SECRET_ACCESS_KEY`. CI receives empty values. They are needed to retrieve `DEV_FIREBASE_ANDROID_PRIVATE_KEY` and `DEV_FIREBASE_IOS_PRIVATE_KEY` from QSS's development AWS Secrets Manager configuration. Native client configs decrypt successfully; `ANDROID_FIREBASE_KEY` and `IOS_FIREBASE_KEY` are decryption passphrases, not push-sending credentials. No secret values need to be shared in this document or chat.
2. Finish the Android CI desktop-creation diagnosis using the new reporter. Local Appium onboarding passes; hosted onboarding has not yet been established as passing.
3. Run iOS Appium when a Mac runner is available, then verify provider delivery, extension activation and taps. The queue snapshot at 17:28 UTC showed five running and 31 queued Mac jobs. The attached Mac's full app build previously stopped at its free-disk guard.
4. For the desktop track, finish provisioning the TUF service and approved roots described by #3485/#3487, then validate native production signing and notarization. The production update gate remains in place.
5. Review and merge both tracks from the bottom up, using their separate local/native, hosted and provider evidence, and validate the combined mobile/desktop stack.

Current attempts are linked from [#3483](https://github.com/TryQuiet/quiet/pull/3483) and the [Android](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-e2e.yml) / [iOS](https://github.com/TryQuiet/quiet/actions/workflows/mobile-notification-ios.yml) workflow pages. This document is a dated snapshot rather than a live CI feed.

The requested Mac disk inventory at `/mnt/storage/holmes-tmp/mac-disk-inventory-20260911.md` identifies about **11.2 GiB** in initial cache/installer/build-output cleanup candidates. No inventory cleanup was performed. It is a supporting document, not another PR.
